### PR TITLE
[NO-ISSUE] Selectbutton padding fix.

### DIFF
--- a/src/assets/themes/scss/themes/azion-light/extended-components/_selectbutton.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_selectbutton.scss
@@ -1,7 +1,7 @@
 // Custom SelectButton
 .p-selectbutton {
   background: var(--surface-300) !important;
-  padding-inline: 0.75rem !important;
+  padding: 0.3rem;
   border-radius: $borderRadius !important;
 
   .p-button {
@@ -19,7 +19,6 @@
     }
 
     &.p-highlight {
-      padding-inline: 0.75rem !important;
       background: var(--surface-0) !important;
       border-color: none !important;
       font-weight: 600 !important;


### PR DESCRIPTION
Padding fix for selectbutton on light mode.

Antes:
![image](https://github.com/aziontech/azion-console-kit/assets/44036260/77e31edd-0335-45b8-839c-5025fefe40f1)

Depois:
![image](https://github.com/aziontech/azion-console-kit/assets/44036260/5032a8b5-dffa-43d1-b0c6-f531801b9ba4)
