### PR TITLE
[NO-ISSUE] chore: update signup api base urls

### DIFF
--- a/src/services/signup-services/make-additional-data-base-url.js
+++ b/src/services/signup-services/make-additional-data-base-url.js
@@ -1,3 +1,4 @@
 export const makeAdditionalDataBaseUrl = () => {
-  return 'iam/additional_data'
+  const version = 'v3'
+  return `${version}/iam/additional_data`
 }

--- a/src/services/signup-services/make-signup-base-url.js
+++ b/src/services/signup-services/make-signup-base-url.js
@@ -1,3 +1,4 @@
 export const makeSignupBaseUrl = () => {
-  return 'signup'
+  const version = 'v3'
+  return `${version}/signup`
 }

--- a/src/tests/services/signup-services/list-additional-data-info-service.test.js
+++ b/src/tests/services/signup-services/list-additional-data-info-service.test.js
@@ -36,11 +36,11 @@ describe('SignupServices', () => {
     })
 
     const { sut } = makeSut()
-
+    const version = 'v3'
     await sut()
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: 'iam/additional_data',
+      url: `${version}/iam/additional_data`,
       method: 'GET'
     })
   })

--- a/src/tests/services/signup-services/signup-service.test.js
+++ b/src/tests/services/signup-services/signup-service.test.js
@@ -23,11 +23,11 @@ describe('SignupServices', () => {
       statusCode: 201
     })
     const { sut } = makeSut()
-
+    const version = 'v3'
     await sut(userPayloadMock)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: 'signup',
+      url: `${version}/signup`,
       method: 'POST',
       body: userPayloadMock
     })


### PR DESCRIPTION
Update additional data and signup to use the same version pattern over the API's base URL's.