### PR TITLE
[UXE-1817] fix: add expand-column in cnames

### DIFF
--- a/src/services/domains-services/list-domains-service.js
+++ b/src/services/domains-services/list-domains-service.js
@@ -23,7 +23,6 @@ const adapt = async (httpResponse) => {
   const edgeApplications = await listEdgeApplications()
 
   const parsedDomains = httpResponse.body.results?.map((domain) => {
-    const cnames = domain.cnames.map((cname) => cname)?.join(',')
     return {
       id: domain.id,
       name: domain.name,
@@ -40,7 +39,7 @@ const adapt = async (httpResponse) => {
       domainName: {
         content: domain.domain_name
       },
-      cnames: cnames,
+      cnames: domain.cnames,
       edgeFirewallId: domain.edge_firewall_id,
       edgeApplicationName: getEdgeApplication(edgeApplications, domain.edge_application_id),
       digitalCertificateId: domain.digital_certificate_id

--- a/src/tests/services/domains-services/list-domains-service.test.js
+++ b/src/tests/services/domains-services/list-domains-service.test.js
@@ -82,7 +82,7 @@ describe('DomainsServices', () => {
         domainName: {
           content: fixtures.domainMock.domain_name
         },
-        cnames: 'CName 1,CName 2',
+        cnames: fixtures.domainMock.cnames,
         active: {
           content: 'Active',
           severity: 'success'
@@ -97,7 +97,7 @@ describe('DomainsServices', () => {
         domainName: {
           content: fixtures.disabledDomainMock.domain_name
         },
-        cnames: 'CName 3,CName 4',
+        cnames: fixtures.disabledDomainMock.cnames,
         active: {
           content: 'Inactive',
           severity: 'danger'

--- a/src/views/Domains/ListView.vue
+++ b/src/views/Domains/ListView.vue
@@ -89,7 +89,11 @@
       },
       {
         field: 'cnames',
-        header: 'CNAME'
+        header: 'CNAME',
+        filterPath: 'description.value',
+        type: 'component',
+        component: (columnData) =>
+          columnBuilder({ data: columnData, columnAppearance: 'expand-column' })  
       },
       {
         field: 'active',


### PR DESCRIPTION
[UXE-1817]

WHY:

 fix: add expand-column in cnames

[UXE-1817]: https://aziontech.atlassian.net/browse/UXE-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


https://github.com/aziontech/azion-console-kit/assets/110847590/7c32aa49-50db-423d-a704-3e2680194535

