### PR TITLE
[NO-ISSUE] fix: correct redirect url to edit view on Digital Certificates

### DIFF
--- a/src/router/routes/digital-certificates-routes/index.js
+++ b/src/router/routes/digital-certificates-routes/index.js
@@ -55,7 +55,7 @@ export const digitalCertificatesRoutes = {
       props: {
         editDigitalCertificateService: DigitalCertificatesService.editDigitalCertificateService,
         loadDigitalCertificateService: DigitalCertificatesService.loadDigitalCertificateService,
-        updatedRedirect: 'digital-certificates'
+        updatedRedirect: 'list-digital-certificates'
       },
       meta: {
         breadCrumbs: [


### PR DESCRIPTION
change redirect url to correct one.

https://github.com/aziontech/azion-platform-kit/assets/101186721/1ec5bd5b-dbbe-4438-8bd8-06da262b1583


