### PR TITLE
[UXE-2173] fix: Show bring your own license solution installation card

### DIFF
--- a/src/services/marketplace-services/load-solution-service.js
+++ b/src/services/marketplace-services/load-solution-service.js
@@ -29,6 +29,7 @@ const adapt = (httpResponse) => {
     usage: removeStyleAttributes(solution.usage),
     overview: removeStyleAttributes(solution.overview),
     support: removeStyleAttributes(solution.support),
+    isBringYourOwnLicense: solution.is_bring_your_own_license,
     isPayAsYouGo: solution.is_pay_as_you_go,
     isLaunched: solution.is_launched,
     isUpdated: solution.is_updated,


### PR DESCRIPTION
WHY:
Na tela de launch das solutions, solutions do tipo bring your own license não estavam apresentando o card de instalação correto
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/e8267d32-a539-40f4-9f91-872b6d81648a">
