### PR TITLE
[UXE-1678] feat: Line break in toast text does not respect close button on Intelligent DNS screen

### DIFF
--- a/src/templates/create-drawer-block/index.vue
+++ b/src/templates/create-drawer-block/index.vue
@@ -69,7 +69,8 @@
     toast.add({
       closable: true,
       severity: severity,
-      summary: summary
+      summary: severity,
+      detail: summary    
     })
   }
 

--- a/src/templates/create-modal-block/index.vue
+++ b/src/templates/create-modal-block/index.vue
@@ -107,6 +107,16 @@
     return selectedTab.value === 'new_resource'
   })
 
+  const showToast = (severity, detail) => {
+    if (!detail) return
+    toast.add({
+      closable: true,
+      severity,
+      summary: severity,
+      detail
+    })
+  }
+
   const redirectToSolution = (template) => {
     const params = {
       vendor: template.vendor.slug,
@@ -127,12 +137,7 @@
       const payload = { type: recommendedHeader.value }
       templates.value = await MarketplaceService.listSolutionsService(payload)
     } catch (error) {
-      toast.add({
-        closable: true,
-        severity: 'error',
-        detail: error,
-        summary: 'Error'
-      })
+      showToast('error', error)
     } finally {
       isLoading.value = false
     }
@@ -144,12 +149,7 @@
       const payload = { type: browseHeader.value }
       browseTemplates.value = await MarketplaceService.listSolutionsService(payload)
     } catch (error) {
-      toast.add({
-        closable: true,
-        severity: 'error',
-        detail: error,
-        summary: 'Error'
-      })
+      showToast('error', error)
     } finally {
       isLoading.value = false
     }

--- a/src/templates/edit-drawer-block/index.vue
+++ b/src/templates/edit-drawer-block/index.vue
@@ -77,11 +77,13 @@
     toggleDrawerVisibility(false)
   }
 
-  const showToast = (severity, summary) => {
+  const showToast = (severity, detail) => {
+    if (!detail) return
     toast.add({
       closable: true,
-      severity: severity,
-      summary: summary
+      severity,
+      summary: severity,
+      detail
     })
   }
 

--- a/src/templates/edit-form-block/no-header.vue
+++ b/src/templates/edit-form-block/no-header.vue
@@ -74,6 +74,15 @@
       this.teleportLoad = true
     },
     methods: {
+      showToast(severity, detail) {
+        if (!detail) return
+        this.$toast.add({
+          closable: true,
+          severity,
+          summary: severity,
+          detail
+        })
+      },
       leavePage(dialogUnsaved) {
         dialogUnsaved = false
         this.handleCancel()
@@ -96,12 +105,7 @@
           const initialData = await this.loadService({ id })
           this.initialDataSetter(initialData)
         } catch (error) {
-          this.$toast.add({
-            closable: true,
-            severity: 'error',
-            summary: 'error',
-            detail: error
-          })
+          this.showToast('error', error)
         } finally {
           this.isLoading = false
         }
@@ -110,22 +114,12 @@
         try {
           this.isLoading = true
           await this.editService(this.formData)
-          this.$toast.add({
-            closable: true,
-            severity: 'success',
-            summary: 'success',
-            detail: 'edited successfully'
-          })
+          this.showToast('success', 'edited successfully')
           this.blockViewRedirection = false
           this.goBackToList()
         } catch (error) {
           this.blockViewRedirection = true
-          this.$toast.add({
-            closable: true,
-            severity: 'error',
-            summary: 'error',
-            detail: error
-          })
+          this.showToast('error', error)
         } finally {
           setTimeout(() => {
             this.isLoading = false


### PR DESCRIPTION
[UXE-1678]

WHY: 

feat: Line break in toast text does not respect close button on Intelligent DNS screen

[UXE-1678]: https://aziontech.atlassian.net/browse/UXE-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ