### PR TITLE
[UXE-2158] refactor: replace RTE datetime filter options

### DIFF
--- a/src/views/Metrics/blocks/interval-filter-block.vue
+++ b/src/views/Metrics/blocks/interval-filter-block.vue
@@ -78,11 +78,11 @@
   }
 
   const checkIfDatesAreEqual = (begin, end) => {
-    var isoBegin = begin.toISOString().slice(0, 13)
-    var isoEnd = end.toISOString().slice(0, 13)
+    const isoBegin = begin.toISOString().slice(0, 13)
+    const isoEnd = end.toISOString().slice(0, 13)
 
-    var isoLastBegin = lastFilteredDate.value.begin.toISOString().slice(0, 13)
-    var isoLastEnd = lastFilteredDate.value.end.toISOString().slice(0, 13)
+    const isoLastBegin = lastFilteredDate.value.begin.toISOString().slice(0, 13)
+    const isoLastEnd = lastFilteredDate.value.end.toISOString().slice(0, 13)
 
     return isoBegin === isoLastBegin && isoEnd === isoLastEnd
   }

--- a/src/views/RealTimeEvents/blocks/constants/date-time-interval.js
+++ b/src/views/RealTimeEvents/blocks/constants/date-time-interval.js
@@ -1,0 +1,48 @@
+const DATE_TIME_INTERVALS = [
+  {
+    name: 'Last 15 minutes',
+    code: '0.25'
+  },
+  {
+    name: 'Last 1 hour',
+    code: '1'
+  },
+  {
+    name: 'Last 3 hours',
+    code: '3'
+  },
+  {
+    name: 'Last 6 hours',
+    code: '6'
+  },
+  {
+    name: 'Last 12 hours',
+    code: '12'
+  },
+  {
+    name: 'Last day',
+    code: '24'
+  },
+  {
+    name: 'Last 2 days',
+    code: '48'
+  },
+  {
+    name: 'Last 3 days',
+    code: '72'
+  },
+  {
+    name: 'Last 5 days',
+    code: '120'
+  },
+  {
+    name: 'Last 7 days',
+    code: '168'
+  },
+  {
+    name: 'Custom time range',
+    code: 'custom'
+  }
+]
+
+export default DATE_TIME_INTERVALS

--- a/src/views/RealTimeEvents/blocks/interval-filter-block.vue
+++ b/src/views/RealTimeEvents/blocks/interval-filter-block.vue
@@ -53,6 +53,13 @@
     return max.toUTC(userUTC)
   })
 
+  const minDate = computed(() => {
+    const sevenDaysInHours = 7 * 24
+    const date = new Date()
+    const min = removeSelectedAmountOfHours(sevenDaysInHours, date)
+    return min.toUTC(userUTC)
+  })
+
   const updatedTimeRange = ({ tsRangeBegin, tsRangeEnd, meta }) => {
     const GMT0 = '.000Z'
     const gmt0Begin = `${tsRangeBegin}${GMT0}`
@@ -169,6 +176,7 @@
         showIcon
         iconDisplay="input"
         :maxDate="maxDate"
+        :minDate="minDate"
         :class="classError"
       />
       <small

--- a/src/views/RealTimeEvents/blocks/interval-filter-block.vue
+++ b/src/views/RealTimeEvents/blocks/interval-filter-block.vue
@@ -4,7 +4,7 @@
   import Calendar from 'primevue/calendar'
   import Dropdown from 'primevue/dropdown'
   import { computed, onMounted, ref } from 'vue'
-  import DATE_TIME_INTERVALS from '@/stores/metrics-store/constants/date-time-interval'
+  import DATE_TIME_INTERVALS from './constants/date-time-interval'
 
   const accountStore = useAccountStore()
 
@@ -84,11 +84,11 @@
   }
 
   const checkIfDatesAreEqual = (begin, end) => {
-    var isoBegin = begin.toISOString().slice(0, 13)
-    var isoEnd = end.toISOString().slice(0, 13)
+    const isoBegin = begin.toISOString().slice(0, 13)
+    const isoEnd = end.toISOString().slice(0, 13)
 
-    var isoLastBegin = lastFilteredDate.value.begin.toISOString().slice(0, 13)
-    var isoLastEnd = lastFilteredDate.value.end.toISOString().slice(0, 13)
+    const isoLastBegin = lastFilteredDate.value.begin.toISOString().slice(0, 13)
+    const isoLastEnd = lastFilteredDate.value.end.toISOString().slice(0, 13)
 
     return isoBegin === isoLastBegin && isoEnd === isoLastEnd
   }


### PR DESCRIPTION
### Changes in this PR:
- limit the custom filter to seven days prior to today
- change dropdown options

#### Before
![Screenshot 2024-02-29 at 08 39 05](https://github.com/aziontech/azion-console-kit/assets/95643165/709c81fe-1567-4d3b-b803-b6478997d44e)

![Screenshot 2024-02-29 at 08 39 47](https://github.com/aziontech/azion-console-kit/assets/95643165/141a82ae-17f4-49ae-aba2-f2dc41098fae)

#### After
![Screenshot 2024-02-29 at 08 39 35](https://github.com/aziontech/azion-console-kit/assets/95643165/32beacba-e81d-488c-9b13-1850372eb7bf)

![Screenshot 2024-02-29 at 08 39 29](https://github.com/aziontech/azion-console-kit/assets/95643165/9ddfb75d-293d-4f48-a74d-942b2a61a870)

