### PR TITLE
[NO-SSUE] fix: resolve incorrect prop access

### DIFF
--- a/src/stores/metrics.js
+++ b/src/stores/metrics.js
@@ -125,7 +125,7 @@ export const useMetricsStore = defineStore('metrics', {
       this.group.currentDashboard = newListDashboards.find(({ path }) => `${path}` === dashboardId)
     },
     setCurrentGroupPageByLabels(labelGroup) {
-      this.currentGroupPage = this.group.all.find(({ label }) => label === labelGroup)
+      this.group.current = this.group.all.find(({ label }) => label === labelGroup)
 
       const page = this.group.current?.pagesDashboards[0]
       this.group.currentPage = { ...page }


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Replace the incorrect prop name "currentGroupPage" with "group.current", which caused the dropdown to not work properly

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
No

https://github.com/aziontech/azion-console-kit/assets/95643165/4b5764f4-fd2a-48e6-bd7c-7f6df748f33f

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
