### PR TITLE
[UXE-2534] fix: make service catch when there is a error in the results of a script

### DIFF
--- a/src/services/script-runner-service/get-script-runner-results-service.js
+++ b/src/services/script-runner-service/get-script-runner-results-service.js
@@ -13,7 +13,7 @@ export const getScriptRunnerResultsService = async (executionId) => {
 const parseHttpResponse = (httpResponse) => {
   switch (httpResponse.statusCode) {
     case 200:
-      if (!httpResponse.body.result.error) {
+      if (!httpResponse.body.result.errors) {
         return httpResponse.body
       }
       throw new Error(httpResponse.body.result.message).message

--- a/src/tests/services/script-runner-services/get-script-runner-results-serice.test.js
+++ b/src/tests/services/script-runner-services/get-script-runner-results-serice.test.js
@@ -7,7 +7,7 @@ const fixtures = {
   executionId: 'xx',
   deploymentFailed: {
     result: {
-      error: true,
+      errors: [],
       message: 'deploy failed'
     }
   }


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Change the service to catch the errors in Script Runner results.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/c5ad4ea9-0613-4541-86d1-7f3d905dc764">### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
