### PR TITLE
[EDU-3781] chore: change mapper of digital certificates list to use TLS name

### DIFF
--- a/src/services/digital-certificates-services/list-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/list-digital-certificates-service.js
@@ -17,7 +17,7 @@ export const listDigitalCertificatesService = async ({
   return parseHttpResponse(httpResponse)
 }
 
-export const EDGE_CERTIFICATE = 'Edge Certificate'
+export const EDGE_CERTIFICATE = 'TLS Certificate'
 export const TRUSTED_CA_CERTIFICATE = 'Trusted CA Certificate'
 
 const parseStatusData = (status) => {

--- a/src/tests/services/digital-certificates-services/list-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/list-digital-certificates-service.test.js
@@ -86,7 +86,7 @@ describe('DigitalCertificatesServices', () => {
       id: fixtures.certificateMock.id,
       name: fixtures.certificateMock.name,
       issuer: fixtures.certificateMock.issuer,
-      type: 'Edge Certificate',
+      type: 'TLS Certificate',
       subjectName: 'Subject 1,Subject 2',
       validity: 'Nov 10, 2023, 12:00 AM',
       status: {
@@ -128,7 +128,7 @@ describe('DigitalCertificatesServices', () => {
         id: fixtures.certificateMock.id,
         name: fixtures.certificateMock.name,
         issuer: fixtures.certificateMock.issuer,
-        type: 'Edge Certificate',
+        type: 'TLS Certificate',
         subjectName: 'Subject 1,Subject 2',
         validity: 'Nov 10, 2023, 12:00 AM',
         status: {


### PR DESCRIPTION

old:
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/13b573d2-fbca-4543-8d29-b26587703196)

new name (TLS Certificate intead of Edge Certificate)

![image](https://github.com/aziontech/azion-console-kit/assets/101186721/b9cfdbfc-6599-4dc5-a262-f1a754e0cd69)
