### PR TITLE
[UXE-1720] fix: add validations when certificate or private key are empty strings

### DIFF
--- a/src/services/digital-certificates-services/create-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-service.js
@@ -35,18 +35,29 @@ const parseHttpResponse = (httpResponse) => {
   }
 }
 
-const adapt = (payload) => {
-  if (!payload.certificate && !payload.privateKey) {
-    return {
-      name: payload.digitalCertificateName,
-      certificate_type: payload.certificateType
-    }
-  }
+const validateCertificateFields = ({ certificate, privateKey }) => {
+  const hasCertificate = !!certificate?.trim()
+  const hasPrivateKey = !!privateKey?.trim()
 
+  if (!hasCertificate && !hasPrivateKey) return {}
+
+  if (!hasPrivateKey) return { certificate }
+
+  if (!hasCertificate) return { private_key: privateKey }
+
+  return {
+    certificate,
+    private_key: privateKey
+  }
+}
+
+const adapt = (payload) => {
   return {
     name: payload.digitalCertificateName,
     certificate_type: payload.certificateType,
-    certificate: payload.certificate,
-    private_key: payload.privateKey
+    ...validateCertificateFields({
+      certificate: payload.certificate,
+      privateKey: payload.privateKey
+    })
   }
 }

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
@@ -9,24 +9,41 @@ import {
 import { createDigitalCertificatesService } from '@/services/digital-certificates-services'
 import { describe, expect, it, vi } from 'vitest'
 
+const basePayloadMock = {
+  digitalCertificateName: 'MyWebsiteCertificate',
+  certificateType: 'SSL/TLS',
+  certificate:
+    '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
+  privateKey:
+    '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
+}
+
 const fixture = {
-  payloadMock: {
-    digitalCertificateName: 'MyWebsiteCertificate',
-    certificateType: 'SSL/TLS',
-    certificate:
-      '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
-    privateKey:
-      '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
-  },
+  payloadMock: { ...basePayloadMock },
+  payloadMockWithoutPrivateKey: { ...basePayloadMock, privateKey: '' },
+  payloadMockWithoutCertificate: { ...basePayloadMock, certificate: '' },
   payloadMockWithoutCertificateAndPrivateKey: {
-    digitalCertificateName: 'MyWebsiteCertificate',
-    certificateType: 'SSL/TLS'
+    ...basePayloadMock,
+    certificate: '',
+    privateKey: ''
   },
   requestBodyMock: {
     name: 'MyWebsiteCertificate',
     certificate_type: 'SSL/TLS',
     certificate:
       '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----',
+    private_key:
+      '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
+  },
+  requestBodyMockWithoutPrivateKey: {
+    name: 'MyWebsiteCertificate',
+    certificate_type: 'SSL/TLS',
+    certificate:
+      '-----BEGIN CERTIFICATE-----\nMIIE... (certificate content) ...\n-----END CERTIFICATE-----'
+  },
+  requestBodyMockWithoutCertificate: {
+    name: 'MyWebsiteCertificate',
+    certificate_type: 'SSL/TLS',
     private_key:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
   },
@@ -92,6 +109,48 @@ describe('DigitalCertificatesServices', () => {
       method: 'POST',
       url: `${version}/digital_certificates`,
       body: fixture.requestBodyMockWithoutCertificateAndPrivateKey
+    })
+  })
+
+  it('should not send certificate when key is not provided', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 201,
+      body: {
+        results: {
+          id: 1
+        }
+      }
+    })
+
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut(fixture.payloadMockWithoutCertificate)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'POST',
+      url: `${version}/digital_certificates`,
+      body: fixture.requestBodyMockWithoutCertificate
+    })
+  })
+
+  it('should not send private key when key is not provided', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 201,
+      body: {
+        results: {
+          id: 1
+        }
+      }
+    })
+
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut(fixture.payloadMockWithoutPrivateKey)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'POST',
+      url: `${version}/digital_certificates`,
+      body: fixture.requestBodyMockWithoutPrivateKey
     })
   })
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Add validation scenarios when either certificate ou privateKey is not set
- Add tests

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
Old
![Screenshot 2024-04-08 at 12 09 55](https://github.com/aziontech/azion-console-kit/assets/95643165/577c81e3-2dc5-4051-91a7-a7981d0327a8)

New
![Screenshot 2024-04-08 at 12 14 34](https://github.com/aziontech/azion-console-kit/assets/95643165/bbac3cac-0333-4372-8fdc-b6537c6708ed)


### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
