### PR TITLE
[NO-ISSUE] fix: add default selection to https port

### DIFF
--- a/src/views/EdgeApplications/CreateView.vue
+++ b/src/views/EdgeApplications/CreateView.vue
@@ -55,7 +55,7 @@
     deliveryProtocol: 'http',
     http3: false,
     httpPort: [{ name: '80 (Default)', value: '80' }],
-    httpsPort: [{ name: '8008', value: '8008' }],
+    httpsPort: [{ name: '443 (Default)', value: '443' }],
     minimumTlsVersion: { label: 'None', value: '' },
     supportedVersion: { label: 'All', value: 'all' },
     originType: { label: 'Single Origin', value: 'single_origin' },


### PR DESCRIPTION
WHY:
Add a default option to HTTPS ports in edge application main settings 
<img width="902" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/ed53becf-0d3c-447e-bd0a-1c5c71992484">

