### PR TITLE
[UXE-2150] fix: capitalize activity history type first letter

### DIFF
--- a/src/services/real-time-events-service/activity-history/load-activity-history.js
+++ b/src/services/real-time-events-service/activity-history/load-activity-history.js
@@ -40,7 +40,8 @@ const adaptResponse = (response) => {
 
   return {
     title: activityHistoryEvents.title,
-    type: activityHistoryEvents.type,
+    type: activityHistoryEvents.type.charAt(0).toUpperCase()
+    + activityHistoryEvents.type.slice(1),
     ts: convertValueToDate(activityHistoryEvents.ts),
     authorName: activityHistoryEvents.authorName,
     accountId: activityHistoryEvents.accountId,


### PR DESCRIPTION
WHY:
As tags de type dentro do drawer de activity history estavam com o texto inteiro em letras minusculas.
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/eca03b37-2254-451c-84cc-d3ec8c91773e">
