### PR TITLE
[UXE-2806] fix: added a default value for ttl field in edge dns records field

### DIFF
--- a/src/tests/services/edge-dns-records-services/create-records-service.test.js
+++ b/src/tests/services/edge-dns-records-services/create-records-service.test.js
@@ -13,7 +13,18 @@ const fixtures = {
     description: 'dns record description',
     selectedPolicy: { _value: 'weighted' },
     weight: 0.9
-  }
+  },
+  anameDnsRecordTypeMock: {
+    edgeDNSID: 123987902,
+    selectedRecordType: { _value: 'aname' },
+    name: 'Aname-dns-name',
+    value: 'aname-record-type',
+    ttl: 20,
+    description: 'dns anamerecord description',
+    selectedPolicy: { _value: 'weighted' },
+    weight: 0.9
+  },
+  ttlDefaultValue: 20
 }
 
 const makeSut = () => {
@@ -49,6 +60,33 @@ describe('EdgeDnsRecordsServices', () => {
         description: fixtures.dnsRecordMock.description,
         policy: fixtures.dnsRecordMock.selectedPolicy,
         weight: fixtures.dnsRecordMock.weight
+      }
+    })
+  })
+  it('should create a aname record type with default value', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 201,
+      body: {
+        results: {
+          id: 1
+        }
+      }
+    })
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut(fixtures.anameDnsRecordTypeMock)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `${version}/intelligent_dns/${fixtures.anameDnsRecordTypeMock.edgeDNSID}/records`,
+      method: 'POST',
+      body: {
+        record_type: fixtures.anameDnsRecordTypeMock.selectedRecordType,
+        entry: fixtures.anameDnsRecordTypeMock.name,
+        answers_list: [fixtures.anameDnsRecordTypeMock.value],
+        ttl: fixtures.ttlDefaultValue,
+        description: fixtures.anameDnsRecordTypeMock.description,
+        policy: fixtures.anameDnsRecordTypeMock.selectedPolicy,
+        weight: fixtures.anameDnsRecordTypeMock.weight
       }
     })
   })

--- a/src/tests/services/edge-dns-records-services/create-records-service.test.js
+++ b/src/tests/services/edge-dns-records-services/create-records-service.test.js
@@ -6,22 +6,22 @@ import { describe, expect, it, vi } from 'vitest'
 const fixtures = {
   dnsRecordMock: {
     edgeDNSID: 123987902,
-    selectedRecordType: { _value: 'dns-record-value' },
+    selectedRecordType: 'dns-record-value',
     name: 'Az-dns-name',
     value: 'dns-answer-record-value',
     ttl: '8000',
     description: 'dns record description',
-    selectedPolicy: { _value: 'weighted' },
+    selectedPolicy: 'weighted',
     weight: 0.9
   },
   anameDnsRecordTypeMock: {
     edgeDNSID: 123987902,
-    selectedRecordType: { _value: 'aname' },
+    selectedRecordType: 'aname',
     name: 'Aname-dns-name',
     value: 'aname-record-type',
     ttl: 20,
-    description: 'dns anamerecord description',
-    selectedPolicy: { _value: 'weighted' },
+    description: 'dns aname record description',
+    selectedPolicy: 'weighted',
     weight: 0.9
   },
   ttlDefaultValue: 20
@@ -75,11 +75,13 @@ describe('EdgeDnsRecordsServices', () => {
     const { sut } = makeSut()
     await sut(fixtures.anameDnsRecordTypeMock)
 
-    expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
-      body: expect.objectContaining({
-        ttl: fixtures.ttlDefaultValue
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          ttl: fixtures.ttlDefaultValue
+        })
       })
-    }))
+    )
   })
 
   it('should return a feedback message on successfully created', async () => {

--- a/src/tests/services/edge-dns-records-services/create-records-service.test.js
+++ b/src/tests/services/edge-dns-records-services/create-records-service.test.js
@@ -73,22 +73,13 @@ describe('EdgeDnsRecordsServices', () => {
       }
     })
     const { sut } = makeSut()
-    const version = 'v3'
     await sut(fixtures.anameDnsRecordTypeMock)
 
-    expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/intelligent_dns/${fixtures.anameDnsRecordTypeMock.edgeDNSID}/records`,
-      method: 'POST',
-      body: {
-        record_type: fixtures.anameDnsRecordTypeMock.selectedRecordType,
-        entry: fixtures.anameDnsRecordTypeMock.name,
-        answers_list: [fixtures.anameDnsRecordTypeMock.value],
-        ttl: fixtures.ttlDefaultValue,
-        description: fixtures.anameDnsRecordTypeMock.description,
-        policy: fixtures.anameDnsRecordTypeMock.selectedPolicy,
-        weight: fixtures.anameDnsRecordTypeMock.weight
-      }
-    })
+    expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.objectContaining({
+        ttl: fixtures.ttlDefaultValue
+      })
+    }))
   })
 
   it('should return a feedback message on successfully created', async () => {

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -94,6 +94,9 @@
             class="text-color text-base font-medium"
             >Record Type *</label
           >
+          <pre>
+            {{ selectedRecordType }}
+          </pre>
           <Dropdown
             appendTo="self"
             v-model="selectedRecordType"

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -19,7 +19,8 @@
 
   const edgeDNSStore = useEdgeDNSStore()
 
-  const RECORD_TYPE_WITHOUT_TTL = 'ANAME'
+  const RECORD_TYPE_WITH_DEFAULT_TTL = 'ANAME'
+  const TTL_DEFAULT_VALUE = 20
 
   const policyList = ref([
     { label: 'Simple', value: 'simple' },
@@ -44,9 +45,13 @@
     return selectedPolicy.value === 'weighted'
   })
 
-  const showTTLField = computed(() => {
-    return selectedRecordType.value !== RECORD_TYPE_WITHOUT_TTL
+  const enableTTLField = computed(() => {
+    return selectedRecordType.value !== RECORD_TYPE_WITH_DEFAULT_TTL
   })
+
+  const setTtlByRecordType = () => {
+    if (!enableTTLField.value) ttl.value = TTL_DEFAULT_VALUE
+  }
 </script>
 
 <template>
@@ -92,6 +97,7 @@
           <Dropdown
             appendTo="self"
             v-model="selectedRecordType"
+            @change="setTtlByRecordType"
             :options="recordsTypes"
             optionLabel="label"
             id="type"
@@ -111,10 +117,7 @@
           >
         </div>
 
-        <div
-          v-if="showTTLField"
-          class="flex flex-col sm:max-w-xs w-full gap-2"
-        >
+        <div class="flex flex-col sm:max-w-xs w-full gap-2">
           <label
             for="ttl"
             class="text-color text-base font-medium"
@@ -123,6 +126,7 @@
 
           <InputNumber
             showButtons
+            :disabled="!enableTTLField"
             placeholder="TTL (seconds):"
             v-model="ttl"
             id="ttl"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
<!-- Describe your changes in detail -->
 * added a default value for ttl field in edge dns records field based in RTM.
 * for ANAME type the value is 20
 * field now is showing for this type
 * added test case for default value in aname type

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->
https://github.com/aziontech/azion-console-kit/assets/109550332/d07b3122-37b9-4802-82dd-83c538580bfb

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
