### PR TITLE
[NO-ISSUE] fix: ensure isActive is provided with default value for CreateView at IntelligentDNS

### DIFF
--- a/src/views/IntelligentDNS/CreateView.vue
+++ b/src/views/IntelligentDNS/CreateView.vue
@@ -24,6 +24,7 @@
           <InputSwitch v-bind="isActive"  v-model="isActive.value"  :class="{ 'p-invalid': errors.isActive }"/>
         </div>
     </template>
+
 </CreateFormBlock>
 </template>
 
@@ -51,6 +52,9 @@ const validationSchema = yup.object({
 // validation with VeeValidate
 const { errors, defineInputBinds, meta, resetForm, values } = useForm({
   validationSchema,
+  initialValues:{
+    isActive:false
+  }
 })
 
 const name = defineInputBinds('name', { validateOnInput: true })


### PR DESCRIPTION
This make sure to have an initial value for the isActive property at the formData payload. This is required to integrate with the API.