### PR TITLE
[ENG-28094] test: add cache settings unit tests to load service

### DIFF
--- a/src/services/edge-application-cache-settings-services/list-cache-settings-service.js
+++ b/src/services/edge-application-cache-settings-services/list-cache-settings-service.js
@@ -4,7 +4,7 @@ import { makeEdgeApplicationBaseUrl } from '../edge-application-services/make-ed
 /**
  * @param {Object} payload - The error schema.
  * @param {string } payload.id - The id of edge application.
- * @returns {string|undefined} The result message based on the status code.
+ * @returns {Promise<string|undefined>} The result message based on the status code.
  */
 export const listCacheSettingsService = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({

--- a/src/tests/services/edge-application-cache-settings-services/list-cache-settings-service.test.js
+++ b/src/tests/services/edge-application-cache-settings-services/list-cache-settings-service.test.js
@@ -1,5 +1,4 @@
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
-import * as Errors from '@/services/axios/errors'
 import { listCacheSettingsService } from '@/services/edge-application-cache-settings-services'
 import { describe, expect, it, vi } from 'vitest'
 

--- a/src/tests/services/edge-application-cache-settings-services/list-cache-settings-service.test.js
+++ b/src/tests/services/edge-application-cache-settings-services/list-cache-settings-service.test.js
@@ -1,0 +1,64 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import * as Errors from '@/services/axios/errors'
+import { listCacheSettingsService } from '@/services/edge-application-cache-settings-services'
+import { describe, expect, it, vi } from 'vitest'
+
+const fixtures = {
+  edgeApplicationId: 1920763586747,
+  cacheSettingsMock: {
+    id: 181729637,
+    name: 'Cache Settings Console Kit',
+    browser_cache_settings: true,
+    cdn_cache_settings: false
+  }
+}
+
+const makeSut = () => {
+  const sut = listCacheSettingsService
+
+  return { sut }
+}
+
+describe('EdgeApplicationCacheSettingsServices', () => {
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: []
+      }
+    })
+
+    const { sut } = makeSut()
+    await sut({
+      id: fixtures.edgeApplicationId
+    })
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `v3/edge_applications/${fixtures.edgeApplicationId}/cache_settings`,
+      method: 'GET'
+    })
+  })
+
+  it('should parse each cache settings correctly', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: [fixtures.cacheSettingsMock]
+      }
+    })
+
+    const { sut } = makeSut()
+    const result = await sut({
+      id: fixtures.edgeApplicationId
+    })
+
+    expect(result).toEqual([
+      {
+        id: fixtures.cacheSettingsMock.id,
+        name: fixtures.cacheSettingsMock.name,
+        browserCache: fixtures.cacheSettingsMock.browser_cache_settings,
+        cdnCache: fixtures.cacheSettingsMock.cdn_cache_settings
+      }
+    ])
+  })
+})

--- a/src/tests/services/edge-application-cache-settings-services/load-cache-settings-service.test.js
+++ b/src/tests/services/edge-application-cache-settings-services/load-cache-settings-service.test.js
@@ -1,0 +1,114 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { loadCacheSettingsService } from '@/services/edge-application-cache-settings-services'
+import { describe, expect, it, vi } from 'vitest'
+
+const fixtures = {
+  edgeApplicationId: 4516528793898,
+  cacheSettingsMock: {
+    id: 817236,
+    name: 'mockName',
+    browser_cache_settings: 'mockBrowserCacheSettings',
+    browser_cache_settings_maximum_ttl: 'mockBrowserCacheSettingsMaximumTtl',
+    cdn_cache_settings: 'mockCdnCacheSettings',
+    cdn_cache_settings_maximum_ttl: 'mockCdnCacheSettingsMaximumTtl',
+    is_slice_configuration_enabled: false,
+    slice_configuration_range: 'mockSliceConfigurationRange',
+    cache_by_query_string: 'mockCacheByQueryString',
+    enable_query_string_sort: false,
+    enable_caching_for_post: false,
+    enable_caching_for_options: false,
+    enable_stale_cache: false,
+    cache_by_cookies: 'mockCacheByCookies',
+    cookie_names: [],
+    query_string_fields: [],
+    adaptive_delivery_action: 'mockAdaptiveDeliveryAction',
+    device_group: null
+  }
+}
+
+const makeSut = () => {
+  const sut = loadCacheSettingsService
+
+  return { sut }
+}
+
+describe('EdgeApplicationCacheSettingsServices', () => {
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: fixtures.cacheSettingsMock
+      }
+    })
+
+    const { sut } = makeSut()
+    await sut({
+      edgeApplicationId: fixtures.edgeApplicationId,
+      id: fixtures.cacheSettingsMock.id
+    })
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `v3/edge_applications/${fixtures.edgeApplicationId}/cache_settings/${fixtures.cacheSettingsMock.id}`,
+      method: 'GET'
+    })
+  })
+
+  it('should parse each returned device group', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: { ...fixtures.cacheSettingsMock, device_group: [123, 456] }
+      }
+    })
+
+    const { sut } = makeSut()
+    const results = await sut({
+      edgeApplicationId: fixtures.edgeApplicationId,
+      id: fixtures.cacheSettingsMock.id
+    })
+
+    expect(results.deviceGroup).toEqual([
+      {
+        id: 123
+      },
+      { id: 456 }
+    ])
+  })
+
+  it('should parse each cookie name in cache settings', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: { ...fixtures.cacheSettingsMock, cookie_names: ['cookieName1', 'cookieName2'] }
+      }
+    })
+
+    const { sut } = makeSut()
+    const results = await sut({
+      edgeApplicationId: fixtures.edgeApplicationId,
+      id: fixtures.cacheSettingsMock.id
+    })
+
+    expect(results.cookieNames).toEqual('cookieName1\ncookieName2')
+  })
+
+  it('should parse each query string in cache settings', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: {
+          ...fixtures.cacheSettingsMock,
+          query_string_fields: ['queryString1', 'queryString2']
+        }
+      }
+    })
+
+    const { sut } = makeSut()
+    const results = await sut({
+      edgeApplicationId: fixtures.edgeApplicationId,
+      id: fixtures.cacheSettingsMock.id
+    })
+
+    expect(results.queryStringFields).toEqual('queryString1\nqueryString2')
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -28,10 +28,10 @@ export default mergeConfig(
       coverage: {
         enabled: true,
         include: ['src/services/**', 'src/views/**', 'src/helpers/**'],
-        statements: 90,
-        branches: 90,
-        functions: 89,
-        lines: 90,
+        statements: 91,
+        branches: 91,
+        functions: 91,
+        lines: 91,
         reporter: ['text', 'lcov', 'html']
       },
       reporters: ['default', 'vitest-sonar-reporter'],


### PR DESCRIPTION
Only add necessary unit tests to the cache settings services, such as load service and list service.
As a bonus this PR also introduce a new coverage threshold with a percentagem of 91 as the default value.