### PR TITLE
[UXE-2896] Change color for $inputPlaceholderTextColor token

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/variables/_form.scss
+++ b/src/assets/themes/scss/themes/azion-dark/variables/_form.scss
@@ -36,7 +36,7 @@ $inputErrorBorderColor: $errorColor;
 
 /// Text color of a placeholder
 /// @group form
-$inputPlaceholderTextColor: $textSecondaryColor;
+$inputPlaceholderTextColor: #666;
 
 /// Background of a filled input
 /// @group form

--- a/src/assets/themes/scss/themes/azion-light/variables/_form.scss
+++ b/src/assets/themes/scss/themes/azion-light/variables/_form.scss
@@ -36,7 +36,7 @@ $inputErrorBorderColor: $errorColor;
 
 /// Text color of a placeholder
 /// @group form
-$inputPlaceholderTextColor: #666666;
+$inputPlaceholderTextColor: #979797;
 
 /// Background of a filled input
 /// @group form


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Change color for $inputPlaceholderTextColor token, now the color has aspect of "empty"

### Does this PR introduce breaking changes?
- [X] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="592" alt="Captura de Tela 2024-04-24 às 10 26 04" src="https://github.com/aziontech/azion-console-kit/assets/95422158/6fc6a399-0153-4394-85a3-422ebe131b84">
<img width="559" alt="Captura de Tela 2024-04-24 às 10 26 17" src="https://github.com/aziontech/azion-console-kit/assets/95422158/bf4dc4cc-d693-47bb-810d-04f74638ab0a">


### Does it have a link on Figma?
No Figma

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [X] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [X] Edge
- [X] Firefox
- [X] Safari
