### PR TITLE
[NO-ISSUE] feat: include text wrap for breadcrumb

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_breadcumb.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_breadcumb.scss
@@ -1,7 +1,8 @@
 // Custom Breadcrumb
 .p-breadcrumb {
   .p-breadcrumb-list {
-    font-weight: 500;
+    font-weight: 500 !important;
+    text-wrap: nowrap !important;
     .p-menuitem-link {
       padding: 0.25rem 0.125rem !important;
       transition: $formElementTransition !important;

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_breadcumb.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_breadcumb.scss
@@ -1,7 +1,8 @@
 // Custom Breadcrumb
 .p-breadcrumb {
   .p-breadcrumb-list {
-    font-weight: 500;
+    font-weight: 500 !important;
+    text-wrap: nowrap !important;
     .p-menuitem-link {
       padding: 0.25rem 0.125rem !important;
       transition: $formElementTransition !important;


### PR DESCRIPTION

https://github.com/aziontech/azion-platform-kit/assets/95422158/f49484a1-d012-4318-907e-84e4e4833ead

Apenas inclui propriedade para o texto não quebrar. Feito via theme. 