### PR TITLE
[ENG-28869] fix: adjusted import tag in sidebar block

### DIFF
--- a/src/templates/sidebar-block/index.vue
+++ b/src/templates/sidebar-block/index.vue
@@ -43,7 +43,7 @@
         >
           <span v-bind="props.icon" />
           <span v-bind="props.label">{{ label }}</span>
-          <Tag
+          <PrimeTag
             v-if="item.tag"
             :value="item.tag"
             class="ml-2"
@@ -57,7 +57,7 @@
 <script setup>
   import { ref, computed } from 'vue'
   import { useRouter } from 'vue-router'
-
+  import PrimeTag from 'primevue/tag'
   import PrimeButton from 'primevue/button'
   import PrimeMenu from 'primevue/menu'
   import Sidebar from 'primevue/sidebar'


### PR DESCRIPTION
fix import name from Prime vue to use Tag component in sidebar-block