### PR TITLE
[UXE-2759] fix: add validation to weight field based on originType

### DIFF
--- a/src/services/edge-application-origins-services/create-origin-service.js
+++ b/src/services/edge-application-origins-services/create-origin-service.js
@@ -28,12 +28,19 @@ const adapt = (payload) => {
     origin_type: payload.originType,
     host_header: payload.hostHeader,
     method: payload.method,
-    addresses: payload.addresses?.map((addressItem) => ({
-      address: addressItem?.address,
-      weight: addressItem?.weight,
-      server_role: addressItem?.serverRole,
-      is_active: addressItem?.isActive
-    })),
+    addresses: payload.addresses?.map((addressItem) => {
+      const address = {
+        address: addressItem?.address,
+        server_role: addressItem?.serverRole,
+        is_active: addressItem?.isActive
+      }
+
+      if (payload.originType === 'load_balancer') {
+        address.weight = addressItem?.weight
+      }
+
+      return address
+    }),
     origin_path: payload.originPath,
     origin_protocol_policy: payload.originProtocolPolicy,
     hmac_authentication: payload.hmacAuthentication,

--- a/src/tests/services/edge-application-origins-services/create-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/create-origin-service.test.js
@@ -4,14 +4,37 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 
 const fixtures = {
-  originMock: {
+  requestPayloadMock: {
     id: 123,
+    name: 'New Origin',
+    originType: 'single_origin',
+    method: '',
+    addresses: [
+      {
+        address: 'httpbin.org',
+        serverRole: 'primary',
+        isActive: true
+      }
+    ],
+    originProtocolPolicy: 'http',
+    hostHeader: '${host}',
+    originPath: '/requests',
+    hmacAuthentication: false,
+    hmacRegionName: '',
+    hmacAccessKey: '',
+    hmacSecretKey: '',
+    connectionTimeout: 60,
+    timeoutBetweenBytes: 35
+  },
+  adaptedPayloadMock: {
     name: 'New Origin',
     origin_type: 'single_origin',
     method: '',
     addresses: [
       {
-        address: 'httpbin.org'
+        address: 'httpbin.org',
+        server_role: 'primary',
+        is_active: true
       }
     ],
     origin_protocol_policy: 'http',
@@ -26,6 +49,52 @@ const fixtures = {
   }
 }
 
+const scenarios = [
+  {
+    label: 'should call API with correct params when origin type is single origin',
+    payload: fixtures.requestPayloadMock,
+    adaptedPayload: fixtures.adaptedPayloadMock
+  },
+  {
+    label: 'should call API with correct params when origin type is load balancer',
+    payload: {
+      ...fixtures.requestPayloadMock,
+      originType: 'load_balancer',
+      addresses: [
+        {
+          ...fixtures.requestPayloadMock.addresses[0],
+          weight: 1
+        }
+      ]
+    },
+    adaptedPayload: {
+      ...fixtures.adaptedPayloadMock,
+      origin_type: 'load_balancer',
+      addresses: [
+        {
+          ...fixtures.adaptedPayloadMock.addresses[0],
+          weight: 1
+        }
+      ]
+    }
+  },
+  {
+    label: 'should call API with correct params when origin type is object storage',
+    payload: {
+      ...fixtures.requestPayloadMock,
+      originType: 'object_storage',
+      bucketName: 'my-bucket',
+      prefix: 'test'
+    },
+    adaptedPayload: {
+      name: 'New Origin',
+      origin_type: 'object_storage',
+      bucket: 'my-bucket',
+      prefix: '/test'
+    }
+  }
+]
+
 const makeSut = () => {
   const sut = createOriginService
 
@@ -33,7 +102,7 @@ const makeSut = () => {
 }
 
 describe('EdgeApplicationOriginsServices', () => {
-  it('should call API with correct params', async () => {
+  it.each(scenarios)('$label', async ({ payload, adaptedPayload }) => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 201,
       body: {
@@ -45,25 +114,12 @@ describe('EdgeApplicationOriginsServices', () => {
 
     const { sut } = makeSut()
     const version = 'v3'
-    await sut(fixtures.originMock)
+    await sut(payload)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/edge_applications/${fixtures.originMock.id}/origins`,
+      url: `${version}/edge_applications/${payload.id}/origins`,
       method: 'POST',
-      body: {
-        name: fixtures.originMock.name,
-        host_header: fixtures.originMock.hostHeader,
-        method: fixtures.originMock.method,
-        addresses: fixtures.originMock.addresses,
-        origin_path: fixtures.originMock.originPath,
-        origin_protocol_policy: fixtures.originMock.originProtocolPolicy,
-        hmac_authentication: fixtures.originMock.hmacAuthentication,
-        hmac_region_name: fixtures.originMock.hmacRegionName,
-        hmac_access_key: fixtures.originMock.hmacAccessKey,
-        hmac_secret_key: fixtures.originMock.hmacSecretKey,
-        connection_timeout: fixtures.originMock.connectionTimeout,
-        timeout_between_bytes: fixtures.originMock.timeoutBetweenBytes
-      }
+      body: adaptedPayload
     })
   })
 
@@ -78,7 +134,7 @@ describe('EdgeApplicationOriginsServices', () => {
     })
     const { sut } = makeSut()
 
-    const feedbackMessage = sut(fixtures.originMock)
+    const feedbackMessage = sut(fixtures.adaptedPayloadMock)
 
     expect(feedbackMessage).rejects.toThrow(apiErrorMock)
   })
@@ -94,7 +150,7 @@ describe('EdgeApplicationOriginsServices', () => {
     })
     const { sut } = makeSut()
 
-    const feedbackMessage = sut(fixtures.originMock)
+    const feedbackMessage = sut(fixtures.adaptedPayloadMock)
 
     expect(feedbackMessage).rejects.toThrow(apiErrorMock)
   })
@@ -109,7 +165,7 @@ describe('EdgeApplicationOriginsServices', () => {
     })
     const { sut } = makeSut()
 
-    const feedbackMessage = sut(fixtures.originMock)
+    const feedbackMessage = sut(fixtures.adaptedPayloadMock)
 
     expect(feedbackMessage).rejects.toThrow(apiErrorMock)
   })
@@ -125,7 +181,10 @@ describe('EdgeApplicationOriginsServices', () => {
     })
     const { sut } = makeSut()
 
-    const { feedback, originKey } = await sut(fixtures.originMock, fixtures.edgeApplicationId)
+    const { feedback, originKey } = await sut(
+      fixtures.adaptedPayloadMock,
+      fixtures.edgeApplicationId
+    )
 
     expect(originKey).toBe('test-origin-key')
     expect(feedback).toBe('Your origin has been created')
@@ -156,7 +215,7 @@ describe('EdgeApplicationOriginsServices', () => {
       })
       const { sut } = makeSut()
 
-      const response = sut(fixtures.originMock)
+      const response = sut(fixtures.adaptedPayloadMock)
 
       expect(response).rejects.toBe(expectedError)
     }


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- add weight key to address only when originType is 'load balance'
- add tests for different originType scenarios

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
![Screenshot 2024-04-08 at 15 25 14](https://github.com/aziontech/azion-console-kit/assets/95643165/916d0abb-f2bb-4b33-afd9-e01d4208857f)

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
