### PR TITLE
[UXE-2885] fix: add method to verify error_description query in login url

### DIFF
--- a/src/templates/sign-in-block/index.vue
+++ b/src/templates/sign-in-block/index.vue
@@ -162,10 +162,11 @@
   import Password from 'primevue/password'
   import SocialIdpsBlock from '@/templates/social-idps-block'
   import { useField, useForm } from 'vee-validate'
-  import { ref, inject } from 'vue'
-  import { useRouter } from 'vue-router'
+  import { ref, inject, onMounted } from 'vue'
+  import { useRoute, useRouter } from 'vue-router'
   import Divider from 'primevue/divider'
   import * as yup from 'yup'
+  import { useToast } from 'primevue/usetoast'
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
 
@@ -199,6 +200,26 @@
       type: Function,
       required: true
     }
+  })
+
+  const route = useRoute()
+  const toast = useToast()
+
+  const verifyErrorsOnUrl = () => {
+    const { error_description: errorMessage } = route.query
+
+    if (errorMessage) {
+      toast.add({
+        closable: true,
+        severity: 'error',
+        summary: 'Error',
+        detail: errorMessage
+      })
+    }
+  }
+
+  onMounted(() => {
+    verifyErrorsOnUrl()
   })
 
   const showSocialIdps = ref(true)


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- implement method to verify for `error_description` in login url
- show error description in the toast

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
![Screenshot 2024-04-23 at 13 46 59](https://github.com/aziontech/azion-console-kit/assets/95643165/43b45efe-f33d-47a8-a3f9-5b13ea336c7b)

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
