### PR TITLE
[UXE-2151] fix: wrap text when text is too big

### DIFF
--- a/src/templates/info-drawer-block/info-section/index.vue
+++ b/src/templates/info-drawer-block/info-section/index.vue
@@ -38,8 +38,10 @@
     class="flex max-w-screen-2xl mx-auto gap-4 w-full surface-section rounded-md border surface-border p-3 sm:p-8 flex-wrap min-w-[2rem]"
   >
     <div class="whitespace-nowrap flex-col justify-center items-start gap-3 flex">
-      <h2 class="text-color text-xl font-medium flex flex-wrap gap-2">
-        {{ props.title }}
+      <div class=" flex flex-wrap gap-2">
+        <h2 class="whitespace-normal text-color text-xl font-medium">
+          {{ props.title }}
+        </h2>
         <Tag
           v-for="(tags, i) in props.tags"
           :key="i"
@@ -48,7 +50,7 @@
           :icon="tags?.icon"
           :value="tags.text"
         />
-      </h2>
+      </div>
       <div
         v-if="props.date"
         class="justify-start items-center gap-1 inline-flex"


### PR DESCRIPTION
WHY:
Textos estavam sem quebra de linha, ultrapassando os limites da tela quando mobile
<img width="320" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/e2783285-a040-4b9f-9f45-77df29c5cf47">
