### PR TITLE
[UXE-2339] fix: remove autocomplete from sign up form and display only one testimonial

### DIFF
--- a/src/assets/icons/azionicons.scss
+++ b/src/assets/icons/azionicons.scss
@@ -141,4 +141,3 @@
 .ai.ai-astro::before {
   content: '\ea42';
 }
-

--- a/src/templates/signup-block/client-testimonials-block.vue
+++ b/src/templates/signup-block/client-testimonials-block.vue
@@ -6,11 +6,10 @@
     <Carousel
       :value="listTestimonials"
       :numVisible="1"
-      :numScroll="1"
-      circular
+      :circular="false"
       :showNavigators="false"
       :showIndicators="false"
-      :autoplayInterval="3000"
+      :autoplayInterval="timeToNextSlideInMs"
     >
       <template #item="slotProps">
         <div class="flex flex-col gap-2">
@@ -33,6 +32,7 @@
   import Carousel from 'primevue/carousel'
   import Vtex from '@/assets/svg/vtex-logo.vue'
   import { h, ref } from 'vue'
+  const timeToNextSlideInMs = 10000
 
   const listTestimonials = ref([
     {

--- a/src/templates/signup-block/form-signup-block.vue
+++ b/src/templates/signup-block/form-signup-block.vue
@@ -5,6 +5,7 @@
         <div class="w-full flex flex-col gap-8 animate-fadeIn">
           <form
             class="flex flex-col gap-8"
+            autocomplete="off"
             @submit.prevent
           >
             <div class="gap-3 flex flex-col">

--- a/src/templates/signup-block/login-with-email-block.vue
+++ b/src/templates/signup-block/login-with-email-block.vue
@@ -175,11 +175,17 @@
     }
   }
 
+  const extractNameFromEmail = (email) => {
+    const [emailBeforeAt] = email.split('@')
+    return emailBeforeAt
+  }
+
   const signUp = handleSubmit(async (values) => {
     loading.value = true
     try {
+      const name = extractNameFromEmail(values.email)
       const captcha = await recaptcha.execute('signup')
-      await props.signupService({ ...values, captcha })
+      await props.signupService({ ...values, name, captcha })
 
       tracker.signUp.userSignedUp({ method: 'email' })
       router.push({ query: { email: encodeEmail(values.email) } })

--- a/src/templates/signup-block/login-with-email-block.vue
+++ b/src/templates/signup-block/login-with-email-block.vue
@@ -12,6 +12,7 @@
       </label>
       <InputText
         v-model="email"
+        autocomplete="off"
         id="email"
         type="email"
         class="w-full"
@@ -21,27 +22,6 @@
         v-if="errors.email"
         class="p-error text-xs font-normal leading-tight"
         >{{ errors.email }}</small
-      >
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <label
-        for="name"
-        class="font-semibold text-sm"
-      >
-        Full Name *
-      </label>
-      <InputText
-        v-model="name"
-        id="name"
-        type="name"
-        class="w-full"
-        :class="{ 'p-invalid': errors.name }"
-      />
-      <small
-        v-if="errors.name"
-        class="p-error text-xs font-normal leading-tight"
-        >{{ errors.name }}</small
       >
     </div>
 
@@ -59,6 +39,7 @@
         v-model="password"
         promptLabel="Choose a password"
         weakLabel="Weak"
+        autocomplete="off"
         mediumLabel="Medium"
         strongLabel="Strong"
         required
@@ -148,10 +129,6 @@
       .max(254, 'Exceeded number of characters.')
       .email('Enter a valid email.')
       .required('Email is a required field.'),
-    name: yup
-      .string()
-      .max(254, 'Exceeded number of characters.')
-      .required('Name is a required field.'),
     password: yup
       .string()
       .required('Password is a required field.')
@@ -178,7 +155,6 @@
 
   const { value: password } = useField('password')
   const { value: email } = useField('email')
-  const { value: name } = useField('name')
 
   const toast = useToast()
   const router = useRouter()

--- a/src/tests/services/domains-services/load-domain-service.test.js
+++ b/src/tests/services/domains-services/load-domain-service.test.js
@@ -22,8 +22,8 @@ const fixtures = {
     is_active: false,
     activeSort: true,
     digital_certificate_id: null,
-    edge_application_id: 'ea1234',
-  },
+    edge_application_id: 'ea1234'
+  }
 }
 
 const makeSut = () => {

--- a/src/views/Domains/FormFields/FormFieldsEditDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsEditDomains.vue
@@ -75,7 +75,6 @@
       value: certificate.id
     }))
   })
-
 </script>
 
 <template>


### PR DESCRIPTION

## Pull Request

### What is the new behavior introduced by this PR?
- removes the auto complete behavior from signup form fields.
- removes infinite loop from the Carousel of testimonials.
- remove full name field, since it should me used only in the new additional data page.
- full name will be send by extraction of the first part of the email. Ex: john.doe@gmail.com -> will be john.doe. 

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

No
### Does this PR introduce UI changes? Add a video or screenshots here.
Yes, remove Full Name field. It will be move to additional data page.
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/cc1d49d5-f6cf-4112-80cc-fad034c5d6e0)

### Does it have a link on Figma?
No.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
