### PR TITLE
[ENG-28979] refactor: improve code readability with eslint variable name rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
   },
   rules: {
     'no-case-declarations': 0,
-    'no-console': 'error'
+    'no-console': 'error',
+    'id-length': ['error', { min: 2 }]
   }
 }

--- a/src/helpers/parse-api-body.js
+++ b/src/helpers/parse-api-body.js
@@ -1,5 +1,5 @@
 const snakeToCamelCase = (str) => {
-  return str.replace(/_([a-z])/g, function (_, letter) {
+  return str.replace(/_([a-z])/g, function (__, letter) {
     return letter.toUpperCase()
   })
 }

--- a/src/router/hooks/beforeEachRoute.js
+++ b/src/router/hooks/beforeEachRoute.js
@@ -3,7 +3,7 @@ import { logoutService } from '@/services/auth-services'
 import { useAccountStore } from '@/stores/account'
 import { useLoadingStore } from '@/stores/loading'
 
-export default async function beforeEachRoute(to, _, next) {
+export default async function beforeEachRoute(to, __, next) {
   const accountStore = useAccountStore()
   const loadingStore = useLoadingStore()
 

--- a/src/router/routes/signup-routes/index.js
+++ b/src/router/routes/signup-routes/index.js
@@ -45,7 +45,7 @@ export const signupRoutes = {
       meta: {
         hideNavigation: true
       },
-      beforeEnter: (_, __, next) => {
+      beforeEnter: (__, ___, next) => {
         const accountStore = useAccountStore()
         if (accountStore.isFirstLogin) {
           next()

--- a/src/router/routes/switch-account-routes/index.js
+++ b/src/router/routes/switch-account-routes/index.js
@@ -9,7 +9,7 @@ export const switchAccountRoutes = {
   meta: {
     isPublic: true
   },
-  beforeEnter: async (_, __, next) => {
+  beforeEnter: async (__, ___, next) => {
     const accountHandler = new AccountHandler(
       AuthServices.switchAccountService,
       listTypeAccountService

--- a/src/services/users-services/list-users-service.js
+++ b/src/services/users-services/list-users-service.js
@@ -56,8 +56,8 @@ const adapt = (httpResponse) => {
         email: user.email,
         teams:
           user.teams.length > 1
-            ? user.teams.map((t) => t.name).join(', ')
-            : user.teams.map((t) => t.name),
+            ? user.teams.map((team) => team.name).join(', ')
+            : user.teams.map((team) => team.name),
         mfa: ACTIVE_AS_TAG[user.two_factor_enabled],
         status: ACTIVE_AS_TAG[user.is_active],
         owner: OWNER_AS_TAG[user.is_account_owner]

--- a/src/templates/mfa-authenticate-block/index.vue
+++ b/src/templates/mfa-authenticate-block/index.vue
@@ -93,8 +93,8 @@
     event.preventDefault()
     const pastedData = event.clipboardData.getData('text')
 
-    for (let i = 0; i < pastedData.length; i++) {
-      digitsMfa[i].value.value = pastedData[i]
+    for (let mfaDigitIndex = 0; mfaDigitIndex < pastedData.length; mfaDigitIndex++) {
+      digitsMfa[mfaDigitIndex].value.value = pastedData[mfaDigitIndex]
     }
   }
 

--- a/src/templates/mfa-setup-block/index.vue
+++ b/src/templates/mfa-setup-block/index.vue
@@ -171,8 +171,8 @@
     event.preventDefault()
     const pastedData = event.clipboardData.getData('text')
 
-    for (let i = 0; i < pastedData.length; i++) {
-      digitsMfa[i].value.value = pastedData[i]
+    for (let mfaDigitIndex = 0; mfaDigitIndex < pastedData.length; mfaDigitIndex++) {
+      digitsMfa[mfaDigitIndex].value.value = pastedData[mfaDigitIndex]
     }
   }
 

--- a/src/templates/search-block/index.vue
+++ b/src/templates/search-block/index.vue
@@ -75,7 +75,7 @@
   import PrimeDialog from 'primevue/dialog'
   import PrimeButton from 'primevue/button'
 
-  const { meta, k, control } = useMagicKeys()
+  const { meta, k: keyboardKeyK, control } = useMagicKeys()
 
   defineOptions({ name: 'search-block' })
 
@@ -87,7 +87,7 @@
   }
 
   watchEffect(() => {
-    if (control.value && k.value) openSearch()
-    if (meta.value && k.value) openSearch()
+    if (control.value && keyboardKeyK.value) openSearch()
+    if (meta.value && keyboardKeyK.value) openSearch()
   })
 </script>

--- a/src/templates/template-engine-block/index.vue
+++ b/src/templates/template-engine-block/index.vue
@@ -312,7 +312,7 @@
           payload.push(...group.fields)
         })
       }
-      payload.forEach((_, index) => {
+      payload.forEach((__, index) => {
         payload[index] = JSON.parse(JSON.stringify(payload[index]))
         const sanitizedField = {
           field: payload[index].name,
@@ -321,7 +321,7 @@
         }
 
         // Hidden field
-        const hiddenField = props.hiddenFields.find((i) => i.name === payload[index].name)
+        const hiddenField = props.hiddenFields.find((field) => field.name === payload[index].name)
         if (hiddenField) {
           sanitizedField.value = hiddenField.value
         }

--- a/src/templates/toast-block/index.vue
+++ b/src/templates/toast-block/index.vue
@@ -90,7 +90,7 @@
     },
     methods: {
       getValue({ id }) {
-        return this.progress.find((i) => i.id === id)?.value || 0
+        return this.progress.find((toastProgress) => toastProgress.id === id)?.value || 0
       },
       getProgressBarStyle({ severity }) {
         let color = 'black'

--- a/src/tests/services/credentials-services/list-credentials-service.test.js
+++ b/src/tests/services/credentials-services/list-credentials-service.test.js
@@ -6,8 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/edge-application-services/list-edge-applications-service.test.js
+++ b/src/tests/services/edge-application-services/list-edge-applications-service.test.js
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/edge-functions-services/list-edge-functions-service.test.js
+++ b/src/tests/services/edge-functions-services/list-edge-functions-service.test.js
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/edge-node-service-services/list-service-edge-node-service.test.js
+++ b/src/tests/services/edge-node-service-services/list-service-edge-node-service.test.js
@@ -5,8 +5,8 @@ import { describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/edge-service-resources-services/list-resources-services.test.js
+++ b/src/tests/services/edge-service-resources-services/list-resources-services.test.js
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/edge-service-services/list-edge-service-services.test.js
+++ b/src/tests/services/edge-service-services/list-edge-service-services.test.js
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/personal-tokens-services/list-personal-tokens-service.test.js
+++ b/src/tests/services/personal-tokens-services/list-personal-tokens-service.test.js
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
   vi.spyOn(window.global.Intl, 'DateTimeFormat')
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
-    .mockImplementationOnce((_, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
+    .mockImplementationOnce((__, options) => DateTimeFormat(locale, { ...options }))
 }
 
 const fixtures = {

--- a/src/tests/services/real-time-purge/list-real-time-purge.test.js
+++ b/src/tests/services/real-time-purge/list-real-time-purge.test.js
@@ -6,7 +6,7 @@ import graphQLApi from '@/services/axios/makeEventsApi'
 
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
-  vi.spyOn(window.global.Intl, 'DateTimeFormat').mockImplementation((_, options) =>
+  vi.spyOn(window.global.Intl, 'DateTimeFormat').mockImplementation((__, options) =>
     DateTimeFormat(locale, { ...options })
   )
 }

--- a/src/tests/utils/localeMock.js
+++ b/src/tests/utils/localeMock.js
@@ -2,7 +2,7 @@ import { vi } from 'vitest'
 
 const localeMock = (locale = 'en') => {
   const DateTimeFormat = Intl.DateTimeFormat
-  vi.spyOn(window.global.Intl, 'DateTimeFormat').mockImplementationOnce((_, options) =>
+  vi.spyOn(window.global.Intl, 'DateTimeFormat').mockImplementationOnce((__, options) =>
     DateTimeFormat(locale, { ...options })
   )
 }

--- a/src/views/IntelligentDNS/EditView.vue
+++ b/src/views/IntelligentDNS/EditView.vue
@@ -164,8 +164,8 @@
     }
   }
 
-  const changeRouteByClickingOnTab = (e) => {
-    if (e.index === 0) {
+  const changeRouteByClickingOnTab = (tabEvent) => {
+    if (tabEvent.index === 0) {
       router.push({ name: 'edit-intelligent-dns', params: { id: intelligentDNSID.value } })
     } else {
       router.push({

--- a/src/views/Marketplace/MarketplaceHomeView.vue
+++ b/src/views/Marketplace/MarketplaceHomeView.vue
@@ -217,8 +217,8 @@
       searching.value = !!search.value
       loading.value = true
       const payload = { type: PAGE_TYPE, search: search.value }
-      const items = await loadSolutions(payload)
-      solutions.value = items.filter((i) => !i.instanceType.isTemplate)
+      const loadedSolutions = await loadSolutions(payload)
+      solutions.value = loadedSolutions.filter((solution) => !solution.instanceType.isTemplate)
     } catch (error) {
       $toast.add({ ...ERROR_PROPS, summary: error })
     } finally {
@@ -243,11 +243,11 @@
   }
 
   const featured = computed(() => {
-    return solutions.value.filter((i) => i.featured)
+    return solutions.value.filter((solution) => solution.featured)
   })
 
   const released = computed(() => {
-    return solutions.value.filter((i) => i.released)
+    return solutions.value.filter((solution) => solution.released)
   })
 
   const allSelected = computed(() => {
@@ -255,13 +255,15 @@
   })
 
   const categoriesList = computed(() => {
-    let mapped = categories.value.map((i) => ({
-      name: i.name,
-      code: i.slug,
-      total: i.solutionsCount
+    let mappedCategories = categories.value.map((category) => ({
+      name: category.name,
+      code: category.slug,
+      total: category.solutionsCount
     }))
-    mapped = mapped.filter((i) => i.total > 0 && i.code !== 'build')
+    mappedCategories = mappedCategories.filter(
+      (category) => category.total > 0 && category.code !== 'build'
+    )
 
-    return mapped.length ? [CATEGORY_ALL, ...mapped] : []
+    return mappedCategories.length ? [CATEGORY_ALL, ...mappedCategories] : []
   })
 </script>

--- a/src/views/Marketplace/drawer/IntegrationInstall.vue
+++ b/src/views/Marketplace/drawer/IntegrationInstall.vue
@@ -175,7 +175,7 @@
   })
 
   const warnUpdate = computed(() => {
-    const app = edgeApps.value.find((i) => i.value === edgeApplication.value)
+    const app = edgeApps.value.find((edgeApp) => edgeApp.value === edgeApplication.value)
     return app?.upgradeable
   })
 

--- a/src/views/PersonalTokens/FormFields/FormFieldsPersonalToken.vue
+++ b/src/views/PersonalTokens/FormFields/FormFieldsPersonalToken.vue
@@ -65,23 +65,24 @@
     return value.toISOString().slice(0, -5)
   }
 
-  const convertOffset = (offset) => {
-    const [sign, H, h, M, m] = offset
-    const hours = `${H}${h}`
-    const minutes = `${M}${m}`
+  const convertOffsetToDecimal = (offset) => {
+    const [offsetSign, hourTens, hourUnits, minuteTens, minuteUnits] = offset
+    const hours = `${hourTens}${hourUnits}`
+    const minutes = `${minuteTens}${minuteUnits}`
 
-    const convert = {
+    const minuteToDecimalConversion = {
       15: 25,
       30: 50,
       45: 75
     }
-    const convertedMinutes = minutes > 0 ? convert[minutes] : minutes
 
-    return `${sign}${hours}.${convertedMinutes}`
+    const decimalMinutes = minutes > 0 ? minuteToDecimalConversion[minutes] : minutes
+
+    return `${offsetSign}${hours}.${decimalMinutes}`
   }
 
   const expiresDate = (expirationDate) => {
-    const userOffset = convertOffset(account.value.utc_offset)
+    const userOffset = convertOffsetToDecimal(account.value.utc_offset)
     const timeZoneOffsetMinutesToMilli = expirationDate.getTimezoneOffset() * 60000
     const toUTC = expirationDate.getTime() + timeZoneOffsetMinutesToMilli
     const offsetHoursToMilli = userOffset * 3600000

--- a/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
+++ b/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
@@ -309,8 +309,8 @@
         <ul class="text-color-secondary list-inside space-y-3">
           <li
             class="flex gap-3 items-center text-color-secondary"
-            :key="i"
-            v-for="(requirement, i) in passwordRequirementsList"
+            v-for="(requirement, index) in passwordRequirementsList"
+            :key="index"
           >
             <div class="w-3">
               <span


### PR DESCRIPTION
Avoid using variables that are only 1 character long to encourage developers to use more descriptive and meaningful names in the project code.