### PR TITLE
[UXE-1795] fix: data streaming code editor indent

### DIFF
--- a/src/views/DataStreaming/FormFields/FormFieldsDataStreaming.vue
+++ b/src/views/DataStreaming/FormFields/FormFieldsDataStreaming.vue
@@ -1379,7 +1379,12 @@
 
   const insertDataSet = (templateID) => {
     const index = listTemplates.value.map((el) => el.value).indexOf(templateID)
-    dataSet.value = listTemplates.value[index].template
+    try {
+      const dataSetJSON = JSON.parse(listTemplates.value[index].template)
+      dataSet.value = JSON.stringify(dataSetJSON, null, '\t')
+    } catch (exception) {
+      dataSet.value = listTemplates.value[index].template
+    }
   }
 
   // Using the store
@@ -1391,6 +1396,8 @@
 
   const optionsMonacoEditor = computed(() => {
     return {
+      minimap: { enabled: false },
+      wordWrap: 'on',
       tabSize: 2,
       formatOnPaste: true
     }


### PR DESCRIPTION
Fix options to Monaco Editor display the code values better:

![Screenshot 2024-02-12 at 17 13 15](https://github.com/aziontech/azion-console-kit/assets/25899/75d57af9-79f1-4bf7-bd33-64258d1fe21b)
