### PR TITLE
[UXE-1798] fix: [global] apply overscroll-behavior-contain to all elements

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -16,6 +16,12 @@ body.p-overflow-hidden {
   --scrollbar-width: 0px !important;
 }
 
+/* https://aziontech.atlassian.net/browse/UXE-1798 */
+/* child scroll behaviour is affecting the parent scroll behaviour */
+* {
+  overscroll-behavior: contain !important;
+}
+
 #app {
   font-family: var(--font-family);
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
Fix the following behavior

https://github.com/aziontech/azion-console-kit/assets/95643165/ca78cac2-46e9-4246-a28b-2746034b1987
