### PR TITLE
[UXE-1882] feat: add track event Click To Create

### DIFF
--- a/src/plugins/adapters/AnalyticsTrackerAdapter.js
+++ b/src/plugins/adapters/AnalyticsTrackerAdapter.js
@@ -5,6 +5,10 @@
  */
 
 /**
+ * @typedef {'Edge Application'|'Origins'|'Domains'} AzionProductsNames
+ */
+
+/**
  * @typedef {Object} AnalyticsAdapter
  * @property {Function} identify - Identifies a user.
  * @property {Function} assignGroupTraits - Assigns traits to a user group.
@@ -61,14 +65,14 @@ export class AnalyticsTrackerAdapter {
   }
 
   /**
-   * @param {string} eventName
-   * @param {Object} props
+   * @param {Object} payload
+   * @param {AzionProductsNames} payload.productName
    * @returns {AnalyticsTrackerAdapter}
    */
-  click(eventName, props) {
+  clickToCreate(payload) {
     this.#events.push({
-      eventName: eventName,
-      props: { ...props }
+      eventName: `Clicked to Create ${payload.productName}`,
+      props: {}
     })
     return this
   }

--- a/src/services/real-time-events-service/activity-history/load-activity-history.js
+++ b/src/services/real-time-events-service/activity-history/load-activity-history.js
@@ -40,8 +40,7 @@ const adaptResponse = (response) => {
 
   return {
     title: activityHistoryEvents.title,
-    type: activityHistoryEvents.type.charAt(0).toUpperCase()
-    + activityHistoryEvents.type.slice(1),
+    type: activityHistoryEvents.type.charAt(0).toUpperCase() + activityHistoryEvents.type.slice(1),
     ts: convertValueToDate(activityHistoryEvents.ts),
     authorName: activityHistoryEvents.authorName,
     accountId: activityHistoryEvents.accountId,

--- a/src/templates/info-drawer-block/info-section/index.vue
+++ b/src/templates/info-drawer-block/info-section/index.vue
@@ -38,7 +38,7 @@
     class="flex max-w-screen-2xl mx-auto gap-4 w-full surface-section rounded-md border surface-border p-3 sm:p-8 flex-wrap min-w-[2rem]"
   >
     <div class="whitespace-nowrap flex-col justify-center items-start gap-3 flex">
-      <div class=" flex flex-wrap gap-2">
+      <div class="flex flex-wrap gap-2">
         <h2 class="whitespace-normal text-color text-xl font-medium">
           {{ props.title }}
         </h2>

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -189,7 +189,7 @@
   import DeleteDialog from './dialog/delete-dialog'
 
   defineOptions({ name: 'list-table-block' })
-  const emit = defineEmits(['on-load-data'])
+  const emit = defineEmits(['on-load-data', 'on-before-go-to-add-page'])
 
   const props = defineProps({
     columns: {
@@ -334,6 +334,7 @@
   const router = useRouter()
 
   const navigateToAddPage = () => {
+    emit('on-before-go-to-add-page')
     router.push(props.createPagePath)
   }
 

--- a/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
@@ -32,24 +32,25 @@ describe('AnalyticsTrackerAdapter', () => {
     expect(analyticsClientSpy.identify).not.toHaveBeenCalled()
   })
 
-  it('should be able to store multiple events and track them all', async () => {
+  it('should be able to store multiple events and track them all', () => {
     const { sut, analyticsClientSpy } = makeSut()
     sut.pageLoad({ url: 'test-url-1' }).pageLoad({ url: 'test-url-2' })
     sut.pageLoad({ url: 'test-url-3' })
 
-    await sut.track()
+    sut.track()
 
     expect(analyticsClientSpy.track).toHaveBeenCalledTimes(3)
   })
 
-  it('should be able to track page load event with correct params', async () => {
+  it('should be able to track page load event with correct params', () => {
     const { sut, analyticsClientSpy } = makeSut()
     const mockUrl = 'test-url-ABC/q-2/t'
     sut.pageLoad({
       url: mockUrl
     })
 
-    await sut.track()
+    sut.track()
+
     expect(analyticsClientSpy.track).toHaveBeenCalledWith('Page Loaded', { url: mockUrl })
   })
 
@@ -88,5 +89,21 @@ describe('AnalyticsTrackerAdapter', () => {
       id: mockId,
       email: emailMock
     })
+  })
+
+  it('should be able to track click to create event with correct params', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const productNameMock = 'Azion Product Name'
+
+    sut.clickToCreate({
+      productName: productNameMock
+    })
+
+    sut.track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith(
+      'Clicked to Create Azion Product Name',
+      {}
+    )
   })
 })

--- a/src/views/EdgeApplications/ListView.vue
+++ b/src/views/EdgeApplications/ListView.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { computed, ref } from 'vue'
+  import { computed, inject, ref } from 'vue'
 
   import Illustration from '@/assets/svg/illustration-layers.vue'
   import ContentBlock from '@/templates/content-block'
@@ -9,6 +9,8 @@
   import PageHeadingBlock from '@/templates/page-heading-block'
 
   defineOptions({ name: 'list-edge-applications' })
+  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   const props = defineProps({
     listEdgeApplicationsService: {
@@ -29,6 +31,11 @@
 
   const handleLoadData = (event) => {
     hasContentToList.value = event
+  }
+  const handleTrackEvent = () => {
+    tracker.clickToCreate({
+      productName: 'Edge Application'
+    })
   }
 
   const getColumns = computed(() => {
@@ -77,6 +84,7 @@
         :deleteService="props.deleteEdgeApplicationService"
         :columns="getColumns"
         @on-load-data="handleLoadData"
+        @on-before-go-to-add-page="handleTrackEvent"
         emptyListMessage="No Edge Application found."
       />
       <EmptyResultsBlock


### PR DESCRIPTION
This PR introduces:
- new tracker event called clickToCreate
- unit tests related to this new event
- a new emitter on list-table-block, called n-before-go-to-add-page
- a event handle on listView to track the event Click to Create with the product name provided as Edge Application.


<img width="609" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/8038e7b9-0da7-4f47-89ab-9f1e67ba20ed">
