### PR TITLE
[UXE-2562] fix: phase button hidden in edit rules engine

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -8,6 +8,7 @@
   import PrimeButton from 'primevue/button'
   import PrimeMenu from 'primevue/menu'
   import InputSwitch from 'primevue/inputswitch'
+  import InlineMessage from 'primevue/inlinemessage'
   import Divider from 'primevue/divider'
   import AutoComplete from 'primevue/autocomplete'
   import { computed, ref, onMounted } from 'vue'
@@ -624,6 +625,10 @@
     return behaviors.value.length >= MAXIMUM_NUMBER
   })
 
+  const isNotTheSelectedPhase = (phaseItem) => {
+    return isEditDrawer.value && phaseItem !== phase.value
+  }
+
   onMounted(() => {
     updateBehaviorsOptionsRequires()
 
@@ -682,23 +687,35 @@
     v-if="!checkPhaseIsDefaultValue"
   >
     <template #inputs>
+      <InlineMessage
+        v-if="isEditDrawer"
+        class="p-2"
+        severity="info"
+      >
+        Once a rule is created, its phase cannot be changed. If you want to change the phase, you
+        must create a new rule.
+      </InlineMessage>
+
       <div class="flex flex-col gap-2">
         <template
           v-for="item in phasesList"
           :key="item.value"
         >
           <div
-            v-if="!isEditDrawer || phase === item.value"
             class="w-full border-1 rounded-md surface-border flex align-items-center justify-between p-4 gap-2"
             :class="{ 'border-radio-card-active': phase === item.value }"
           >
-            <label class="font-medium">
+            <label
+              class="font-medium"
+              :class="{ 'opacity-30': isNotTheSelectedPhase(item.value) }"
+            >
               {{ item.label }}
               <div class="text-color-secondary text-sm font-normal">{{ item.description }}</div>
             </label>
 
             <PrimeRadio
               v-model="phase"
+              :disabled="isNotTheSelectedPhase(item.value)"
               :value="item.value"
             />
           </div>

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -688,7 +688,7 @@
           :key="item.value"
         >
           <div
-            v-if="!isEditDrawer.value || phase === item.value"
+            v-if="!isEditDrawer || phase === item.value"
             class="w-full border-1 rounded-md surface-border flex align-items-center justify-between p-4 gap-2"
             :class="{ 'border-radio-card-active': phase === item.value }"
           >


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
<!-- Describe your changes in detail -->
* phase button hidden at edit rules engine

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->
Before:
<img width="902" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/109550332/9abc23ab-625e-4cfc-bc07-4cb22059fc7c">

After:
<img width="902" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/109550332/d135057e-98b5-4273-ac9f-3deebfb8813c">


### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
