### PR TITLE
[ENG-28245]feat: add left and right slotst to main action button of empty-results-block

### DIFF
--- a/src/templates/empty-results-block/index.vue
+++ b/src/templates/empty-results-block/index.vue
@@ -12,12 +12,13 @@
     </div>
     <div class="flex flex-col gap-5 items-center">
       <div class="flex flex-wrap gap-2">
-        <slot name="extraActions"></slot>
+        <slot name="extraActionsLeft"></slot>
         <PrimeButton
           icon="pi pi-plus"
           :label="createButtonLabel"
           @click="navigateToCreatePage"
         />
+        <slot name="extraActionsRight"></slot>
       </div>
       <PrimeButton
         outlined


### PR DESCRIPTION
issue:
https://aziontech.atlassian.net/browse/ENG-28245

Print example:
<img width="884" alt="image" src="https://github.com/aziontech/azion-platform-kit/assets/101186721/af1f5c4f-b855-4334-8793-2a44dcea4419">
