### PR TITLE
[UXE-1885] feat: add event click to edit

### DIFF
--- a/src/plugins/adapters/AnalyticsTrackerAdapter.js
+++ b/src/plugins/adapters/AnalyticsTrackerAdapter.js
@@ -70,6 +70,19 @@ export class AnalyticsTrackerAdapter {
   }
 
   /**
+   * @param {Object} payload
+   * @param {AzionProductsNames} payload.productName
+   * @returns {AnalyticsTrackerAdapter}
+   */
+  clickToEdit(payload) {
+    this.#events.push({
+      eventName: `Clicked to Edit ${payload.productName}`,
+      props: {}
+    })
+    return this
+  }
+
+  /**
    * @returns {AnalyticsTrackerAdapter}
    */
   userSigned() {
@@ -117,7 +130,7 @@ export class AnalyticsTrackerAdapter {
     return this
   }
 
-  /*
+  /**
    * @param {string} payload.url
    * @param {string} payload.location
    * @returns {AnalyticsTrackerAdapter}

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -189,7 +189,7 @@
   import DeleteDialog from './dialog/delete-dialog'
 
   defineOptions({ name: 'list-table-block' })
-  const emit = defineEmits(['on-load-data', 'on-before-go-to-add-page'])
+  const emit = defineEmits(['on-load-data', 'on-before-go-to-add-page', 'on-before-go-to-edit'])
 
   const props = defineProps({
     columns: {
@@ -344,6 +344,7 @@
     menuRef.value[selectedID].toggle(event)
   }
   const editItemSelected = ({ data: item }) => {
+    emit('on-before-go-to-edit')
     if (props.editInDrawer) {
       props.editInDrawer(item)
       return

--- a/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
@@ -107,6 +107,19 @@ describe('AnalyticsTrackerAdapter', () => {
     )
   })
 
+  it('should be able to track click to edit event with correct params', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const productNameMock = 'Azion Product Name'
+
+    sut.clickToEdit({
+      productName: productNameMock
+    })
+
+    sut.track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith('Clicked to Edit Azion Product Name', {})
+  })
+
   it('should be able to track a product created successfully', () => {
     const { sut, analyticsClientSpy } = makeSut()
     const productNameMock = 'Azion Product Name Mock'

--- a/src/views/EdgeApplications/CreateView.vue
+++ b/src/views/EdgeApplications/CreateView.vue
@@ -89,8 +89,10 @@
   }
 
   const handleTrackFailedCreation = () => {
-    tracker.failedToCreate({
-      productName: 'Edge Application'
-    })
+    tracker
+      .failedToCreate({
+        productName: 'Edge Application'
+      })
+      .track()
   }
 </script>

--- a/src/views/EdgeApplications/ListView.vue
+++ b/src/views/EdgeApplications/ListView.vue
@@ -37,6 +37,11 @@
       productName: 'Edge Application'
     })
   }
+  const handleTrackEditEvent = () => {
+    tracker.clickToEdit({
+      productName: 'Edge Application'
+    })
+  }
 
   const getColumns = computed(() => {
     return [
@@ -85,6 +90,7 @@
         :columns="getColumns"
         @on-load-data="handleLoadData"
         @on-before-go-to-add-page="handleTrackEvent"
+        @on-before-go-to-edit="handleTrackEditEvent"
         emptyListMessage="No Edge Application found."
       />
       <EmptyResultsBlock


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Add a new event track for the click in a row inside list blocks. This event is the click to edit, and will trigger by a row inside a list-table-block.

Also fixes the execution of edge application create fail event on in the Create View, ensure to execute .track() method to avoid only store the event without any execution to remote tracker server.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
new event screeshot:
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/5769c317-10f9-409a-937a-f7f35591b246)

test coverage:
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/cba6bfab-a81c-4ac8-ab21-89c346879674)


### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
