### PR TITLE
[UXE-1801] fix: typo in edge firewall functions

### DIFF
--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -35,7 +35,7 @@
   import { ref, onMounted, computed } from 'vue'
   import * as yup from 'yup'
   import CreateDrawerBlock from '@templates/create-drawer-block'
-  import FormFieldsDrawerFunction from '@/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions'
+  import FormFieldsDrawerFunction from '@/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions'
   import EditDrawerBlock from '@templates/edit-drawer-block'
   import { refDebounced } from '@vueuse/core'
 


### PR DESCRIPTION
WHY:
Existia um typo na tela de functions em edge firewall que estava ocorrendo pois lá era importado a tela de edge functions de edge firewall
<img width="902" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/c83ec878-52c7-4a83-8a8b-ff00fb102818">
