### PR TITLE
[ENG-28245] fix: ensure to clear input data after dialog closes

### DIFF
--- a/src/templates/list-table-block/dialog/delete-dialog.vue
+++ b/src/templates/list-table-block/dialog/delete-dialog.vue
@@ -150,6 +150,7 @@
       },
 
       cancelDialog() {
+        this.resetForm()
         this.deleteDialogVisible = false
       }
     },


### PR DESCRIPTION
ensure to clear all dialog form data, when cancel button got clicked.
<img width="647" alt="image" src="https://github.com/aziontech/azion-platform-kit/assets/101186721/72990ece-d424-4c7d-9cad-2747d52b7ae7">
