### PR TITLE
[UXE-2219] fix: show digital certificate status

### DIFF
--- a/src/services/digital-certificates-services/list-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/list-digital-certificates-service.js
@@ -25,7 +25,7 @@ const parseStatusData = (status) => {
   const isActive = status.toUpperCase() === 'ACTIVE'
   const parsedStatus = isActive
     ? {
-        content: 'Active',
+        content: capitalizeFirstLetter(status),
         severity: 'success'
       }
     : {

--- a/src/services/digital-certificates-services/list-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/list-digital-certificates-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeDigitalCertificatesBaseUrl } from './make-digital-certificates-base-url'
+import { capitalizeFirstLetter } from '@/helpers'
 export const listDigitalCertificatesService = async ({
   orderBy = 'name',
   sort = 'asc',
@@ -22,14 +23,13 @@ export const TRUSTED_CA_CERTIFICATE = 'Trusted CA Certificate'
 
 const parseStatusData = (status) => {
   const isActive = status.toUpperCase() === 'ACTIVE'
-
   const parsedStatus = isActive
     ? {
         content: 'Active',
         severity: 'success'
       }
     : {
-        content: 'Inactive',
+        content: capitalizeFirstLetter(status),
         severity: 'danger'
       }
 

--- a/src/tests/services/digital-certificates-services/list-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/list-digital-certificates-service.test.js
@@ -99,7 +99,7 @@ describe('DigitalCertificatesServices', () => {
       issuer: '-',
       name: 'Certificate 2',
       status: {
-        content: 'Inactive',
+        content: 'Pending',
         severity: 'danger'
       },
       subjectName: '-',


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Adiciona na tela de listagem de digital certificates o status do certificado, não apenas se esta inativo ou ativo

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/1b465637-8592-4652-bcc3-32bc8ea35630">

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
