### PR TITLE
[UXE-1770] fix: filter domains that already have an edge firewall instancied

### DIFF
--- a/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
+++ b/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
@@ -61,8 +61,8 @@
             return domain
           }
         }) || []
-
-      domainsList.value = [notSelectedDomains.filter((element) => !element.edgeFirewallId), alreadySelectedDomains]
+      const availableDomains = notSelectedDomains.filter((element) => !element.edgeFirewallId)
+      domainsList.value = [availableDomains, alreadySelectedDomains]
       resetField({
         value: alreadySelectedDomains
       })

--- a/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
+++ b/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
@@ -62,8 +62,7 @@
           }
         }) || []
 
-      domainsList.value = [notSelectedDomains, alreadySelectedDomains]
-
+      domainsList.value = [notSelectedDomains.filter((element) => !element.edgeFirewallId), alreadySelectedDomains]
       resetField({
         value: alreadySelectedDomains
       })


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Filter domains list in edge firewall create and edit forms to show only domains that haven't been used yet

Uploading Screenshare - 2024-04-08 4_20_02 PM.mp4…


### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
