### PR TITLE
[UXE-2833] fix: escape  special use in error message of template fields

### DIFF
--- a/src/templates/template-engine-block/index.vue
+++ b/src/templates/template-engine-block/index.vue
@@ -48,7 +48,7 @@
             v-if="formTools.errors[field.name]"
             class="p-error text-xs font-normal leading-tight"
           >
-            {{ formTools.errors[field.name] }}
+            {{ unescapeErrorMessage(formTools.errors[field.name]) }}
           </small>
         </div>
       </template>
@@ -154,7 +154,7 @@
                 v-if="formTools.errors[field.name]"
                 class="p-error text-xs font-normal leading-tight"
               >
-                {{ formTools.errors[field.name] }}
+                {{ unescapeErrorMessage(formTools.errors[field.name]) }}
               </small>
             </div>
           </div>
@@ -295,6 +295,14 @@
     })
   }
 
+  const escapeErrorMessage = (errorMessage) => {
+    return errorMessage.replaceAll('${', '#$')
+  }
+
+  const unescapeErrorMessage = (errorMessage) => {
+    return errorMessage.replaceAll('#$', '${')
+  }
+
   const renderInvalidClass = (containErrorInField) => {
     if (containErrorInField) return 'p-invalid'
     return ''
@@ -356,7 +364,7 @@
 
     if (element.validators) {
       element.validators.forEach((validator) => {
-        schema = schema.test(`valid-${element.name}`, validator.errorMessage, function (value) {
+        schema = schema.test(`valid-${element.name}`, escapeErrorMessage(validator.errorMessage), function (value) {
           const domainRegex = new RegExp(validator.regex)
           return domainRegex.test(value)
         })


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Escape the use of ${} in template fields error messages, that was resulting in undefined in some templates
<img width="1064" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/235cc15e-1712-4d5a-a483-bc981967a897">

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
