### PR TITLE
[UXE-1685] fix: added close rules create and edit drawer at save

### DIFF
--- a/src/templates/list-table-block/columns/expand-text-column.vue
+++ b/src/templates/list-table-block/columns/expand-text-column.vue
@@ -28,7 +28,7 @@
   const SLICE_VALUE = 15
   const displayShowMore = textColumn.value?.length > SLICE_VALUE
   const totalItems = textColumn.value?.length - SLICE_VALUE
-  const formatValue = textColumn.value?.slice(0, SLICE_VALUE)
+  const formatValue = textColumn.value?.toString().slice(0, SLICE_VALUE)
   const newValue = `${formatValue}${displayShowMore ? '...' : ''}`
 
   const textToShow = computed(() => {


### PR DESCRIPTION
* Refactored the rules engine form validations (based on the edge firewall)
* Fixed slice function error in the table, which was affecting cache settings
* Rules engine drawers now close upon saving