### PR TITLE
style: include font-weight prop for buttons

### DIFF
--- a/src/assets/themes/scss/theme-base/components/button/_button.scss
+++ b/src/assets/themes/scss/theme-base/components/button/_button.scss
@@ -4,6 +4,7 @@
   border: $buttonBorder;
   padding: $buttonPadding;
   font-size: $fontSize;
+  font-weight: 600;
   transition: $formElementTransition;
   border-radius: $borderRadius;
 


### PR DESCRIPTION
Apenas a inclusão da propriedade `font-weight` `no theme-base.scss`. 