### PR TITLE
fix: ajuste de theme nos tooltips

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_tooltip.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_tooltip.scss
@@ -1,5 +1,6 @@
 .p-tooltip {
   .p-tooltip-text {
+    box-shadow: none !important;
     font-size: 0.875rem !important;
     padding: 0.375rem 0.5rem !important;
   }

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_tooltip.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_tooltip.scss
@@ -1,5 +1,7 @@
 .p-tooltip {
   .p-tooltip-text {
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1) !important;
+    background: #2a2a2a !important;
     font-size: 0.875rem !important;
     padding: 0.375rem 0.5rem !important;
   }


### PR DESCRIPTION
Foi ajustado pros tooltips terem a cor de contraste e sombra ajustado.

![image](https://github.com/aziontech/azion-platform-kit/assets/44036260/0d258cde-9709-4e5c-81a2-71a54c7f8ef5)
