### PR TITLE
[NO-ISSUE] chore: indent function args on monaco

### DIFF
--- a/src/services/edge-application-functions-services/list-edge-functions-service.js
+++ b/src/services/edge-application-functions-services/list-edge-functions-service.js
@@ -22,7 +22,7 @@ const adapt = (httpResponse) => {
     return {
       value: edgeFunction.id,
       label: edgeFunction.name,
-      args: JSON.stringify(edgeFunction.json_args),
+      args: JSON.stringify(edgeFunction.json_args, null, '\t'),
       initiatorType: edgeFunction.initiator_type
     }
   })

--- a/src/services/edge-firewall-functions-services/list-edge-functions-service.js
+++ b/src/services/edge-firewall-functions-services/list-edge-functions-service.js
@@ -22,7 +22,7 @@ const adapt = (httpResponse) => {
     return {
       value: edgeFunction.id,
       label: edgeFunction.name,
-      args: JSON.stringify(edgeFunction.json_args),
+      args: JSON.stringify(edgeFunction.json_args, null, '\t'),
       initiatorType: edgeFunction.initiator_type
     }
   })


### PR DESCRIPTION
Add configuration to JSON.stringfy to format the code on Monaco Editor.

<img width="801" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/25899/bd5b34a1-87d9-4a58-8dbc-56d258d68c71">
