### PR TITLE
[ENG-28766] CLI callback page

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/_variables.scss
+++ b/src/assets/themes/scss/themes/azion-dark/_variables.scss
@@ -39,9 +39,31 @@ $colors: (
   --surface-e: #ffffff;
   --surface-f: #ffffff;
 
+  --green-50:#f4fcf7;
+  --green-100:#caf1d8;
+  --green-200:#a0e6ba;
+  --green-300:#76db9b;
+  --green-400:#4cd07d;
+  --green-500:#22c55e;
+  --green-600:#1da750;
+  --green-700:#188a42;
+  --green-800:#136c34;
+  --green-900:#0e4f26;
+
+  --red-50:#fff5f5;
+  --red-100:#ffd0ce;
+  --red-200:#ffaca7;
+  --red-300:#ff8780;
+  --red-400:#ff6259;
+  --red-500:#ff3d32;
+  --red-600:#d9342b;
+  --red-700:#b32b23;
+  --red-800:#8c221c;
+  --red-900:#661814;
+
   --text-color: #ededed;
   --text-color-secondary: #b5b5b5;
-  --text-color-link: #3265cb;
+  --text-color-link: #93c5fd;
 
   --primary-color: #f4f4f4;
   --primary-color-text: #1e1e1e;

--- a/src/assets/themes/scss/themes/azion-light/_variables.scss
+++ b/src/assets/themes/scss/themes/azion-light/_variables.scss
@@ -60,6 +60,28 @@ $colors: (
   --surface-800: #b5b5b5;
   --surface-900: #a7a7a7;
 
+  --green-50:#f4fcf7;
+  --green-100:#caf1d8;
+  --green-200:#a0e6ba;
+  --green-300:#76db9b;
+  --green-400:#4cd07d;
+  --green-500:#22c55e;
+  --green-600:#1da750;
+  --green-700:#188a42;
+  --green-800:#136c34;
+  --green-900:#0e4f26;
+
+  --red-50:#fff5f5;
+  --red-100:#ffd0ce;
+  --red-200:#ffaca7;
+  --red-300:#ff8780;
+  --red-400:#ff6259;
+  --red-500:#ff3d32;
+  --red-600:#d9342b;
+  --red-700:#b32b23;
+  --red-800:#8c221c;
+  --red-900:#661814;
+  
   --gray-50: #fafafa;
   --gray-100: #f5f5f5;
   --gray-200: #eeeeee;

--- a/src/router/hooks/beforeEachRoute.js
+++ b/src/router/hooks/beforeEachRoute.js
@@ -4,7 +4,7 @@ import { useAccountStore } from '@/stores/account'
 
 export default async function beforeEachRoute(to, _, next) {
   const accountStore = useAccountStore()
-
+  const cliCallbackURLs = ['/cli-callback-fail', '/cli-callback-success']
   // TODO: remove the usage of localStorage when API returns the theme
   const theme = localStorage.getItem('theme')
 
@@ -14,6 +14,10 @@ export default async function beforeEachRoute(to, _, next) {
   if (to.path === '/logout') {
     await logoutService()
     accountStore.setAccountData({})
+    return next()
+  }
+
+  if (cliCallbackURLs.includes(to.path)) {
     return next()
   }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,11 +28,13 @@ import { signupRoutes } from '@routes/signup-routes'
 import { marketplaceRoutes } from '@routes/marketplace-routes'
 import { accountRoutes } from '@/router/routes/account-routes'
 import { settingsRoutes } from '@/router/routes/your-settings-routes'
+import { cliCallbackRoutes } from '@/router/routes/cli-callback-routes'
 import beforeEachRoute from './hooks/beforeEachRoute'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    cliCallbackRoutes,
     dataStreamingRoutes,
     digitalCertificatesRoutes,
     domainsRoutes,

--- a/src/router/routes/cli-callback-routes/index.js
+++ b/src/router/routes/cli-callback-routes/index.js
@@ -1,0 +1,15 @@
+/** @type {import('vue-router').RouteRecordRaw} */
+export const cliCallbackRoutes = {
+  children: [
+    {
+      path: '/cli-callback-success',
+      name: 'cli-callback-success-page',
+      component: () => import('@views/CliCallback/SuccessView.vue')
+    },
+    {
+      path: '/cli-callback-fail',
+      name: 'cli-callback-fail-page',
+      component: () => import('@views/CliCallback/FailView.vue')
+    }
+  ]
+}

--- a/src/views/CliCallback/FailView.vue
+++ b/src/views/CliCallback/FailView.vue
@@ -1,9 +1,26 @@
 <template>
-  <div class="min-h-[calc(100vh-60px-56px)] sm:py-20 pt-4 pb-8 px-3">FAIL</div>
+  <div class="mx-auto max-w-[720px] items-center text-center gap-6">
+    <div style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%);" class=" p-4 rounded-md">
+      <i class="pi pi-times" style="color:var(--red-400); font-size: 2rem;"></i>
+    </div>
+    <h1 class="text-3xl lg:text-4xl text-medium">Azion CLI Authentication Failed</h1>
+    <p class="mx-8 text-lg text-color-secondary">Unable to authenticate the Azion CLI with the provided credentials. Please double-check your account details and try again. If the issue persists, ensure that you have the correct permissions or consider <PrimeButton class="p-0 font-normal text-lg"  label="resetting your password." link></PrimeButton>
+    </p>
+    
+    <p class="mx-8 text-lg text-color-secondary">For assistance, you can refer to the documentation or contact Azion support.
+    </p>
+  </div>
 </template>
 
 <script>
   export default {
-    name: 'cli-callback-fail-view'
+    name: 'cli-callback-fail-view',
+    components: {
+      PrimeButton,
+  },
   }
+
+
+import PrimeButton from 'primevue/button';
+
 </script>

--- a/src/views/CliCallback/FailView.vue
+++ b/src/views/CliCallback/FailView.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-[calc(100vh-60px-56px)] sm:py-20 pt-4 pb-8 px-3">FAIL</div>
+</template>
+
+<script>
+  export default {
+    name: 'cli-callback-fail-view'
+  }
+</script>

--- a/src/views/CliCallback/FailView.vue
+++ b/src/views/CliCallback/FailView.vue
@@ -1,26 +1,28 @@
 <template>
   <div class="mx-auto max-w-[720px] items-center text-center gap-6">
-    <div style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%);" class=" p-4 rounded-md">
-      <i class="pi pi-times" style="color:var(--red-400); font-size: 2rem;"></i>
+    <div
+      style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%)"
+      class="p-4 rounded-md"
+    >
+      <i
+        class="pi pi-times"
+        style="color: var(--red-400); font-size: 2rem"
+      ></i>
     </div>
     <h1 class="text-3xl lg:text-4xl text-medium">Azion CLI Authentication Failed</h1>
-    <p class="mx-8 text-lg text-color-secondary">Unable to authenticate the Azion CLI with the provided credentials. Please double-check your account details and try again. If the issue persists, ensure that you have the correct permissions or consider <PrimeButton class="p-0 font-normal text-lg"  label="resetting your password." link></PrimeButton>
+    <p class="mx-8 text-lg text-color-secondary">
+      Unable to authenticate the Azion CLI with the provided credentials. Please double-check your
+      account details and try again.
     </p>
-    
-    <p class="mx-8 text-lg text-color-secondary">For assistance, you can refer to the documentation or contact Azion support.
+
+    <p class="mx-8 text-lg text-color-secondary">
+      For assistance, you can refer to the documentation or contact Azion support.
     </p>
   </div>
 </template>
 
 <script>
   export default {
-    name: 'cli-callback-fail-view',
-    components: {
-      PrimeButton,
-  },
+    name: 'cli-callback-fail-view'
   }
-
-
-import PrimeButton from 'primevue/button';
-
 </script>

--- a/src/views/CliCallback/SuccessView.vue
+++ b/src/views/CliCallback/SuccessView.vue
@@ -1,25 +1,27 @@
 <template>
   <div class="mx-auto max-w-[720px] items-center text-center gap-6">
-    <div style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%);" class=" p-4 rounded-md">
-      <i class="pi pi-check" style="color:var(--green-500); font-size: 2rem;"></i>
+    <div
+      style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%)"
+      class="p-4 rounded-md"
+    >
+      <i
+        class="pi pi-check"
+        style="color: var(--green-500); font-size: 2rem"
+      ></i>
     </div>
     <h1 class="mx-8 text-3xl lg:text-4xl text-medium">Azion CLI Authentication Successfull</h1>
-    <p class="mx-8 text-lg text-color-secondary">You've successfully authenticated the Azion CLI with the following account:
+    <p class="mx-8 text-lg text-color-secondary">
+      You've successfully authenticated the Azion CLI.
     </p>
-    <span class="p-4 text-lg font-robotomono text-color-link surface-200">alessandro.cauduro@gmail.com</span>
-    <p class="mx-8 text-lg text-color-secondary">you can now close this tab and return to the CLI.
-    </p>
+    <p class="mx-8 text-lg text-color-secondary">You can now close this tab.</p>
   </div>
 </template>
 
 <script>
-export default {
-  name: 'cli-callback-success-view',
-  PrimeButton,
-}
+  export default {
+    name: 'cli-callback-success-view',
+    PrimeButton
+  }
 
-
-import PrimeButton from 'primevue/button';
-
-
+  import PrimeButton from 'primevue/button'
 </script>

--- a/src/views/CliCallback/SuccessView.vue
+++ b/src/views/CliCallback/SuccessView.vue
@@ -1,9 +1,25 @@
 <template>
-  <div class="min-h-[calc(100vh-60px-56px)] sm:py-20 pt-4 pb-8 px-3">SUCCESS</div>
+  <div class="mx-auto max-w-[720px] items-center text-center gap-6">
+    <div style="background: linear-gradient(to bottom, var(--surface-200) 0%, transparent 100%);" class=" p-4 rounded-md">
+      <i class="pi pi-check" style="color:var(--green-500); font-size: 2rem;"></i>
+    </div>
+    <h1 class="mx-8 text-3xl lg:text-4xl text-medium">Azion CLI Authentication Successfull</h1>
+    <p class="mx-8 text-lg text-color-secondary">You've successfully authenticated the Azion CLI with the following account:
+    </p>
+    <span class="p-4 text-lg font-robotomono text-color-link surface-200">alessandro.cauduro@gmail.com</span>
+    <p class="mx-8 text-lg text-color-secondary">you can now close this tab and return to the CLI.
+    </p>
+  </div>
 </template>
 
 <script>
-  export default {
-    name: 'cli-callback-success-view'
-  }
+export default {
+  name: 'cli-callback-success-view',
+  PrimeButton,
+}
+
+
+import PrimeButton from 'primevue/button';
+
+
 </script>

--- a/src/views/CliCallback/SuccessView.vue
+++ b/src/views/CliCallback/SuccessView.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-[calc(100vh-60px-56px)] sm:py-20 pt-4 pb-8 px-3">SUCCESS</div>
+</template>
+
+<script>
+  export default {
+    name: 'cli-callback-success-view'
+  }
+</script>


### PR DESCRIPTION
Implemented two statics pages to be called after the CLI auth process:
These pages don't have any logic, so the content and the texts are static.

Success Page (console.azion.com/cli-callback-success):
![image](https://github.com/aziontech/azion-console-kit/assets/25899/7724e191-1cde-42cc-850d-9e6dab0592a9)


Fail Page (console.azion.com/cli-callback-fail):
![image](https://github.com/aziontech/azion-console-kit/assets/25899/4cb63bc0-3700-4c15-8726-114939993dce)


