### PR TITLE
[ENG-28071] feat: use toasts in digital certificates api validations

### DIFF
--- a/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
@@ -1,5 +1,6 @@
-import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
+import { AxiosHttpClientAdapter} from '../axios/AxiosHttpClientAdapter'
 import { makeDigitalCertificatesBaseUrl } from './make-digital-certificates-base-url'
+import * as Errors from '@/services/axios/errors'
 
 export const createDigitalCertificatesCSRService = async (payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -9,6 +10,26 @@ export const createDigitalCertificatesCSRService = async (payload) => {
   })
 
   return parseHttpResponse(httpResponse)
+}
+
+const parseHttpResponse = (httpResponse) => {
+  switch (httpResponse.statusCode) {
+    case 201:
+      return 'Your digital certificate has been created!'
+    case 400:
+      const apiError = httpResponse.body.error[0]
+      throw new Error(apiError)
+    case 401:
+      throw new Errors.InvalidApiTokenError().message
+    case 403:
+      throw new Errors.PermissionError().message
+    case 404:
+      throw new Errors.NotFoundError().message
+    case 500:
+      throw new Errors.InternalServerError().message
+    default:
+      throw new Errors.UnexpectedError().message
+  }
 }
 
 const adapt = (payload) => {

--- a/src/services/digital-certificates-services/create-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-service.js
@@ -1,5 +1,6 @@
-import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
+import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeDigitalCertificatesBaseUrl } from './make-digital-certificates-base-url'
+import * as Errors from '@/services/axios/errors'
 
 export const createDigitalCertificatesService = async (payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -9,6 +10,26 @@ export const createDigitalCertificatesService = async (payload) => {
   })
 
   return parseHttpResponse(httpResponse)
+}
+
+const parseHttpResponse = (httpResponse) => {
+  switch (httpResponse.statusCode) {
+    case 201:
+      return 'Your digital certificate has been created!'
+    case 400:
+      const apiError = httpResponse.body.error[0]
+      throw new Error(apiError)
+    case 401:
+      throw new Errors.InvalidApiTokenError().message
+    case 403:
+      throw new Errors.PermissionError().message
+    case 404:
+      throw new Errors.NotFoundError().message
+    case 500:
+      throw new Errors.InternalServerError().message
+    default:
+      throw new Errors.UnexpectedError().message
+  }
 }
 
 const adapt = (payload) => {

--- a/src/services/digital-certificates-services/delete-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/delete-digital-certificates-service.js
@@ -1,11 +1,30 @@
-import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
+import { AxiosHttpClientAdapter} from '../axios/AxiosHttpClientAdapter'
 import { makeDigitalCertificatesBaseUrl } from './make-digital-certificates-base-url'
+import * as Errors from '@/services/axios/errors'
 
 export const deleteDigitalCertificatesService = async (id) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeDigitalCertificatesBaseUrl()}/${id}`,
     method: 'DELETE'
   })
-
   return parseHttpResponse(httpResponse)
+}
+
+const parseHttpResponse = (httpResponse) => {
+  switch (httpResponse.statusCode) {
+    case 204:
+      return 'Digital certificate successfully deleted!'
+    case 400:
+      throw new Errors.NotFoundError().message
+    case 401:
+      throw new Errors.InvalidApiTokenError().message
+    case 403:
+      throw new Errors.PermissionError().message
+    case 404:
+      throw new Errors.NotFoundError().message
+    case 500:
+      throw new Errors.InternalServerError().message
+    default:
+      throw new Errors.UnexpectedError().message
+  }
 }

--- a/src/services/digital-certificates-services/edit-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/edit-digital-certificates-service.js
@@ -1,5 +1,6 @@
-import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
+import { AxiosHttpClientAdapter} from '../axios/AxiosHttpClientAdapter'
 import { makeDigitalCertificatesBaseUrl } from './make-digital-certificates-base-url'
+import * as Errors from '@/services/axios/errors'
 
 export const editDigitalCertificateService = async (payload) => {
   const parsedPayload = adapt(payload)
@@ -10,6 +11,27 @@ export const editDigitalCertificateService = async (payload) => {
   })
 
   return parseHttpResponse(httpResponse)
+}
+
+
+const parseHttpResponse = (httpResponse) => {
+  switch (httpResponse.statusCode) {
+    case 200:
+      return 'Your digital certificate has been updated!'
+    case 400:
+      const apiError = httpResponse.body.error[0]
+      throw new Error(apiError)
+    case 401:
+      throw new Errors.InvalidApiTokenError().message
+    case 403:
+      throw new Errors.PermissionError().message
+    case 404:
+      throw new Errors.NotFoundError().message
+    case 500:
+      throw new Errors.InternalServerError().message
+    default:
+      throw new Errors.UnexpectedError().message
+  }
 }
 
 const adapt = (payload) => {

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
@@ -1,7 +1,6 @@
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import {
   InternalServerError,
-  InvalidApiRequestError,
   InvalidApiTokenError,
   NotFoundError,
   PermissionError,
@@ -33,6 +32,9 @@ const fixture = {
     organization_unity: 'OrganizationUnity',
     private_key_type: 'rsa_2048',
     sans: ['SAN1', 'SAN2', 'SAN3']
+  },
+  errorMock: {
+    error: ['Error Message']
   }
 }
 
@@ -47,7 +49,7 @@ const makeSut = () => {
 describe('DigitalCertificatesServices', () => {
   it('should call api with correct params', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 200
+      statusCode: 201
     })
 
     const { sut } = makeSut()
@@ -64,7 +66,7 @@ describe('DigitalCertificatesServices', () => {
   it.each([
     {
       statusCode: 400,
-      expectedError: new InvalidApiRequestError().message
+      expectedError: fixture.errorMock[0]
     },
     {
       statusCode: 401,
@@ -90,13 +92,13 @@ describe('DigitalCertificatesServices', () => {
     'should throw when request fails with statusCode $statusCode',
     async ({ statusCode, expectedError }) => {
       vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-        statusCode
+        statusCode,
+        body: fixture.errorMock
       })
       const { sut } = makeSut()
 
       const response = sut(fixture.csrCertificateMock)
-
-      expect(response).rejects.toBe(expectedError)
+      expect(response).rejects.toThrow(expectedError)
     }
   )
 })

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
@@ -1,7 +1,6 @@
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import {
   InternalServerError,
-  InvalidApiRequestError,
   InvalidApiTokenError,
   NotFoundError,
   PermissionError,
@@ -27,6 +26,9 @@ const fixture = {
       '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
     private_key:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
+  },
+  errorMock: {
+    error: ['Error Message']
   }
 }
 
@@ -58,7 +60,7 @@ describe('DigitalCertificatesServices', () => {
   it.each([
     {
       statusCode: 400,
-      expectedError: new InvalidApiRequestError().message
+      expectedError: fixture.errorMock[0]
     },
     {
       statusCode: 401,
@@ -84,13 +86,14 @@ describe('DigitalCertificatesServices', () => {
     'should throw when request fails with statusCode $statusCode',
     async ({ statusCode, expectedError }) => {
       vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-        statusCode
+        statusCode,
+        body: fixture.errorMock
       })
       const { sut } = makeSut()
 
       const response = sut(fixture.payloadMock)
 
-      expect(response).rejects.toBe(expectedError)
+      expect(response).rejects.toThrow(expectedError)
     }
   )
 })

--- a/src/tests/services/digital-certificates-services/delete-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/delete-digital-certificates-service.test.js
@@ -36,13 +36,13 @@ describe('DigitalCertificatesServices', () => {
 
     const feedbackMessage = await sut(idStub)
 
-    expect(feedbackMessage).toBe('Resource successfully deleted')
+    expect(feedbackMessage).toBe('Digital certificate successfully deleted!')
   })
 
   it.each([
     {
       statusCode: 400,
-      expectedError: new Errors.InvalidApiRequestError().message
+      expectedError: 'Resource not found.'
     },
     {
       statusCode: 401,

--- a/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
@@ -11,6 +11,9 @@ const fixture = {
       '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
     privateKey:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
+  },
+  errorMock: {
+    error: ['Error Message']
   }
 }
 
@@ -25,7 +28,7 @@ const makeSut = () => {
 describe('DigitalCertificatesServices', () => {
   it('should call api with correct params', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 202
+      statusCode: 200
     })
     const { sut } = makeSut()
 
@@ -44,19 +47,19 @@ describe('DigitalCertificatesServices', () => {
 
   it('should return a feedback message on successfully updated', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 202
+      statusCode: 200
     })
     const { sut } = makeSut()
 
-    const feedbackMessage = await sut(fixture.payloadMock)
+    const feedbackMessage = sut(fixture.payloadMock)
 
-    expect(feedbackMessage).toBe('Resource successfully updated')
+    expect(feedbackMessage).resolves.toBe('Your digital certificate has been updated!')
   })
 
   it.each([
     {
       statusCode: 400,
-      expectedError: new Errors.InvalidApiRequestError().message
+      expectedError: fixture.errorMock[0]
     },
     {
       statusCode: 401,
@@ -82,13 +85,14 @@ describe('DigitalCertificatesServices', () => {
     'should throw when request fails with statusCode $statusCode',
     async ({ statusCode, expectedError }) => {
       vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-        statusCode
+        statusCode,
+        body: fixture.errorMock
       })
       const { sut } = makeSut()
 
       const response = sut(fixture.payloadMock)
 
-      expect(response).rejects.toBe(expectedError)
+      expect(response).rejects.toThrow(expectedError)
     }
   )
 })


### PR DESCRIPTION
Add toast messages corresponding to the API responses.

<img width="565" alt="image" src="https://github.com/aziontech/azion-platform-kit/assets/107002324/22c48390-96b5-4bd8-b917-f0874195297d">

<img width="565" alt="image" src="https://github.com/aziontech/azion-platform-kit/assets/107002324/54b24eea-d925-4f5f-8b6b-0321e6b28143">
