### PR TITLE
[NO-ISSUE]  fix: sync figma padding minimo site/kit

### DIFF
--- a/src/templates/main-menu-block/index.vue
+++ b/src/templates/main-menu-block/index.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Header Container -->
   <header
-    class="p-3 bg-header text-white border-b surface-border items-center flex justify-between md:px-8 md:py-3 w-full fixed top-0 z-10 h-[56px]"
+    class="p-3 bg-header text-white border-b surface-border items-center flex justify-between px-4 md:px-8 md:py-3 w-full fixed top-0 z-10 h-[56px]"
     @keyup.esc="closeSideBar"
   >
     <div


### PR DESCRIPTION
@cesaroeduardo told us on the site interface the px-4, verifying in the repository i note the usage of p-3 and md-px-8, I only fixed to px-4 to me used on minimum screen.