### PR TITLE
[NO-ISSUE] fix: background toasts fix

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/_extensions.scss
+++ b/src/assets/themes/scss/themes/azion-dark/_extensions.scss
@@ -10,4 +10,5 @@
   @import '../azion-dark/extended-components/sidebar';
   @import '../azion-dark/extended-components/tooltip';
   @import '../azion-dark/extended-components/inputpassword';
+  @import '../azion-light/extended-components/toast';
 }

--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_toast.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_toast.scss
@@ -2,6 +2,8 @@
 .p-toast {
   .p-toast-message {
     .p-toast-message-content {
+      background: var(--surface-card) !important;
+      border-radius: $borderRadius !important;
       .p-toast-message-text {
       }
 

--- a/src/assets/themes/scss/themes/azion-light/_extensions.scss
+++ b/src/assets/themes/scss/themes/azion-light/_extensions.scss
@@ -10,4 +10,5 @@
   @import '../azion-light/extended-components/sidebar';
   @import '../azion-light/extended-components/tooltip';
   @import '../azion-light/extended-components/inputpassword';
+  @import '../azion-light/extended-components/toast';
 }

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_toast.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_toast.scss
@@ -2,6 +2,8 @@
 .p-toast {
   .p-toast-message {
     .p-toast-message-content {
+      background: var(--surface-card) !important;
+      border-radius: $borderRadius !important;
       .p-toast-message-text {
       }
 
@@ -55,7 +57,7 @@
     }
 
     &.p-toast-message-error {
-      background: var(--surface-section) !important;
+      background: var(--surface-section) !important;  
       .p-toast-message-icon {
       }
       .p-toast-icon-close {


### PR DESCRIPTION
Ajustado um erro de thematização onde o toast ficava transparente.

![image](https://github.com/aziontech/azion-platform-kit/assets/44036260/93bb1a46-1fa1-47cb-9cca-12148008b784)
