### PR TITLE
[UXE-2830] fix: default rule presents set origin behavior with empty value

### DIFF
--- a/src/services/edge-application-origins-services/list-origins-service.js
+++ b/src/services/edge-application-origins-services/list-origins-service.js
@@ -34,7 +34,7 @@ const adapt = (httpResponse) => {
       originKey: {
         content: origin.origin_key
       },
-      originId: origin.origin_id,
+      originId: convertOriginIdToString(origin.origin_id),
       name: origin.name,
       originType: originTypeFormat[origin.origin_type],
       addresses: formattedListOfAddresses,
@@ -66,4 +66,8 @@ const makeSearchParams = ({ orderBy, sort, page, pageSize }) => {
   searchParams.set('page_size', pageSize)
 
   return searchParams
+}
+
+const convertOriginIdToString = (originId) => {
+  return new String(originId).toString()
 }


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
default rule presents set origin behavior with empty value

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/3192eff7-67c3-462d-b67b-bdedfd2883fe


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
