### PR TITLE
[ENG-28245] fix: page heading slot spaces

### DIFF
--- a/src/templates/page-heading-block-tabs/index.vue
+++ b/src/templates/page-heading-block-tabs/index.vue
@@ -23,8 +23,11 @@
           {{ description }}
         </div>
       </div>
-      <div class="ml-auto w-full h-9 items-end flex justify-end">
-        <slot></slot>
+      <div
+        v-if="hasDefaultSlot"
+        class="ml-auto w-full h-9 items-end flex justify-end"
+      >
+        <slot name="default"></slot>
       </div>
     </div>
     <slot name="tabs"></slot>
@@ -89,6 +92,9 @@
       },
       generateBreadCrumbs() {
         return this.$router.currentRoute.value.meta.breadCrumbs ?? []
+      },
+      hasDefaultSlot() {
+        return !!this.$slots.default
       }
     }
   }

--- a/src/templates/page-heading-block/index.vue
+++ b/src/templates/page-heading-block/index.vue
@@ -23,7 +23,10 @@
           {{ description }}
         </div>
       </div>
-      <div class="ml-auto w-full items-end flex justify-end">
+      <div
+        v-if="hasDefaultSlot"
+        class="ml-auto w-full items-end flex justify-end"
+      >
         <slot></slot>
       </div>
     </div>
@@ -88,6 +91,9 @@
       },
       generateBreadCrumbs() {
         return this.$router.currentRoute.value.meta.breadCrumbs ?? []
+      },
+      hasDefaultSlot() {
+        return !!this.$slots.default
       }
     }
   }


### PR DESCRIPTION
Avoid to create slot html with all tailwind classes and HTML markup in the DOM, when default slot is not provided/used.

![image](https://github.com/aziontech/azion-platform-kit/assets/101186721/3cd33ca3-d571-4f3e-b5dd-cf6474e599d6)
