### PR TITLE
[UXE-27512] fix: L2 cache module  at edge application 

### DIFF
--- a/src/services/edge-application-services/edit-edge-application-service.js
+++ b/src/services/edge-application-services/edit-edge-application-service.js
@@ -1,7 +1,35 @@
+/**
+ * @typedef {Object} EditEdgeApplicationPayload
+ * @property {string} id - The ID of the application.
+ * @property {string} name - The name of the application.
+ * @property {string} deliveryProtocol - The delivery protocol.
+ * @property {boolean} http3 - Whether HTTP3 is enabled.
+ * @property {Object} httpPort - The HTTP port value.
+ * @property {Object} httpsPort - The HTTPS port value.
+ * @property {string} minimumTlsVersion - The minimum TLS version.
+ * @property {boolean} active - Whether the application is active.
+ * @property {Object} debugRules - The debug rules.
+ * @property {string[]} supportedCiphers - The supported ciphers.
+ * @property {boolean} applicationAcceleration - Whether application acceleration is enabled.
+ * @property {boolean} deviceDetection - Whether device detection is enabled.
+ * @property {boolean} edgeFunctions - Whether edge functions are enabled.
+ * @property {boolean} imageOptimization - Whether image optimization is enabled.
+ * @property {boolean} l2Caching - Whether L2 caching is enabled.
+ * @property {boolean} loadBalancer - Whether a load balancer is enabled.
+ * @property {boolean} websocket - Whether WebSocket is enabled.
+ * @property {boolean} rawLogs - Whether raw logs are enabled.
+ * @property {boolean} webApplicationFirewall - Whether web application firewall is enabled.
+ */
+
 import * as Errors from '@/services/axios/errors'
 import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeEdgeApplicationBaseUrl } from './make-edge-application-base-url'
 
+/**
+ * Edits an edge application.
+ * @param {EditEdgeApplicationPayload} payload - The payload for editing the application.
+ * @returns {Promise<any>} - A promise that resolves with the result of the edit operation.
+ */
 export const editEdgeApplicationService = async (payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeEdgeApplicationBaseUrl()}/${payload.id}`,
@@ -12,6 +40,9 @@ export const editEdgeApplicationService = async (payload) => {
   return parseHttpResponse(httpResponse)
 }
 
+/**
+ *  @param {EditEdgeApplicationPayload} payload
+ */
 const adapt = (payload) => {
   return {
     name: payload.name,
@@ -39,6 +70,19 @@ const adapt = (payload) => {
 /**
  * @param {Object} httpResponse - The HTTP response object.
  * @param {Object} httpResponse.body - The response body.
+ * @returns {string} The result message based on the status code.
+ */
+const extractApiError = (httpResponse) => {
+  const [key] = Object.keys(httpResponse.body)
+
+  const errorMessage = httpResponse.body[key]
+
+  return errorMessage
+}
+
+/**
+ * @param {Object} httpResponse - The HTTP response object.
+ * @param {Object} httpResponse.body - The response body.
  * @param {String} httpResponse.statusCode - The HTTP status code.
  * @returns {string} The result message based on the status code.
  * @throws {Error} If there is an error with the response.
@@ -48,15 +92,15 @@ const parseHttpResponse = (httpResponse) => {
     case 200:
       return 'Your edge application has been updated'
     case 400:
-      throw new Error(Object.keys(httpResponse.body)[0]).message
-    case 409:
-      throw new Error(Object.keys(httpResponse.body)[0]).message
+      throw new Error(extractApiError(httpResponse)).message
     case 401:
       throw new Errors.InvalidApiTokenError().message
     case 403:
       throw new Errors.PermissionError().message
     case 404:
       throw new Errors.NotFoundError().message
+    case 409:
+      throw new Error(Object.keys(httpResponse.body)[0]).message
     case 500:
       throw new Errors.InternalServerError().message
     default:

--- a/src/services/edge-application-services/edit-edge-application-service.js
+++ b/src/services/edge-application-services/edit-edge-application-service.js
@@ -73,9 +73,16 @@ const adapt = (payload) => {
  * @returns {string} The result message based on the status code.
  */
 const extractApiError = (httpResponse) => {
-  const [key] = Object.keys(httpResponse.body)
+  const errorKeys = Object.keys(httpResponse.body)
+  const noProductErrorFound = errorKeys.includes('user_has_no_product')
 
-  const errorMessage = httpResponse.body[key]
+  if (noProductErrorFound) {
+    const noProductErrorMessage =
+      'In order to perform this action, you must first have access to the product Tiered Cache'
+    return noProductErrorMessage
+  }
+  const [firstError] = errorKeys
+  const errorMessage = httpResponse.body[firstError]
 
   return errorMessage
 }

--- a/src/services/edge-application-services/index.js
+++ b/src/services/edge-application-services/index.js
@@ -5,6 +5,19 @@ import { loadEdgeApplicationService } from './load-edge-application-service'
 import { editEdgeApplicationService } from './edit-edge-application-service'
 import { contactSalesEdgeApplicationService } from './contact-sales-service'
 
+/**
+ * @typedef {Object} ExportedServicesType - The type of the exported services
+ * @property {typeof loadEdgeApplicationService} loadEdgeApplicationService - The loadEdgeApplicationService reference
+ * @property {typeof editEdgeApplicationService} editEdgeApplicationService - The editEdgeApplicationService reference
+ * @property {typeof listEdgeApplicationsService} listEdgeApplicationsService - The listEdgeApplicationsService reference
+ * @property {typeof deleteEdgeApplicationService} deleteEdgeApplicationService - The deleteEdgeApplicationService reference
+ * @property {typeof createEdgeApplicationService} createEdgeApplicationService - The createEdgeApplicationService reference
+ * @property {typeof contactSalesEdgeApplicationService} contactSalesEdgeApplicationService - The contactSalesEdgeApplicationService reference
+ */
+
+/**
+ * @type {ExportedServicesType}
+ */
 export {
   loadEdgeApplicationService,
   editEdgeApplicationService,

--- a/src/tests/services/edge-application-services/edit-edge-application-service.test.js
+++ b/src/tests/services/edge-application-services/edit-edge-application-service.test.js
@@ -1,0 +1,165 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { editEdgeApplicationService } from '@/services/edge-application-services'
+import { describe, expect, it, vi } from 'vitest'
+import * as Errors from '@/services/axios/errors'
+
+const fixtures = {
+  edgeApplicationMock: {
+    id: 'Abcj256789',
+    name: 'example',
+    deliveryProtocol: 'https',
+    http3: true,
+    httpPort: { value: 80 },
+    httpsPort: { value: 443 },
+    minimumTlsVersion: 'TLSv1.2',
+    active: true,
+    debugRules: ['rule1', 'rule2'],
+    supportedCiphers: ['cipher1', 'cipher2'],
+    applicationAcceleration: true,
+    deviceDetection: true,
+    edgeFunctions: true,
+    imageOptimization: true,
+    l2Caching: true,
+    loadBalancer: true,
+    websocket: true,
+    rawLogs: true,
+    webApplicationFirewall: true
+  }
+}
+const makeSut = () => {
+  const sut = editEdgeApplicationService
+
+  return {
+    sut
+  }
+}
+
+describe('EdgeApplicationServices', () => {
+  it('should be able to call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200
+    })
+    const { sut } = makeSut(fixtures.edgeApplicationMock)
+
+    await sut(fixtures.edgeApplicationMock)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'PATCH',
+      url: `v3/edge_applications/${fixtures.edgeApplicationMock.id}`,
+      body: {
+        name: fixtures.edgeApplicationMock.name,
+        delivery_protocol: fixtures.edgeApplicationMock.deliveryProtocol,
+        http3: fixtures.edgeApplicationMock.http3,
+        http_port: [fixtures.edgeApplicationMock.httpPort.value],
+        https_port: [fixtures.edgeApplicationMock.httpsPort.value],
+        minimum_tls_version: fixtures.edgeApplicationMock.minimumTlsVersion,
+        active: fixtures.edgeApplicationMock.active,
+        debug_rules: ['rule1', 'rule2'],
+        supported_ciphers: ['cipher1', 'cipher2'],
+        application_acceleration: fixtures.edgeApplicationMock.applicationAcceleration,
+        device_detection: fixtures.edgeApplicationMock.deviceDetection,
+        edge_firewall: false,
+        edge_functions: fixtures.edgeApplicationMock.edgeFunctions,
+        image_optimization: fixtures.edgeApplicationMock.imageOptimization,
+        l2_caching: fixtures.edgeApplicationMock.l2Caching,
+        load_balancer: fixtures.edgeApplicationMock.loadBalancer,
+        websocket: fixtures.edgeApplicationMock.websocket,
+        raw_logs: fixtures.edgeApplicationMock.rawLogs,
+        web_application_firewall: fixtures.edgeApplicationMock.webApplicationFirewall
+      }
+    })
+  })
+
+  it('should keep edge firewall disabled', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200
+    })
+    const { sut } = makeSut(fixtures.edgeApplicationMock)
+
+    await sut(fixtures.edgeApplicationMock)
+
+    expect(requestSpy.mock.lastCall[0].body).toHaveProperty('edge_firewall', false)
+  })
+
+  it('should return first api error message on Not Found api request (404)', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: {
+        user_has_no_flag: 'api-error-message'
+      }
+    })
+    const { sut } = makeSut(fixtures.edgeApplicationMock)
+
+    const result = sut(fixtures.edgeApplicationMock)
+
+    expect(result).rejects.toBe('api-error-message')
+  })
+
+  it('should show user no product error first ', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: {
+        user_has_no_flag: 'api-error',
+        user_has_no_product: 'no-product-error-message'
+      }
+    })
+    const { sut } = makeSut(fixtures.edgeApplicationMock)
+
+    const result = sut(fixtures.edgeApplicationMock)
+
+    expect(result).rejects.toBe(
+      'In order to perform this action, you must first have access to the product Tiered Cache'
+    )
+  })
+
+  it('should return first error name on conflict status code (409)', async () => {
+    const errorMessageMock = 'api-error-message'
+    const errorKeyMock = 'api-error-key'
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 409,
+      body: {
+        [errorKeyMock]: errorMessageMock
+      }
+    })
+    const { sut } = makeSut(fixtures.edgeApplicationMock)
+
+    const result = sut(fixtures.edgeApplicationMock)
+
+    expect(result).rejects.toBe(errorKeyMock)
+  })
+
+  it.each([
+    {
+      statusCode: 401,
+      expectedError: new Errors.InvalidApiTokenError().message
+    },
+    {
+      statusCode: 403,
+      expectedError: new Errors.PermissionError().message
+    },
+    {
+      statusCode: 404,
+      expectedError: new Errors.NotFoundError().message
+    },
+    {
+      statusCode: 500,
+      expectedError: new Errors.InternalServerError().message
+    },
+    {
+      statusCode: 'unmappedStatusCode',
+      expectedError: new Errors.UnexpectedError().message
+    }
+  ])(
+    'should throw when request fails with status code $statusCode',
+    async ({ statusCode, expectedError }) => {
+      vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+        statusCode
+      })
+      const { sut } = makeSut()
+
+      const response = sut(fixtures.edgeApplicationMock)
+
+      expect(response).rejects.toBe(expectedError)
+    }
+  )
+})

--- a/src/views/EdgeApplications/FormFields/FormFieldsCreateEdgeApplications.vue
+++ b/src/views/EdgeApplications/FormFields/FormFieldsCreateEdgeApplications.vue
@@ -106,7 +106,6 @@
   const isHttp3Protocol = computed(() => deliveryProtocol.value === 'http,https' && http3.value)
   const isBrowserCacheTypeHonor = computed(() => browserCacheSettings.value === 'honor')
   const websocketIsEnabled = computed(() => websocket.value)
-  const l2CachingIsEnable = computed(() => l2Caching.value)
   const cdnCacheSettingsIsOverride = computed(() => cdnCacheSettings.value === 'override')
 </script>
 
@@ -718,14 +717,10 @@
                 class: 'text-sm font-normal text-color-secondary m-0 pr-0 md:pr-[2.5rem]'
               }
             }"
-            :class="!l2CachingIsEnable ? 'opacity-50' : ''"
           >
             <template #title>
-              <span class="text-base">L2 Caching</span>
-              <InputSwitch
-                v-model="l2Caching"
-                :disabled="!l2CachingIsEnable"
-              />
+              <span class="text-base">Tiered Cache</span>
+              <InputSwitch v-model="l2Caching" />
             </template>
             <template #subtitle>Enable an additional cache layer at the edge. </template>
           </Card>


### PR DESCRIPTION
-  Enable toggle functionality at edge application - edit -main settings
 
<img width="907" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/040a9606-286f-47de-8882-a34c1888900c">


- handle error when users had no access to this product and try to use it.
- Add custom message when error user_has_no_product is found on returned API validation
<img width="918" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/9051614e-b4bb-4fab-9b13-9c3d5c34c6ae">

- Add unit test cases to document behaviors of editing an edge application
<img width="793" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/f7109f79-11b8-41c2-a33f-ce3424e76622">

