### PR TITLE
[NO-ISSUE] fix: network lists size for ip in edit view

### DIFF
--- a/src/views/NetworkLists/FormFields/FormFieldsEditNetworkLists.vue
+++ b/src/views/NetworkLists/FormFields/FormFieldsEditNetworkLists.vue
@@ -146,7 +146,7 @@
           disabled
           :class="{ 'p-invalid': itemsValuesError }"
           v-model="itemsValues"
-          rows="2"
+          rows="16"
           id="ipCidr"
           cols="30"
           placeholder="192.168.0.1&#10;192.168.0.2/32&#10;10.1.1.10/16"


### PR DESCRIPTION
Update network list textarea rows for IP addresses in EDIT view.

<img width="923" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/25899/1fa53806-ba33-43e5-8196-89e49b264529">
