### PR TITLE
[UXE-2809] fix: onsaved dialog being opened even after saving changes

### DIFF
--- a/src/templates/edit-form-block/index.vue
+++ b/src/templates/edit-form-block/index.vue
@@ -60,7 +60,7 @@
 
   watch(formHasChanges, () => {
     if (!props.isTabs) return
-    formHasUpdated.value = formHasChanges
+    formHasUpdated.value = formHasChanges.value
     visibleOnSaved.value = false
   })
 

--- a/src/views/EdgeApplications/EditView.vue
+++ b/src/views/EdgeApplications/EditView.vue
@@ -4,7 +4,7 @@
     :loadService="loadEdgeApplication"
     :updatedRedirect="props.updatedRedirect"
     :schema="validationSchema"
-    @on-edit-success="handleTrackSuccessEdit"
+    @on-edit-success="[handleTrackSuccessEdit, updatedStatusUnSaved]"
     @on-edit-fail="handleTrackFailEdit"
     disableRedirect
     :isTabs="true"
@@ -39,6 +39,7 @@
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
 
   const tracker = inject('tracker')
+  const unsavedStatus = inject('unsaved')
 
   const props = defineProps({
     editEdgeApplicationService: {
@@ -64,6 +65,10 @@
 
   const loadEdgeApplication = async () => {
     return props.edgeApplication
+  }
+
+  const updatedStatusUnSaved = () => {
+    unsavedStatus.formHasUpdated = false
   }
 
   const handleTrackSuccessEdit = () => {


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
onsaved dialog being opened even after saving changes

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/365ab6f5-597f-4bc3-a59f-5ebed6700dea


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
