### PR TITLE
[NO-ISSUE] fix: center style for header/footer

### DIFF
--- a/src/templates/footer-block/index.vue
+++ b/src/templates/footer-block/index.vue
@@ -10,7 +10,7 @@
       class="flex flex-col gap-3 lg:gap-4 items-center lg:flex lg:flex-row flex-none md-auto md:flex-1"
     >
       <div class="w-full flex flex-col md:flex-row gap-3 justify-center items-center">
-        <div class="flex gap-1 lg:pl-[9%] pl-0">
+        <div class="flex gap-1 lg:pl-[16%] pl-0">
           <PrimeButton
             label="About"
             link
@@ -72,6 +72,7 @@
             :autoOptionFocus="false"
             :pt="{
               root: {
+                class: 'w-[7.4rem]',
                 style: 'background: var(--surface-section) !important'
               },
               item: { class: 'w-full text-sm' },

--- a/src/templates/main-menu-block/index.vue
+++ b/src/templates/main-menu-block/index.vue
@@ -48,7 +48,7 @@
       </div>
 
       <!-- Search -->
-      <span class="top-0 p-input-icon-left p-input-icon-right hidden lg:flex">
+      <span class="top-0 p-input-icon-left p-input-icon-right hidden lg:flex md:absolute md:my-3 md:ml-[calc(50%-10rem)]">
         <i class="pi pi-search text-white" />
         <i class="!top-[32%]">
           <span


### PR DESCRIPTION
O que foi feito:
- Adicionado classes de centralização idenpendente ao searchbar no header
- Fixado o tamanho do dropdown de theme no footer
- Adicionado compensação de padding-left aos links do footer para centraliza-lo em relação aos demais boxes.

![image](https://github.com/aziontech/azion-platform-kit/assets/44036260/caad0215-05da-44f8-bc0c-21b32fa2f288)

