### PR TITLE
[UXE-2774] fix: reset page state if page is cached by browser

### DIFF
--- a/src/templates/sign-in-block/index.vue
+++ b/src/templates/sign-in-block/index.vue
@@ -167,7 +167,6 @@
   import Divider from 'primevue/divider'
   import * as yup from 'yup'
   import { useToast } from 'primevue/usetoast'
-  import { useLoadingStore } from '@/stores/loading'
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
 
@@ -205,7 +204,6 @@
 
   const route = useRoute()
   const toast = useToast()
-  const loadingStore = useLoadingStore()
 
   const verifyErrorsOnUrl = () => {
     const { error_description: errorMessage } = route.query
@@ -221,7 +219,6 @@
   }
 
   onMounted(() => {
-    loadingStore.finishLoading()
     verifyErrorsOnUrl()
   })
 

--- a/src/templates/social-idps-block/index.vue
+++ b/src/templates/social-idps-block/index.vue
@@ -56,7 +56,7 @@
   const showSkeleton = computed(() => idps.value.length === 0)
 
   onMounted(() => {
-    window.addEventListener('pageshow', verifyBfcache)
+    window.addEventListener('pageshow', resetLoadingState)
     loadSocialIdps()
   })
 
@@ -106,17 +106,14 @@
 
   /*
     When user goes to social login page and then goes back, the login page is cached in the browser.
-    To reset to default state, we need to check if the page is cached.
     https://web.dev/articles/bfcache
   */
-  const verifyBfcache = (event) => {
-    if (event.persisted) {
-      loadingStore.finishLoading()
-      submittedIdp.value = null
-    }
+  const resetLoadingState = () => {
+    loadingStore.finishLoading()
+    submittedIdp.value = null
   }
 
   onUnmounted(() => {
-    window.removeEventListener('pageshow', verifyBfcache)
+    window.removeEventListener('pageshow', resetLoadingState)
   })
 </script>

--- a/src/templates/social-idps-block/index.vue
+++ b/src/templates/social-idps-block/index.vue
@@ -36,7 +36,7 @@
   import PrimeButton from 'primevue/button'
   import Skeleton from 'primevue/skeleton'
   import { useToast } from 'primevue/usetoast'
-  import { computed, onMounted, ref, inject } from 'vue'
+  import { computed, onMounted, ref, inject, onUnmounted } from 'vue'
 
   defineOptions({ name: 'social-idps-block' })
   const emit = defineEmits(['showSocialIdps'])
@@ -56,6 +56,7 @@
   const showSkeleton = computed(() => idps.value.length === 0)
 
   onMounted(() => {
+    window.addEventListener('pageshow', verifyBfcache)
     loadSocialIdps()
   })
 
@@ -102,4 +103,20 @@
     window.location.href = idp.loginUrl
     tracker.signUp.userClickedSignedUp({ method: idp.slug }).track()
   }
+
+  /*
+    When user goes to social login page and then goes back, the login page is cached in the browser.
+    To reset to default state, we need to check if the page is cached.
+    https://web.dev/articles/bfcache
+  */
+  const verifyBfcache = (event) => {
+    if (event.persisted) {
+      loadingStore.finishLoading()
+      submittedIdp.value = null
+    }
+  }
+
+  onUnmounted(() => {
+    window.removeEventListener('pageshow', verifyBfcache)
+  })
 </script>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Resets login page state if is cached by [bfcache](https://web.dev/articles/bfcache)

> It was not exactly tested, because the behavior does not happen in local env.
> Applying the response header `Cache Control: 'no-cache'` to the rule engine only worked in chrome

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
No

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
