### PR TITLE
[UXE-2149] fix: remove typo in activity history property name

### DIFF
--- a/src/views/RealTimeEventsActivityHistory/Drawer/index.vue
+++ b/src/views/RealTimeEventsActivityHistory/Drawer/index.vue
@@ -63,7 +63,7 @@
               <div class="flex flex-col gap-3">
                 <TextInfo label="Account">{{ details.authorName }}</TextInfo>
                 <TextInfo label="ID">{{ details.accountId }}</TextInfo>
-                <TextInfo label="Client ID">{{ details.userId }}</TextInfo>
+                <TextInfo label="User ID">{{ details.userId }}</TextInfo>
               </div>
               <div class="flex flex-col gap-3">
                 <TextInfo label="User Name">{{ details.authorEmail }}</TextInfo>


### PR DESCRIPTION
WHY:
Havia um typo na ui, onde mostrava o User ID a label estava como Client ID
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/152eda08-eda0-46d1-a891-3f5a7438c6ca">
