### PR TITLE
[NO-ISSUE] fix: deleteTeamPermissionService to use correct status code and base url

### DIFF
--- a/src/services/team-permission/delete-team-permission-service.js
+++ b/src/services/team-permission/delete-team-permission-service.js
@@ -4,7 +4,7 @@ import * as Errors from '@/services/axios/errors'
 
 export const deleteTeamPermissionService = async (teamPermissionId) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeTeamPermissionBaseUrl()}/${teamPermissionId}/`,
+    url: `${makeTeamPermissionBaseUrl()}/${teamPermissionId}`,
     method: 'DELETE'
   })
 
@@ -19,7 +19,7 @@ export const deleteTeamPermissionService = async (teamPermissionId) => {
  */
 const parseHttpResponse = (httpResponse) => {
   switch (httpResponse.statusCode) {
-    case 204:
+    case 200:
       return 'Team Permission successfully deleted'
     case 400:
       throw new Errors.NotFoundError().message

--- a/src/tests/services/team-permission-services/delete-team-permission-service.test.js
+++ b/src/tests/services/team-permission-services/delete-team-permission-service.test.js
@@ -14,7 +14,7 @@ const makeSut = () => {
 describe('TeamPermissionServices', () => {
   it('should call API with correct params', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 204
+      statusCode: 200
     })
     const environmentVariableIdMock = 765678
     const { sut } = makeSut()
@@ -22,14 +22,14 @@ describe('TeamPermissionServices', () => {
     await sut(environmentVariableIdMock)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `teams/${environmentVariableIdMock}/`,
+      url: `teams/${environmentVariableIdMock}`,
       method: 'DELETE'
     })
   })
 
   it('should return a feedback message on successfully deleted', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 204
+      statusCode: 200
     })
     const environmentVariableIdMock = 7816825367
     const { sut } = makeSut()


### PR DESCRIPTION
Fix:
-  correct base url to delete team permission
-  use correct http status code on successfully deletion , change from 204 to 200 ( API is returning 200 instead of 204)

![image](https://github.com/aziontech/azion-platform-kit/assets/101186721/dc177e66-cb79-41d7-8031-48ea0a58b992)
