### PR TITLE
[NO-ISSUE] refactor: rename real-time-metrics url

### DIFF
--- a/src/router/routes/metrics-routes/index.js
+++ b/src/router/routes/metrics-routes/index.js
@@ -3,7 +3,7 @@ import * as MetricsServices from '@/services/metrics-services'
 
 /** @type {import('vue-router').RouteRecordRaw} */
 export const metricsRoutes = {
-  path: '/real-time-metrics/:pageId?/:dashboardId?',
+  path: '/real-time-metrics/:group?/:product?',
   name: 'real-time-metrics',
   component: () => import('@views/Metrics/MetricsView.vue'),
   props: {

--- a/src/router/routes/metrics-routes/index.js
+++ b/src/router/routes/metrics-routes/index.js
@@ -3,8 +3,8 @@ import * as MetricsServices from '@/services/metrics-services'
 
 /** @type {import('vue-router').RouteRecordRaw} */
 export const metricsRoutes = {
-  path: '/metrics/:pageId?/:dashboardId?',
-  name: 'metrics',
+  path: '/real-time-metrics/:pageId?/:dashboardId?',
+  name: 'real-time-metrics',
   component: () => import('@views/Metrics/MetricsView.vue'),
   props: {
     playgroundOpener: metricsPlaygroundOpener,

--- a/src/services/metrics-services/constants/dashboards.js
+++ b/src/services/metrics-services/constants/dashboards.js
@@ -40,7 +40,7 @@ const PAGES_DASHBOARDS = {
       dashboards: [
         {
           id: 357549371218199219n,
-          label: 'caching-offload',
+          label: 'Caching Offload',
           url: 'caching-offload',
           dataset: 'l2CacheMetrics'
         }

--- a/src/services/metrics-services/fetch-metrics-dashboards-service.js
+++ b/src/services/metrics-services/fetch-metrics-dashboards-service.js
@@ -1,13 +1,13 @@
 import GROUP_DASHBOARDS from './constants/dashboards'
 
-export const fetchMetricsDashboardsService = async (groupId, productId) => {
-  if (!productId || !groupId) {
+export const fetchMetricsDashboardsService = async (groupPath, productPath) => {
+  if (!productPath || !groupPath) {
     return Promise.resolve([])
   }
 
-  const { pagesDashboards } = GROUP_DASHBOARDS.find((group) => group.id == groupId)
+  const { pagesDashboards } = GROUP_DASHBOARDS.find((group) => group.value == groupPath)
 
-  const products = pagesDashboards.filter((product) => product.id == productId)
+  const products = pagesDashboards.filter((product) => product.path == productPath)
 
   if (!products.length) {
     return Promise.resolve([])
@@ -17,7 +17,8 @@ export const fetchMetricsDashboardsService = async (groupId, productId) => {
     return {
       id: dashboard.id,
       label: dashboard.label,
-      dataset: dashboard.dataset
+      dataset: dashboard.dataset,
+      path: dashboard.url
     }
   })
 

--- a/src/services/metrics-services/fetch-metrics-dashboards-service.js
+++ b/src/services/metrics-services/fetch-metrics-dashboards-service.js
@@ -7,7 +7,7 @@ export const fetchMetricsDashboardsService = async (groupPath, productPath) => {
 
   const { pagesDashboards } = GROUP_DASHBOARDS.find((group) => group.value == groupPath)
 
-  const products = pagesDashboards.filter((product) => product.path == productPath)
+  const products = pagesDashboards.filter((product) => product.url == productPath)
 
   if (!products.length) {
     return Promise.resolve([])

--- a/src/services/metrics-services/fetch-metrics-products-service.js
+++ b/src/services/metrics-services/fetch-metrics-products-service.js
@@ -10,7 +10,8 @@ export const fetchMetricsProductsService = async (groupValue) => {
     return {
       id: dashboard.id,
       label: dashboard.label,
-      groupId: dashboard.groupId
+      groupId: dashboard.groupId,
+      path: dashboard.url
     }
   })
 

--- a/src/tests/services/metrics-services/fetch-metrics-dashboards-service.test.js
+++ b/src/tests/services/metrics-services/fetch-metrics-dashboards-service.test.js
@@ -6,64 +6,74 @@ const fixtures = {
     {
       id: 357548608166298191n,
       label: 'Data Transferred',
-      dataset: 'httpMetrics'
+      dataset: 'httpMetrics',
+      path: 'data-transferred'
     },
     {
       id: 357548623571976783n,
       label: 'Requests',
-      dataset: 'httpMetrics'
+      dataset: 'httpMetrics',
+      path: 'requests'
     },
     {
       id: 357548642810200653n,
       label: 'Status Codes',
-      dataset: 'httpMetrics'
+      dataset: 'httpMetrics',
+      path: 'status-codes'
     },
     {
       id: 357549179454620239n,
       label: 'Bandwidth Saving',
-      dataset: 'httpMetrics'
+      dataset: 'httpMetrics',
+      path: 'bandwidth-saving'
     }
   ],
   l2Caching: [
     {
       id: 357549371218199219n,
-      label: 'caching-offload',
-      dataset: 'l2CacheMetrics'
+      label: 'Caching Offload',
+      dataset: 'l2CacheMetrics',
+      path: 'caching-offload'
     }
   ],
   edgeFunctions: [
     {
       id: 357549319029523021n,
       label: 'Invocations',
-      dataset: 'edgeFunctionsMetrics'
+      dataset: 'edgeFunctionsMetrics',
+      path: 'invocations'
     }
   ],
   imageProcessor: [
     {
       id: 357549422933967445n,
       label: 'Requests',
-      dataset: 'imagesProcessedMetrics'
+      dataset: 'imagesProcessedMetrics',
+      path: 'requests'
     }
   ],
   waf: [
     {
       id: 357548675837198933n,
       label: 'Threats',
-      dataset: 'httpMetrics'
+      dataset: 'httpMetrics',
+      path: 'threats'
     }
   ],
   intelligentDns: [
     {
       id: 357549371218199119n,
       label: 'Standard Queries',
-      dataset: 'idnsQueriesMetrics'
+      dataset: 'idnsQueriesMetrics',
+      path: 'standard-queries'
     }
   ],
   dataStreaming: [
     {
       id: 352149476039721549n,
       label: 'Data Streamed',
-      dataset: 'dataStreamedMetrics'
+      dataset: 'dataStreamedMetrics',
+      path: 'requests'
     }
   ]
 }
@@ -80,6 +90,7 @@ const scenarios = [
   {
     group: 'build',
     page: 'edgeApplications',
+    pageUrl: 'edge-applications',
     groupId: 1,
     pageId: 1,
     expected: fixtures.edgeApplications
@@ -87,6 +98,7 @@ const scenarios = [
   {
     group: 'build',
     page: 'l2Caching',
+    pageUrl: 'l2-caching',
     groupId: 1,
     pageId: 2,
     expected: fixtures.l2Caching
@@ -94,6 +106,7 @@ const scenarios = [
   {
     group: 'build',
     page: 'edgeFunctions',
+    pageUrl: 'edge-functions',
     groupId: 1,
     pageId: 3,
     expected: fixtures.edgeFunctions
@@ -101,6 +114,7 @@ const scenarios = [
   {
     group: 'build',
     page: 'imageProcessor',
+    pageUrl: 'image-processor',
     groupId: 1,
     pageId: 4,
     expected: fixtures.imageProcessor
@@ -108,6 +122,7 @@ const scenarios = [
   {
     group: 'secure',
     page: 'waf',
+    pageUrl: 'waf',
     groupId: 2,
     pageId: 6,
     expected: fixtures.waf
@@ -115,6 +130,7 @@ const scenarios = [
   {
     group: 'secure',
     page: 'intelligentDns',
+    pageUrl: 'intelligent-dns',
     groupId: 2,
     pageId: 7,
     expected: fixtures.intelligentDns
@@ -122,6 +138,7 @@ const scenarios = [
   {
     group: 'observe',
     page: 'dataStreaming',
+    pageUrl: 'data-streaming',
     groupId: 3,
     pageId: 8,
     expected: fixtures.dataStreaming
@@ -131,19 +148,19 @@ const scenarios = [
 describe('MetricsServices', () => {
   it.each(scenarios)(
     'should return a list of dashboards within %group group and %page page',
-    async ({ groupId, pageId, expected }) => {
+    async ({ group, pageUrl, expected }) => {
       const { sut } = makeSut()
 
-      const dashboards = await sut(groupId, pageId)
+      const dashboards = await sut(group, pageUrl)
 
       expect(dashboards).toEqual(expected)
     }
   )
 
   it.each([
-    { group: 1, page: 0, expected: [] },
-    { group: 0, page: 1, expected: [] }
-  ])('should return an empty list on not found group or page', async () => {
+    { group: 'build', product: 'undefined', expected: [] },
+    { group: 'undefined', product: 'edge-applications', expected: [] }
+  ])('should return an empty list on not found group or product', async () => {
     const { sut } = makeSut()
 
     const dashboards = await sut()

--- a/src/tests/services/metrics-services/fetch-metrics-products-service.test.js
+++ b/src/tests/services/metrics-services/fetch-metrics-products-service.test.js
@@ -6,41 +6,48 @@ const fixtures = {
     {
       id: 1,
       label: 'Edge Applications',
-      groupId: 1
+      groupId: 1,
+      path: 'edge-applications'
     },
     {
       id: 2,
       label: 'L2 Caching',
-      groupId: 1
+      groupId: 1,
+      path: 'l2-caching'
     },
     {
       id: 3,
       label: 'Edge Functions',
-      groupId: 1
+      groupId: 1,
+      path: 'edge-functions'
     },
     {
       id: 4,
       label: 'Image Processor',
-      groupId: 1
+      groupId: 1,
+      path: 'image-processor'
     }
   ],
   secure: [
     {
       id: 6,
       label: 'WAF',
-      groupId: 2
+      groupId: 2,
+      path: 'waf'
     },
     {
       id: 7,
       label: 'Intelligent DNS',
-      groupId: 2
+      groupId: 2,
+      path: 'intelligent-dns'
     }
   ],
   observe: [
     {
       id: 8,
       label: 'Data Streaming',
-      groupId: 3
+      groupId: 3,
+      path: 'data-streaming'
     }
   ]
 }

--- a/src/views/Metrics/MetricsView.vue
+++ b/src/views/Metrics/MetricsView.vue
@@ -51,13 +51,19 @@
   })
 
   const route = useRoute()
-  const routeParams = ref({})
+  const routeParams = ref({
+    group: 'build',
+    product: 'edge-applications'
+  })
 
   watch(
     route,
     () => {
-      const { pageId, dashboardId } = route.params
-      routeParams.value = { pageId: pageId || '1', dashboardId: dashboardId || '1' }
+      const { group, product } = route.params
+
+      if (group && product) {
+        routeParams.value = { group, product }
+      }
     },
     { immediate: true }
   )

--- a/src/views/Metrics/blocks/dashboard-panel-block.vue
+++ b/src/views/Metrics/blocks/dashboard-panel-block.vue
@@ -22,8 +22,8 @@
   const selectedDashboard = ref(null)
 
   const fetchDashboards = async () => {
-    const { pageId, dashboardId } = props.params
-    dashboards.value = await props.metricsDashboardsService(pageId, dashboardId)
+    const { group, product } = props.params
+    dashboards.value = await props.metricsDashboardsService(group, product)
 
     // TODO: revisit the selected dashboard when the filter is implemented
     selectedDashboard.value = dashboards.value[0]

--- a/src/views/Metrics/blocks/tabs-page-block.vue
+++ b/src/views/Metrics/blocks/tabs-page-block.vue
@@ -31,7 +31,7 @@
 
   const selectedGroup = ref(null)
   const setCurrentGroup = () => {
-    selectedGroup.value = metricsGroups.value.find((group) => group.id == props.params?.pageId)
+    selectedGroup.value = metricsGroups.value.find((group) => group.value == props.params.group)
   }
 
   watch(
@@ -58,15 +58,15 @@
   }
 
   const getCurrentProductIdx = () => {
-    const idx = metricsProducts.value.findIndex((product) => product.id == props.params.dashboardId)
+    const idx = metricsProducts.value.findIndex((product) => product.path == props.params.product)
 
     return idx < 0 ? 0 : idx
   }
 
   const setNewParams = () => {
     router.replace({
-      name: 'metrics',
-      params: { pageId: selectedGroup.value.id, dashboardId: selectedProduct.value.id }
+      name: 'real-time-metrics',
+      params: { group: selectedGroup.value.value, product: selectedProduct.value.path }
     })
   }
 


### PR DESCRIPTION
#### Changes in this PR:

- rename url to `real-time-metrics`
- set url params to hold groups and products names instead of ids
- fix incorrect dashboard name
- fix tests after refactoring

![Screenshot 2024-01-17 at 14 02 02](https://github.com/aziontech/azion-console-kit/assets/95643165/d7b79c00-caee-4811-a602-162ec4ff6224)

