### PR TITLE
[UXE-2401] fix: incorrect loading of digital certificates status on the edit domains screen

### DIFF
--- a/src/services/domains-services/edit-domain-service.js
+++ b/src/services/domains-services/edit-domain-service.js
@@ -18,7 +18,7 @@ const adapt = (payload) => {
     cnames: payload.cnames.split('\n').filter((item) => item !== ''),
     cname_access_only: payload.cnameAccessOnly,
     edge_application_id: payload.edgeApplication,
-    digital_certificate_id: payload.edgeCertificate,
+    digital_certificate_id: payload.edgeCertificate || null,
     is_mtls_enabled: payload.mtlsIsEnabled,
     is_active: payload.active,
     mtls_verification: payload.mtlsVerification,

--- a/src/services/domains-services/load-domain-service.js
+++ b/src/services/domains-services/load-domain-service.js
@@ -22,7 +22,7 @@ const adapt = (httpResponse) => {
     cnames: body?.cnames.join('\n'),
     cnameAccessOnly: body?.cname_access_only,
     edgeApplication: body?.edge_application_id,
-    digitalCertificate: body?.digital_certificate_id,
+    edgeCertificate: body?.digital_certificate_id ?? 0,
     mtlsIsEnabled: body?.mtls_is_enabled,
     active: body.is_active,
     mtlsVerification: body?.mtls_verification,

--- a/src/tests/services/domains-services/edit-domain-service.test.js
+++ b/src/tests/services/domains-services/edit-domain-service.test.js
@@ -61,7 +61,7 @@ describe('DomainsServices', () => {
     expect(feedbackMessage).toBe('Your domain has been edited')
   })
 
-  it('should return a success message on null digital certificate id', async () => {
+  it('should return a success message even when not provided a digital certificate', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200
     })

--- a/src/tests/services/domains-services/edit-domain-service.test.js
+++ b/src/tests/services/domains-services/edit-domain-service.test.js
@@ -56,8 +56,18 @@ describe('DomainsServices', () => {
       statusCode: 200
     })
     const { sut } = makeSut()
-
     const feedbackMessage = await sut(fixtures.domainMock)
+
+    expect(feedbackMessage).toBe('Your domain has been edited')
+  })
+
+  it('should return a success message on null digital certificate id', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200
+    })
+    const { sut } = makeSut()
+
+    const feedbackMessage = await sut({ ...fixtures.domainMock, edgeCertificate: null })
 
     expect(feedbackMessage).toBe('Your domain has been edited')
   })

--- a/src/tests/services/domains-services/load-domain-service.test.js
+++ b/src/tests/services/domains-services/load-domain-service.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadDomainService } from '@/services/domains-services'
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+
+const fixtures = {
+  domainMock: {
+    id: 1234,
+    name: 'Edge App X',
+    domain_name: 'domain A',
+    cnames: ['CName 1', 'CName 2'],
+    is_active: true,
+    activeSort: true,
+    digital_certificate_id: '862026',
+    edge_application_id: 'ea1234',
+    mtls_trusted_ca_certificate_id: '862026'
+  },
+  domainWithoutCertificateMock: {
+    id: 4321,
+    name: 'Edge App Y',
+    domain_name: 'domain B',
+    cnames: ['CName 1', 'CName 2'],
+    is_active: false,
+    activeSort: true,
+    digital_certificate_id: null,
+    edge_application_id: 'ea1234',
+  },
+}
+
+const makeSut = () => {
+  const sut = loadDomainService
+  return {
+    sut
+  }
+}
+
+describe('DomainServices', () => {
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        results: fixtures.domainMock
+      }
+    })
+    const { sut } = makeSut()
+
+    await sut({
+      id: fixtures.domainMock.id
+    })
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `v3/domains/${fixtures.domainMock.id}`,
+      method: 'GET'
+    })
+  })
+
+  it('should correctly parse the returned a domain', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: fixtures.domainMock }
+    })
+    const { sut } = makeSut()
+
+    const result = await sut({
+      id: fixtures.domainMock.id
+    })
+
+    expect(result).toEqual({
+      id: fixtures.domainMock.id,
+      name: fixtures.domainMock.name,
+      domainName: fixtures.domainMock.domain_name,
+      cnames: 'CName 1\nCName 2',
+      cnameAccessOnly: fixtures.domainMock.cname_access_only,
+      edgeApplication: fixtures.domainMock.edge_application_id,
+      edgeCertificate: fixtures.domainMock.digital_certificate_id,
+      mtlsIsEnabled: fixtures.domainMock.mtls_is_enabled,
+      active: fixtures.domainMock.is_active,
+      mtlsVerification: fixtures.domainMock.mtls_verification,
+      mtlsTrustedCertificate: fixtures.domainMock.mtls_trusted_ca_certificate_id
+    })
+  })
+
+  it('should correctly parse the returned a domain without digital certificate', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: fixtures.domainWithoutCertificateMock }
+    })
+    const { sut } = makeSut()
+
+    const result = await sut({
+      id: fixtures.domainMock.id
+    })
+
+    expect(result).toEqual({
+      id: fixtures.domainWithoutCertificateMock.id,
+      name: fixtures.domainWithoutCertificateMock.name,
+      domainName: fixtures.domainWithoutCertificateMock.domain_name,
+      cnames: 'CName 1\nCName 2',
+      cnameAccessOnly: fixtures.domainWithoutCertificateMock.cname_access_only,
+      edgeApplication: fixtures.domainWithoutCertificateMock.edge_application_id,
+      edgeCertificate: 0,
+      mtlsIsEnabled: fixtures.domainWithoutCertificateMock.mtls_is_enabled,
+      active: fixtures.domainWithoutCertificateMock.is_active,
+      mtlsVerification: fixtures.domainWithoutCertificateMock.mtls_verification
+    })
+  })
+})

--- a/src/views/Domains/EditView.vue
+++ b/src/views/Domains/EditView.vue
@@ -19,7 +19,7 @@
             :domainName="domainName"
             :hasDomainName="true"
             @copyDomainName="copyDomainName"
-          ></FormFieldsEditDomains>
+          />
         </template>
         <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/Domains/FormFields/FormFieldsEditDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsEditDomains.vue
@@ -12,7 +12,7 @@
   import RadioButton from 'primevue/radiobutton'
   import PrimeTextarea from 'primevue/textarea'
   import { useField } from 'vee-validate'
-  import { computed, ref, watch } from 'vue'
+  import { computed } from 'vue'
 
   const props = defineProps({
     digitalCertificates: {
@@ -30,12 +30,11 @@
     }
   })
 
-  const edgeCertificate = ref(0)
   const { value: name, errorMessage: errorName } = useField('name')
   const { value: cnames, errorMessage: errorCnames } = useField('cnames')
   const { value: cnameAccessOnly, errorMessage: errorCnameAccessOnly } = useField('cnameAccessOnly')
   const { value: edgeApplication, errorMessage: errorEdgeApplication } = useField('edgeApplication')
-  const { setValue: setEdgeCertificate } = useField('edgeCertificate')
+  const { value: edgeCertificate } = useField('edgeCertificate')
   const { value: mtlsIsEnabled, errorMessage: errorMtlsIsEnabled } = useField('mtlsIsEnabled')
   const { value: active } = useField('active')
   const { value: domainName } = useField('domainName')
@@ -67,6 +66,7 @@
       name: certificate.name,
       value: certificate.id
     }))
+
     return [...defaultCertificate, ...parsedCertificates]
   })
   const trustedCACertificatesOptions = computed(() => {
@@ -76,9 +76,6 @@
     }))
   })
 
-  watch(edgeCertificate, async (newEdgeCertificate) => {
-    setEdgeCertificate(newEdgeCertificate)
-  })
 </script>
 
 <template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
<!-- Describe your changes in detail -->
* incorrect loading of digital certificates status on the edit domains screen

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->

https://github.com/aziontech/azion-console-kit/assets/109550332/422dfaab-ae84-44bd-930f-cbff801f97b5


### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
