### PR TITLE
[UXE-1911 fix: add empty state to edge nodes list

### DIFF
--- a/src/views/EdgeNode/ListView.vue
+++ b/src/views/EdgeNode/ListView.vue
@@ -24,7 +24,7 @@
     }
   })
 
-  let hasContentToList = true
+  let hasContentToList = false
 
   const getColumns = computed(() => [
     {
@@ -93,7 +93,7 @@
         emptyListMessage="No Edge Node found."
       />
       <EmptyEdgeNode
-        v-else
+        v-if="!hasContentToList"
         :documentationService="props.documentationService"
       >
         <template #illustration>


### PR DESCRIPTION
WHY:
Empty list block não estava funcionando corretamente em edge nodes (aparecia a mensagem de busca sem resultados)
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/24fa3607-11bd-4045-bb98-236adc11b117">
