### PR TITLE
[NO-ISSUE] fix: json parse indent functions

### DIFF
--- a/src/services/edge-application-functions-services/loader-function-service.js
+++ b/src/services/edge-application-functions-services/loader-function-service.js
@@ -17,7 +17,7 @@ const adapt = (httpResponse) => {
     id: httpResponse.body.results.id,
     edgeFunctionID: httpResponse.body.results.edge_function_id,
     name: httpResponse.body.results.name,
-    args: JSON.stringify(httpResponse.body.results.args)
+    args: JSON.stringify(httpResponse.body.results.args, null, '\t')
   }
 
   return {

--- a/src/services/edge-firewall-functions-services/loader-function-service.js
+++ b/src/services/edge-firewall-functions-services/loader-function-service.js
@@ -17,7 +17,7 @@ const adapt = (httpResponse) => {
     id: httpResponse.body.results.id,
     edgeFunctionID: httpResponse.body.results.edge_function,
     name: httpResponse.body.results.name,
-    args: JSON.stringify(httpResponse.body.results.json_args)
+    args: JSON.stringify(httpResponse.body.results.json_args, null, '\t')
   }
 
   return {

--- a/src/tests/services/edge-application-functions-services/load-function-service.test.js
+++ b/src/tests/services/edge-application-functions-services/load-function-service.test.js
@@ -51,7 +51,7 @@ describe('LoaderFunctionService', () => {
       id: fixture.functionInstance.id,
       edgeFunctionID: fixture.functionInstance.edge_function_id,
       name: fixture.functionInstance.name,
-      args: JSON.stringify(fixture.functionInstance.args)
+      args: JSON.stringify(fixture.functionInstance.args, null, '\t')
     })
   })
 

--- a/src/tests/services/edge-firewall-functions-services/load-function-service.test.js
+++ b/src/tests/services/edge-firewall-functions-services/load-function-service.test.js
@@ -51,7 +51,7 @@ describe('EdgeFirewallFunctionsServices', () => {
       id: fixture.functionInstance.id,
       edgeFunctionID: fixture.functionInstance.edge_function,
       name: fixture.functionInstance.name,
-      args: JSON.stringify(fixture.functionInstance.json_args)
+      args: JSON.stringify(fixture.functionInstance.json_args, null, '\t')
     })
   })
 

--- a/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -95,7 +95,8 @@
           class="min-h-[200px] overflow-clip surface-border border rounded-md"
         />
         <small class="text-color-secondary text-sm">
-          Customize the arguments in JSON format. Once set, they can be called in code using <code>event.args("arg_name")</code>.
+          Customize the arguments in JSON format. Once set, they can be called in code using
+          <code>event.args("arg_name")</code>.
         </small>
       </div>
     </template>

--- a/src/views/EdgeFirewall/TabsView.vue
+++ b/src/views/EdgeFirewall/TabsView.vue
@@ -127,7 +127,7 @@
           />
         </TabPanel>
         <TabPanel
-          header="Functions"
+          header="Functions Instances"
           v-if="isEnableFunction"
         >
           <EdgeFirewallFunctionsListView


### PR DESCRIPTION
Fix indentation when the Function Instance is edited in Edge Application or Firewall.

<img width="706" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/25899/6b9ccf85-338b-4d32-82eb-67ca5e3a23f4">
