### PR TITLE
[UXE-1720] fix: make TLS certificate optional in digital certificates

### DIFF
--- a/src/services/digital-certificates-services/create-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-service.js
@@ -36,6 +36,13 @@ const parseHttpResponse = (httpResponse) => {
 }
 
 const adapt = (payload) => {
+  if (!payload.certificate && !payload.privateKey) {
+    return {
+      name: payload.digitalCertificateName,
+      certificate_type: payload.certificateType
+    }
+  }
+
   return {
     name: payload.digitalCertificateName,
     certificate_type: payload.certificateType,

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
@@ -7,7 +7,6 @@ import {
   UnexpectedError
 } from '@/services/axios/errors'
 import { createDigitalCertificatesService } from '@/services/digital-certificates-services'
-createDigitalCertificatesService
 import { describe, expect, it, vi } from 'vitest'
 
 const fixture = {
@@ -19,6 +18,10 @@ const fixture = {
     privateKey:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
   },
+  payloadMockWithoutCertificateAndPrivateKey: {
+    digitalCertificateName: 'MyWebsiteCertificate',
+    certificateType: 'SSL/TLS'
+  },
   requestBodyMock: {
     name: 'MyWebsiteCertificate',
     certificate_type: 'SSL/TLS',
@@ -26,6 +29,10 @@ const fixture = {
       '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
     private_key:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
+  },
+  requestBodyMockWithoutCertificateAndPrivateKey: {
+    name: 'MyWebsiteCertificate',
+    certificate_type: 'SSL/TLS'
   },
   errorMock: {
     error: ['Error Message']
@@ -64,6 +71,27 @@ describe('DigitalCertificatesServices', () => {
     expect(result).toEqual({
       feedback: 'Your digital certificate has been created!',
       urlToEditView: `/digital-certificates/edit/1`
+    })
+  })
+
+  it('should not send certificate and private key when neither is provided', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 201,
+      body: {
+        results: {
+          id: 1
+        }
+      }
+    })
+
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut(fixture.payloadMockWithoutCertificateAndPrivateKey)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'POST',
+      url: `${version}/digital_certificates`,
+      body: fixture.requestBodyMockWithoutCertificateAndPrivateKey
     })
   })
 

--- a/src/views/DigitalCertificates/CreateView.vue
+++ b/src/views/DigitalCertificates/CreateView.vue
@@ -100,10 +100,9 @@
   })
 
   const certificateRequiredField = (certificateType) => {
-    const isUploadCertificate = certificateType === certificateTypes.value.EDGE_CERTIFICATE_UPLOAD
     const isTrustedCA = certificateType === certificateTypes.value.TRUSTED
 
-    return isUploadCertificate || isTrustedCA
+    return isTrustedCA
   }
   const validationSchema = yup.object({
     digitalCertificateName: yup.string().required('Name is a required field.'),

--- a/src/views/DigitalCertificates/FormFields/FormFieldsCreateDigitalCertificates.vue
+++ b/src/views/DigitalCertificates/FormFields/FormFieldsCreateDigitalCertificates.vue
@@ -180,7 +180,7 @@
   >
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Certificate *</label>
+        <label>Certificate</label>
         <PrimeTextarea
           v-model="certificate"
           :class="{ 'p-invalid': certificateError }"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Make TLS certificate optional when creating a digital certificate
- Add tests to cover scenario when neither certificate nor private key is set

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/93777f05-ca6d-4d09-9a1d-87a49fbc69b5

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
