### PR TITLE
[NO-ISSUE] chore: update banner padding

### DIFF
--- a/src/templates/content-block/banner.vue
+++ b/src/templates/content-block/banner.vue
@@ -7,7 +7,7 @@
           :closable="false"
           :pt="{
             root: { class: 'mx-3 mt-4 sm:mx-8' },
-            wrapper: { class: 'py-3 px-3 items-start sm:items-center sm:px-8' }
+            wrapper: { class: 'py-3 px-3 items-start sm:items-center' }
           }"
         >
           <template #messageicon>

--- a/src/templates/content-block/index.vue
+++ b/src/templates/content-block/index.vue
@@ -6,7 +6,7 @@
         :closable="false"
         :pt="{
           root: { class: 'mx-3 mt-4 sm:mx-8' },
-          wrapper: { class: 'py-3 px-3 items-start sm:px-8 sm:items-center' }
+          wrapper: { class: 'py-3 px-3 items-start sm:items-center' }
         }"
       >
         <template #messageicon>


### PR DESCRIPTION
Removed the py-8 padding for SM screens in Experimental Banner.

Before:
![image](https://github.com/aziontech/azion-platform-kit/assets/25899/053b8558-104e-4ffd-9d16-bba219aa6da3)

After:
![image](https://github.com/aziontech/azion-platform-kit/assets/25899/9da59d29-6a53-4c89-8ce7-9e53d4136c99)

