### PR TITLE
[NO-ISSUE] fix: view behavior and toast message when deploy fails

### DIFF
--- a/src/router/routes/create-new-routes/index.js
+++ b/src/router/routes/create-new-routes/index.js
@@ -37,7 +37,7 @@ export const createNewRoutes = {
       component: () => import('@views/CreateNew/DeployView.vue'),
       props: {
         getLogsService: ScriptRunnerService.getScriptRunnerLogsService,
-        getResultsService: ScriptRunnerService.getScriptRunnerResultsService,
+        getResultsService: ScriptRunnerService.loadScriptRunnerExecutionResultsService,
         windowOpen
       },
       meta: {

--- a/src/services/script-runner-service/get-script-runner-results-service.js
+++ b/src/services/script-runner-service/get-script-runner-results-service.js
@@ -13,10 +13,11 @@ export const getScriptRunnerResultsService = async (executionId) => {
 const parseHttpResponse = (httpResponse) => {
   switch (httpResponse.statusCode) {
     case 200:
-      if (!httpResponse.body.result.errors) {
-        return httpResponse.body
+      const hasErrors = httpResponse.body.result.errors || httpResponse.body.result.error
+      if (hasErrors) {
+        throw new Error(httpResponse.body.result.message).message
       }
-      throw new Error(httpResponse.body.result.message).message
+      return httpResponse.body
     case 400:
       throw new Errors.NotFoundError().message
     case 401:

--- a/src/services/script-runner-service/index.js
+++ b/src/services/script-runner-service/index.js
@@ -1,5 +1,9 @@
 import { getScriptRunnerLogsService } from './get-script-runner-logs-service'
-import { getScriptRunnerResultsService } from './get-script-runner-results-service'
+import { loadScriptRunnerExecutionResultsService } from './load-script-runner-execution-results-service'
 import { checkStatusScriptRunnerService } from './check-status-script-runner-service'
 
-export { getScriptRunnerLogsService, getScriptRunnerResultsService, checkStatusScriptRunnerService }
+export {
+  getScriptRunnerLogsService,
+  loadScriptRunnerExecutionResultsService,
+  checkStatusScriptRunnerService
+}

--- a/src/services/script-runner-service/load-script-runner-execution-results-service.js
+++ b/src/services/script-runner-service/load-script-runner-execution-results-service.js
@@ -2,7 +2,7 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeScriptRunnerBaseUrl } from './make-script-runner-base-url'
 import * as Errors from '@/services/axios/errors'
 
-export const getScriptRunnerResultsService = async (executionId) => {
+export const loadScriptRunnerExecutionResultsService = async (executionId) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeScriptRunnerBaseUrl()}/executions/${executionId}/results`,
     method: 'GET'

--- a/src/services/template-engine-services/instantiate-template.js
+++ b/src/services/template-engine-services/instantiate-template.js
@@ -2,11 +2,11 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeTemplateEngineBaseUrl } from './make-template-engine-base-url'
 import * as Errors from '@/services/axios/errors'
 
-export const instantiateTemplate = async (templateId, body) => {
+export const instantiateTemplate = async (templateId, payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeTemplateEngineBaseUrl()}/templates/${templateId}/instantiate`,
     method: 'POST',
-    body: body
+    body: payload
   })
   return parseHttpResponse(httpResponse)
 }

--- a/src/templates/script-runner-block/index.vue
+++ b/src/templates/script-runner-block/index.vue
@@ -127,6 +127,10 @@
         const positionY = this.$refs.runner.scrollHeight
         this.$refs.runner.scrollTo(0, positionY)
       }
+    },
+
+    beforeUnmount() {
+      clearInterval(this.polling)
     }
   }
 </script>

--- a/src/tests/services/script-runner-services/get-script-runner-results-serice.test.js
+++ b/src/tests/services/script-runner-services/get-script-runner-results-serice.test.js
@@ -1,5 +1,5 @@
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
-import { getScriptRunnerResultsService } from '@/services/script-runner-service'
+import { loadScriptRunnerExecutionResultsService } from '@/services/script-runner-service'
 import { describe, expect, it, vi } from 'vitest'
 import * as Errors from '@/services/axios/errors'
 
@@ -14,7 +14,7 @@ const fixtures = {
 }
 
 const makeSut = () => {
-  const sut = getScriptRunnerResultsService
+  const sut = loadScriptRunnerExecutionResultsService
   return {
     sut
   }

--- a/src/views/ImportGitHub/ImportStaticView.vue
+++ b/src/views/ImportGitHub/ImportStaticView.vue
@@ -1,5 +1,4 @@
-<script setup>
-</script>
+<script setup></script>
 
 <template>
   <div>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Here are your sentences with corrected English:

1. Fixes incorrect behavior when deployment fails while creating an edge application using the template "journey".
2. Fixes pooling to prevent infinite calls when the script runner is no longer mounted on the view.
3. Enhances code readability by using more cohesive names for variables, functions, and files related to instantiating a template using the script runner.

Fixed and correct behaviour when  deploy fail:
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/04a4df4a-8a13-4f84-9d01-49f7af29b849)

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 




### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/29d4521e-a9d0-40e5-bde9-f677d7922122)


### Does it have a link on Figma?
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
