### PR TITLE
[NO-ISSUE] Sidebar Mobile Bug

### DIFF
--- a/src/templates/main-menu-block/index.vue
+++ b/src/templates/main-menu-block/index.vue
@@ -255,7 +255,7 @@
           <Dropdown
             :modelValue="selectedTheme"
             @update:modelValue="selectTheme"
-            @click="preventSidebarClick"
+            @click.stop
             optionValue="value"
             optionLabel="name"
             :options="themeOptions"
@@ -821,9 +821,6 @@
       }
     },
     methods: {
-      preventSidebarClick(event) {
-        event.stopPropagation()
-      },
       ...mapActions(useAccountStore, ['setTheme']),
       toggleProfileMobile() {
         this.showProfile = !this.showProfile


### PR DESCRIPTION
Removido a função que fazia a sidebar fechar quando clicasse em cima dela, impossibilitando a troca de thema no mobile.

Video do problema:
https://github.com/aziontech/azion-platform-kit/assets/44036260/a136aade-90b1-49d9-982a-9ce2685c41b2

