### PR TITLE
[UXE-2889] fix: align password strength rules between prime component and block implementation

### DIFF
--- a/src/templates/signup-block/login-with-email-block.vue
+++ b/src/templates/signup-block/login-with-email-block.vue
@@ -42,6 +42,7 @@
         autocomplete="off"
         mediumLabel="Medium"
         strongLabel="Strong"
+        :strongRegex="strongPasswordRegex"
         required
         :pt="{
           meter: 'rounded-md',
@@ -115,6 +116,17 @@
     getInstance().showBadge()
   })
 
+  /*
+  Enforce the following rules:
+    1. Must have at least 1 special character - (?=.*[-_!@#$%^&*(),.?":{}|<>])
+    2. Must have at least 1 uppercase letter - (?=.*[A-Z])
+    3. Must have at least 1 lowercase letter - (?=.*[a-z])
+    4. Must have at least 1 number - (?=.*[0-9])
+    5. Must have at least 8 characters - (?=.{8,})
+  */
+  const strongPasswordRegex =
+    '^(?=.*[-_!@#$%^&*(),.?":{}|<>])(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.{8,})'
+
   const passwordRequirementsList = ref([
     { text: '8 characters', valid: false },
     { text: '1 uppercase letter', valid: false },
@@ -137,7 +149,7 @@
       .test('requirements', 'Password does not meet requirements.', (value) => {
         const hasUpperCase = value && /[A-Z]/.test(value)
         const hasLowerCase = value && /[a-z]/.test(value)
-        const hasSpecialChar = value && /[!@#$%^&*(),.?":{}|<>]/.test(value)
+        const hasSpecialChar = value && /[!-_@#$%^&*(),.?":{}|<>]/.test(value)
         const hasMinLength = value?.length > 7
         const hasNumber = value && /[0-9]/.test(value)
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- apply the same regex for PrimePassword component as used in the block
- add `-` and `_` as new special characters

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/dafdf263-018b-45be-b47c-251b5c3c55f0

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
