### PR TITLE
[NO-ISSUE] fix: resolve reload when route is changed by modal create

### DIFF
--- a/src/templates/create-modal-block/index.vue
+++ b/src/templates/create-modal-block/index.vue
@@ -235,9 +235,7 @@
     methods: {
       redirectToSolution(template) {
         this.showSidebar = false
-        this.$router.push(`/create/${template.vendor.slug}/${template.slug}`).then(() => {
-          this.$router.go()
-        })
+        this.$router.push(`/create/${template.vendor.slug}/${template.slug}`)
         this.$emit('closeModal')
       },
       onMenuChange(target) {

--- a/src/templates/main-menu-block/index.vue
+++ b/src/templates/main-menu-block/index.vue
@@ -486,7 +486,7 @@
   >
     <!-- SLOT WIP -->
     <div>
-      <CreateModalBlock @closeModal="createBoardManager.close()" />
+      <CreateModalBlock @closeModal="createModalStore.close()" />
     </div>
   </PrimeDialog>
 

--- a/src/views/CreateNew/CreateView.vue
+++ b/src/views/CreateNew/CreateView.vue
@@ -282,6 +282,11 @@
       handleInstantiate(element) {
         this.$router.push(`/deploy/${element.uuid}`)
       }
+    },
+    watch: {
+      $route (){
+        this.loadSolution()
+      }
     }
   }
 </script>


### PR DESCRIPTION
Coloquei um watcher na tela do formulario do formulario do fluxo de create para executar o carregamento do template quando os parametros da rota são atualizados, desse jeito não é necessario recarregar tudo perdendo o spa da aplicação