### PR TITLE
[ENG-28597] fix: add initial values to start CreateForm of IDNS with correct state

### DIFF
--- a/src/views/IntelligentDNS/CreateView.vue
+++ b/src/views/IntelligentDNS/CreateView.vue
@@ -21,6 +21,7 @@
       <CreateFormBlock
         :createService="props.createIntelligentDNSService"
         :schema="validationSchema"
+        :initialValues="initialValues"
       >
         <template #form>
           <FormFieldsIntelligentDnsCreate></FormFieldsIntelligentDnsCreate>
@@ -69,8 +70,14 @@
         const domainRegex = /^(?:[-A-Za-z0-9]+\.)+[A-Za-z]{2,6}$/
         return domainRegex.test(value)
       }),
-    isActive: yup.boolean().default(true)
+    isActive: yup.boolean()
   })
+
+  const initialValues = {
+    name: '',
+    domain: '',
+    isActive: true
+  }
 
   const handleCopyNameServers = () => {
     props.clipboardWrite('ns1.aziondns.net;ns2.aziondns.com;ns3.aziondns.org')


### PR DESCRIPTION
add initial state to Create form of Idns to avoid empty values on Idns Creation

https://github.com/aziontech/azion-platform-kit/assets/101186721/de5abedd-fc4b-43b0-be89-bad6ab4a3bae

