### PR TITLE
[ENG-27509] feat: add create and reorder to list block

### DIFF
--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -4,21 +4,51 @@
     <PageHeadingBlock :pageTitle="pageTitle" />
 
     <div class="max-w-full mx-8 mt-10">
-      <DataTable v-if="!isLoading" @rowReorder="onRowReorder" scrollable removableSort :value="data" dataKey="id"
-        v-model:filters="this.filters" paginator :rowsPerPageOptions="[5, 10, 20, 50, 100]" :rows="5"
-        :globalFilterFields="filterBy" :loading="isLoading">
+      <DataTable
+        v-if="!isLoading"
+        @rowReorder="onRowReorder"
+        scrollable
+        removableSort
+        :value="data"
+        dataKey="id"
+        v-model:filters="this.filters"
+        paginator
+        :rowsPerPageOptions="[5, 10, 20, 50, 100]"
+        :rows="5"
+        :globalFilterFields="filterBy"
+        :loading="isLoading"
+      >
         <template #header>
           <div class="flex flex-wrap justify-between gap-2 w-full">
             <span class="p-input-icon-left max-sm:w-full">
               <i class="pi pi-search" />
-              <InputText class="w-full" v-model="this.filters.global.value" placeholder="Search" />
+              <InputText
+                class="w-full"
+                v-model="this.filters.global.value"
+                placeholder="Search"
+              />
             </span>
-            <PrimeButton class="max-sm:w-full" @click="navigateToAddPage" icon="pi pi-plus" :label="addButtonLabel"
-              v-if="addButtonLabel" />
+            <PrimeButton
+              class="max-sm:w-full"
+              @click="navigateToAddPage"
+              icon="pi pi-plus"
+              :label="addButtonLabel"
+              v-if="addButtonLabel"
+            />
           </div>
         </template>
-        <Column v-if="reorderableRows" rowReorder headerStyle="width: 3rem" />
-        <Column sortable v-for="col of selectedColumns" :key="col.field" :field="col.field" :header="col.header">
+        <Column
+          v-if="reorderableRows"
+          rowReorder
+          headerStyle="width: 3rem"
+        />
+        <Column
+          sortable
+          v-for="col of selectedColumns"
+          :key="col.field"
+          :field="col.field"
+          :header="col.header"
+        >
           <template #body="{ data: rowData }">
             <template v-if="col.type !== 'component'">
               <div v-html="rowData[col.field]" />
@@ -28,14 +58,29 @@
             </template>
           </template>
         </Column>
-        <Column :frozen="true" :alignFrozen="'right'" headerStyle="width: 13rem">
+        <Column
+          :frozen="true"
+          :alignFrozen="'right'"
+          headerStyle="width: 13rem"
+        >
           <template #header>
             <div class="flex justify-end w-full">
-              <PrimeButton outlined icon="pi pi-bars" @click="toggleColumnSelector" v-tooltip.left="'Hidden columns'">
+              <PrimeButton
+                outlined
+                icon="pi pi-bars"
+                @click="toggleColumnSelector"
+                v-tooltip.left="'Hidden columns'"
+              >
               </PrimeButton>
               <OverlayPanel ref="columnSelectorPanel">
-                <Listbox v-model="selectedColumns" multiple :options="[{ label: 'Hidden columns', items: this.columns }]"
-                  optionLabel="header" optionGroupLabel="label" optionGroupChildren="items">
+                <Listbox
+                  v-model="selectedColumns"
+                  multiple
+                  :options="[{ label: 'Hidden columns', items: this.columns }]"
+                  optionLabel="header"
+                  optionGroupLabel="label"
+                  optionGroupChildren="items"
+                >
                   <template #optiongroup="slotProps">
                     <p class="text-sm font-bold">{{ slotProps.option.label }}</p>
                   </template>
@@ -45,32 +90,63 @@
           </template>
           <template #body="{ data: rowData }">
             <div class="flex justify-end">
-              <PrimeMenu :ref="'menu'" id="overlay_menu" v-bind:model="actionOptions()" :popup="true" />
-              <PrimeButton v-tooltip="'Actions'" size="small" icon="pi pi-ellipsis-h" text
-                @click="(event) => toggleActionsMenu(event, rowData.id)" class="cursor-pointer" />
+              <PrimeMenu
+                :ref="'menu'"
+                id="overlay_menu"
+                v-bind:model="actionOptions()"
+                :popup="true"
+              />
+              <PrimeButton
+                v-tooltip="'Actions'"
+                size="small"
+                icon="pi pi-ellipsis-h"
+                text
+                @click="(event) => toggleActionsMenu(event, rowData.id)"
+                class="cursor-pointer"
+              />
             </div>
           </template>
         </Column>
         <template #empty>
           <div class="my-4 flex flex-col gap-3 justify-center items-center">
             <p class="text-xl font-normal text-gray-600">No registers found.</p>
-            <PrimeButton text icon="pi pi-plus" label="Add" v-if="addButtonLabel" @click="navigateToAddPage" />
+            <PrimeButton
+              text
+              icon="pi pi-plus"
+              label="Add"
+              v-if="addButtonLabel"
+              @click="navigateToAddPage"
+            />
           </div>
         </template>
       </DataTable>
 
-      <DataTable v-else :value="Array(5)" :pt="{
-        header: { class: '!border-t-0' }
-      }">
+      <DataTable
+        v-else
+        :value="Array(5)"
+        :pt="{
+          header: { class: '!border-t-0' }
+        }"
+      >
         <template #header>
           <div class="flex self-start">
             <span class="p-input-icon-left">
               <i class="pi pi-search" />
-              <InputText class="w-full" v-model="this.filters.global.value" placeholder="Search" />
+              <InputText
+                class="w-full"
+                v-model="this.filters.global.value"
+                placeholder="Search"
+              />
             </span>
           </div>
         </template>
-        <Column sortable v-for="col of columns" :key="col.field" :field="col.field" :header="col.header">
+        <Column
+          sortable
+          v-for="col of columns"
+          :key="col.field"
+          :field="col.field"
+          :header="col.header"
+        >
           <template #body>
             <Skeleton></Skeleton>
           </template>
@@ -81,174 +157,174 @@
 </template>
 
 <script>
-import DataTable from 'primevue/datatable'
-import Column from 'primevue/column'
-import Toast from 'primevue/toast'
-import Listbox from 'primevue/listbox'
-import InputText from 'primevue/inputtext'
-import PrimeMenu from 'primevue/menu'
-import Skeleton from 'primevue/skeleton'
-import OverlayPanel from 'primevue/overlaypanel'
-import PrimeButton from 'primevue/button'
-import { FilterMatchMode } from 'primevue/api'
-import PageHeadingBlock from '@/templates/page-heading-block'
+  import DataTable from 'primevue/datatable'
+  import Column from 'primevue/column'
+  import Toast from 'primevue/toast'
+  import Listbox from 'primevue/listbox'
+  import InputText from 'primevue/inputtext'
+  import PrimeMenu from 'primevue/menu'
+  import Skeleton from 'primevue/skeleton'
+  import OverlayPanel from 'primevue/overlaypanel'
+  import PrimeButton from 'primevue/button'
+  import { FilterMatchMode } from 'primevue/api'
+  import PageHeadingBlock from '@/templates/page-heading-block'
 
-export default {
-  name: 'list-table-block',
-  components: {
-    Toast,
-    DataTable,
-    Column,
-    InputText,
-    PrimeButton,
-    PrimeMenu,
-    Skeleton,
-    Listbox,
-    OverlayPanel,
-    PageHeadingBlock
-  },
-  data: () => ({
-    selectedId: null,
-    filters: {
-      global: { value: '', matchMode: FilterMatchMode.CONTAINS }
+  export default {
+    name: 'list-table-block',
+    components: {
+      Toast,
+      DataTable,
+      Column,
+      InputText,
+      PrimeButton,
+      PrimeMenu,
+      Skeleton,
+      Listbox,
+      OverlayPanel,
+      PageHeadingBlock
     },
-    isLoading: false,
-    showColumnSelector: false,
-    data: [],
-    selectedColumns: []
-  }),
-  props: {
-    columns: {
-      type: Array,
-      required: true,
-      default: () => [
-        {
-          field: 'name',
-          header: 'Name'
-        }
-      ]
-    },
-    pageTitle: {
-      type: String,
-      required: true
-    },
-    createPagePath: {
-      type: String,
-      required: true,
-      default: () => '/'
-    },
-    editPagePath: {
-      type: String,
-      required: true,
-      default: () => '/'
-    },
-    addButtonLabel: {
-      type: String,
-      required: true,
-      default: () => ''
-    },
-    listService: {
-      required: true,
-      type: Function
-    },
-    deleteService: {
-      required: true,
-      type: Function
-    },
-    reorderableRows: {
-      required: false,
-      type: Boolean,
-      default: false
-    }
-  },
-  async created() {
-    await this.loadData({ page: 1 })
-    this.selectedColumns = this.columns
-  },
-  computed: {
-    filterBy() {
-      return this.columns.map((item) => item.field)
-    }
-  },
-  methods: {
-    toggleColumnSelector(event) {
-      this.$refs.columnSelectorPanel.toggle(event)
-    },
-    toggleShowColumnSelector() {
-      this.showColumnSelector = !this.showColumnSelector
-    },
-    onRowReorder(event) {
-      this.data = event.value
-    },
-    actionOptions() {
-      const actionOptions = [
-        {
-          label: 'Edit',
-          icon: 'pi pi-fw pi-pencil',
-          command: () => this.editItem()
-        },
-        {
-          label: 'Delete',
-          icon: 'pi pi-fw pi-trash',
-          command: () => this.removeItem()
-        }
-      ]
-
-      return actionOptions
-    },
-    async loadData({ page }) {
-      try {
-        this.isLoading = true
-        const data = await this.listService({ page })
-        this.data = data
-      } catch (error) {
-        this.$toast.add({
-          closable: true,
-          severity: 'error',
-          summary: error,
-          life: 10000
-        })
-      } finally {
-        this.isLoading = false
+    data: () => ({
+      selectedId: null,
+      filters: {
+        global: { value: '', matchMode: FilterMatchMode.CONTAINS }
+      },
+      isLoading: false,
+      showColumnSelector: false,
+      data: [],
+      selectedColumns: []
+    }),
+    props: {
+      columns: {
+        type: Array,
+        required: true,
+        default: () => [
+          {
+            field: 'name',
+            header: 'Name'
+          }
+        ]
+      },
+      pageTitle: {
+        type: String,
+        required: true
+      },
+      createPagePath: {
+        type: String,
+        required: true,
+        default: () => '/'
+      },
+      editPagePath: {
+        type: String,
+        required: true,
+        default: () => '/'
+      },
+      addButtonLabel: {
+        type: String,
+        required: true,
+        default: () => ''
+      },
+      listService: {
+        required: true,
+        type: Function
+      },
+      deleteService: {
+        required: true,
+        type: Function
+      },
+      reorderableRows: {
+        required: false,
+        type: Boolean,
+        default: false
       }
     },
-    navigateToAddPage() {
-      this.$router.push(this.createPagePath)
+    async created() {
+      await this.loadData({ page: 1 })
+      this.selectedColumns = this.columns
     },
-    toggleActionsMenu(event, selectedId) {
-      this.selectedId = selectedId
-      this.$refs.menu.toggle(event)
-    },
-    editItem() {
-      this.$router.push({ path: `${this.editPagePath}/${this.selectedId}` })
-    },
-    async removeItem() {
-      let toastConfig = {
-        closable: true,
-        severity: 'success',
-        summary: 'Deleted successfully',
-        life: 10000
+    computed: {
+      filterBy() {
+        return this.columns.map((item) => item.field)
       }
-      try {
-        this.$toast.add({
+    },
+    methods: {
+      toggleColumnSelector(event) {
+        this.$refs.columnSelectorPanel.toggle(event)
+      },
+      toggleShowColumnSelector() {
+        this.showColumnSelector = !this.showColumnSelector
+      },
+      onRowReorder(event) {
+        this.data = event.value
+      },
+      actionOptions() {
+        const actionOptions = [
+          {
+            label: 'Edit',
+            icon: 'pi pi-fw pi-pencil',
+            command: () => this.editItem()
+          },
+          {
+            label: 'Delete',
+            icon: 'pi pi-fw pi-trash',
+            command: () => this.removeItem()
+          }
+        ]
+
+        return actionOptions
+      },
+      async loadData({ page }) {
+        try {
+          this.isLoading = true
+          const data = await this.listService({ page })
+          this.data = data
+        } catch (error) {
+          this.$toast.add({
+            closable: true,
+            severity: 'error',
+            summary: error,
+            life: 10000
+          })
+        } finally {
+          this.isLoading = false
+        }
+      },
+      navigateToAddPage() {
+        this.$router.push(this.createPagePath)
+      },
+      toggleActionsMenu(event, selectedId) {
+        this.selectedId = selectedId
+        this.$refs.menu.toggle(event)
+      },
+      editItem() {
+        this.$router.push({ path: `${this.editPagePath}/${this.selectedId}` })
+      },
+      async removeItem() {
+        let toastConfig = {
           closable: true,
-          severity: 'info',
-          summary: 'Processing request',
-          life: 5000
-        })
-        await this.deleteService(this.selectedId)
-        this.data = this.data.filter((item) => item.id !== this.selectedId)
-      } catch (error) {
-        toastConfig = {
-          closable: true,
-          severity: 'error',
-          summary: error,
+          severity: 'success',
+          summary: 'Deleted successfully',
           life: 10000
         }
-      } finally {
-        this.$toast.add(toastConfig)
+        try {
+          this.$toast.add({
+            closable: true,
+            severity: 'info',
+            summary: 'Processing request',
+            life: 5000
+          })
+          await this.deleteService(this.selectedId)
+          this.data = this.data.filter((item) => item.id !== this.selectedId)
+        } catch (error) {
+          toastConfig = {
+            closable: true,
+            severity: 'error',
+            summary: error,
+            life: 10000
+          }
+        } finally {
+          this.$toast.add(toastConfig)
+        }
       }
     }
   }
-}
 </script>


### PR DESCRIPTION
- This pR introduces new styles and functionalities to the list-block, check below :
* Add re-order rows without API support 
* Change style of list-block to be a data table full width
* Add column picker to hide specific columns. This feature depends on theme changes to render with correct styles all options inside ListBox primevue componente.

Result after changes.
📹
https://github.com/aziontech/azion-platform-kit/assets/101186721/2df679ab-1a8c-42d6-b40f-f0c7bd336c16

📷 (mobile)
![image](https://github.com/aziontech/azion-platform-kit/assets/101186721/5d1b98dc-1a66-42b7-abaa-53695148771e)

