### PR TITLE
[UXE-1887] feat: add event fail to edit and add it to Edge Application Edit View

### DIFF
--- a/src/plugins/adapters/AnalyticsTrackerAdapter.js
+++ b/src/plugins/adapters/AnalyticsTrackerAdapter.js
@@ -145,6 +145,19 @@ export class AnalyticsTrackerAdapter {
 
   /**
    * @param {Object} payload
+   * @param {AzionProductsNames} payload.productName
+   * @returns {AnalyticsTrackerAdapter}
+   */
+  failedToEdit(payload) {
+    this.#events.push({
+      eventName: `Failed to Edit ${payload.productName}`,
+      props: {}
+    })
+    return this
+  }
+
+  /**
+   * @param {Object} payload
    * @param {string} payload.url
    * @param {string} payload.location
    * @returns {AnalyticsTrackerAdapter}

--- a/src/templates/action-bar-block/index.vue
+++ b/src/templates/action-bar-block/index.vue
@@ -10,7 +10,7 @@
     inDrawer: Boolean,
     cancelDisabled: Boolean,
     submitDisabled: Boolean,
-    primaryActionLabel: { type: String, default: 'Next' },
+    primaryActionLabel: { type: String, default: 'Save' },
     secondaryActionLabel: { type: String, default: 'Cancel' }
   })
 

--- a/src/templates/edit-form-block/index.vue
+++ b/src/templates/edit-form-block/index.vue
@@ -33,7 +33,7 @@
     }
   })
 
-  const emit = defineEmits(['on-edit-success'])
+  const emit = defineEmits(['on-edit-success', 'on-edit-fail'])
 
   const router = useRouter()
   const route = useRoute()
@@ -109,6 +109,7 @@
       }
       goBackToList()
     } catch (error) {
+      emit('on-edit-fail')
       blockViewRedirection.value = true
       showToast('error', error)
     }

--- a/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/adapters/AnalyticsTrackerAdapter.test.js
@@ -162,6 +162,22 @@ describe('AnalyticsTrackerAdapter', () => {
     )
   })
 
+  it('should be able to track a failed event related to edit a product', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const productNameMock = 'Azion Product Name Mock'
+
+    sut
+      .failedToEdit({
+        productName: productNameMock
+      })
+      .track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith(
+      'Failed to Edit Azion Product Name Mock',
+      {}
+    )
+  })
+
   it('should call userSigned when valid identification is provided', () => {
     const { sut, analyticsClientSpy } = makeSut()
 

--- a/src/views/EdgeApplications/EditView.vue
+++ b/src/views/EdgeApplications/EditView.vue
@@ -4,7 +4,8 @@
     :loadService="loadEdgeApplication"
     :updatedRedirect="props.updatedRedirect"
     :schema="validationSchema"
-    @on-edit-success="handleTrackEditWithSuccess"
+    @on-edit-success="handleTrackSuccessEdit"
+    @on-edit-fail="handleTrackFailEdit"
     disableRedirect
     :isTabs="true"
   >
@@ -64,9 +65,16 @@
     return props.edgeApplication
   }
 
-  const handleTrackEditWithSuccess = () => {
+  const handleTrackSuccessEdit = () => {
     tracker
       .productEdited({
+        productName: 'Edge Application'
+      })
+      .track()
+  }
+  const handleTrackFailEdit = () => {
+    tracker
+      .failedToEdit({
         productName: 'Edge Application'
       })
       .track()


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Add new event to track edit requests of an product that fails on edit the register trough API.

Also fixes action bar block default text to use 'Save' for the primary button.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
event being tracked:
<img width="847" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/21b2182b-80de-4ef7-ae38-269ba069dafd">

action block fix, on primary button, from text 'Next' as default to use 'Save'
<img width="316" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/6746fac6-82f6-45e2-9f42-64c8188ea09c">


### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
