### PR TITLE
[NO-ISSUE] style: apply the same action button style for tables

### DIFF
--- a/src/templates/list-table-block/columns/text-with-clipboard-column.vue
+++ b/src/templates/list-table-block/columns/text-with-clipboard-column.vue
@@ -2,10 +2,10 @@
   <div class="gap-2 flex items-center">
     <expand-text-column :value="content"></expand-text-column>
     <PrimeButton
-      text
+      outlined
       icon="pi pi-copy"
       @click.stop="handleCopyContent"
-      v-tooltip.bottom="{ value: 'Copy to clipboard', showDelay: 200 }"
+      v-tooltip.top="{ value: 'Copy to clipboard', showDelay: 200 }"
     />
   </div>
 </template>

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -38,11 +38,13 @@
           </slot>
         </div>
       </template>
+
       <Column
         v-if="reorderableRows"
         rowReorder
         headerStyle="width: 3rem"
       />
+
       <Column
         sortable
         v-for="col of selectedColumns"
@@ -53,13 +55,15 @@
       >
         <template #body="{ data: rowData }">
           <template v-if="col.type !== 'component'">
-            <div v-html="rowData[col.field]" />
+            <div v-html="rowData[col.field]"></div>
           </template>
           <template v-else>
-            <component :is="col.component(rowData[col.field])" />
+            <component :is="col.component(rowData[col.field])"></component>
           </template>
         </template>
       </Column>
+
+      
       <Column
         :frozen="true"
         :alignFrozen="'right'"
@@ -112,7 +116,7 @@
               v-tooltip.top="{ value: 'Actions', showDelay: 200 }"
               size="small"
               icon="pi pi-ellipsis-h"
-              text
+              outlined
               @click="(event) => toggleActionsMenu(event, rowData.id)"
               class="cursor-pointer table-button"
             />

--- a/src/templates/list-table-block/no-header.vue
+++ b/src/templates/list-table-block/no-header.vue
@@ -119,7 +119,7 @@
                 v-tooltip.top="{ value: 'Actions', showDelay: 200 }"
                 size="small"
                 icon="pi pi-ellipsis-h"
-                text
+                outlined
                 @click="(event) => toggleActionsMenu(event, rowData)"
                 class="cursor-pointer table-button"
               />


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Apply the same action button style for tables
Apply top position for buttons tooltip in `templates/list-table`
  

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95422158/74305508-1680-44ab-8f03-2d6b09f88c9e



### Does it have a link on Figma?
https://www.figma.com/file/2hNLUK00QbkDeQSYSC6DDW/PrimeOne-%5B2.0.0%5D-%5BVue%5D?type=design&node-id=3318%3A222516&mode=design&t=OUz1Ql7VwcchlUQa-1

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [X] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [X] Edge
- [X] Firefox
- [X] Safari
