### PR TITLE
[UXE-2578] refactor: hide frame preview for lua functions

### DIFF
--- a/src/views/EdgeFunctions/EditView.vue
+++ b/src/views/EdgeFunctions/EditView.vue
@@ -2,7 +2,10 @@
   <ContentBlock>
     <template #heading>
       <PageHeadingBlock pageTitle="Edit Edge Function">
-        <MobileCodePreview :updateObject="updateObject" />
+        <MobileCodePreview
+          :updateObject="updateObject"
+          :language="language"
+        />
       </PageHeadingBlock>
     </template>
     <template #content>
@@ -13,7 +16,10 @@
         :schema="validationSchema"
       >
         <template #form>
-          <FormFieldsEditEdgeFunctions v-model:preview-data="updateObject" />
+          <FormFieldsEditEdgeFunctions
+            v-model:preview-data="updateObject"
+            v-model:lang="language"
+          />
         </template>
         <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
           <ActionBarBlockWithTeleport
@@ -53,6 +59,7 @@
     }
   })
   const updateObject = ref({})
+  const language = ref(null)
 
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field'),

--- a/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
@@ -11,8 +11,8 @@
   import { useField } from 'vee-validate'
   import { computed, ref, watch } from 'vue'
 
-  defineProps(['previewData'])
-  const emit = defineEmits(['update:previewData'])
+  defineProps(['previewData', 'lang'])
+  const emit = defineEmits(['update:previewData', 'update:lang'])
 
   const SPLITTER_PROPS = {
     height: '50vh',
@@ -21,7 +21,10 @@
   }
   const ARGS_INITIAL_STATE = '{}'
 
-  const showPreview = ref(true)
+  const previewState = ref(true)
+  const showPreview = computed(() => {
+    return previewState.value && language.value !== 'lua'
+  })
 
   const { value: name, errorMessage: nameError } = useField('name')
   const { value: isProprietaryCode } = useField('isProprietaryCode')
@@ -47,6 +50,7 @@
       lua: 'Lua'
     }
 
+    emit('update:lang', language.value)
     return languageLabels[language.value]
   })
 
@@ -155,8 +159,8 @@
       <Splitter
         :style="{ height: SPLITTER_PROPS.height }"
         class="mt-8 surface-border border rounded-md hidden md:flex"
-        @resizestart="showPreview = false"
-        @resizeend="showPreview = true"
+        @resizestart="previewState = false"
+        @resizeend="previewState = true"
         :layout="SPLITTER_PROPS.layout"
       >
         <SplitterPanel
@@ -166,7 +170,7 @@
           <CodeEditor
             v-model="code"
             :initialValue="initialCodeValue"
-            language="javascript"
+            :language="language"
             :errors="hasCodeError"
             :readOnly="isProprietaryCode"
           />
@@ -178,11 +182,11 @@
           </small>
         </SplitterPanel>
 
-        <SplitterPanel :size="SPLITTER_PROPS.panelsSizes[1]">
-          <CodePreview
-            v-if="showPreview"
-            :updateObject="updateObject"
-          />
+        <SplitterPanel
+          v-if="showPreview"
+          :size="SPLITTER_PROPS.panelsSizes[1]"
+        >
+          <CodePreview :updateObject="updateObject" />
         </SplitterPanel>
       </Splitter>
 
@@ -190,7 +194,7 @@
         <CodeEditor
           v-model="code"
           :initialValue="initialCodeValue"
-          language="javascript"
+          :language="language"
           :errors="hasCodeError"
         />
         <small
@@ -206,8 +210,8 @@
       <Splitter
         :style="{ height: SPLITTER_PROPS.height }"
         class="mt-8 surface-border border rounded-md hidden md:flex"
-        @resizestart="showPreview = false"
-        @resizeend="showPreview = true"
+        @resizestart="previewState = false"
+        @resizeend="previewState = true"
         :layout="SPLITTER_PROPS.layout"
       >
         <SplitterPanel :size="SPLITTER_PROPS.panelsSizes[0]">
@@ -219,11 +223,11 @@
           />
         </SplitterPanel>
 
-        <SplitterPanel :size="SPLITTER_PROPS.panelsSizes[1]">
-          <CodePreview
-            v-if="showPreview"
-            :updateObject="updateObject"
-          />
+        <SplitterPanel
+          v-if="showPreview"
+          :size="SPLITTER_PROPS.panelsSizes[1]"
+        >
+          <CodePreview :updateObject="updateObject" />
         </SplitterPanel>
       </Splitter>
       <div class="flex flex-col mt-8 surface-border border rounded-md md:hidden h-[50vh]">

--- a/src/views/EdgeFunctions/components/code-editor.vue
+++ b/src/views/EdgeFunctions/components/code-editor.vue
@@ -28,7 +28,7 @@
       type: String,
       default: 'javascript',
       validator: (value) => {
-        return ['javascript', 'json'].includes(value)
+        return ['javascript', 'json', 'lua'].includes(value)
       }
     },
     errors: Boolean

--- a/src/views/EdgeFunctions/components/mobile-code-preview.vue
+++ b/src/views/EdgeFunctions/components/mobile-code-preview.vue
@@ -3,7 +3,7 @@
     label="Preview"
     severity="primary"
     outlined
-    class="flex md:hidden"
+    :class="[buttonClasses]"
     @click="showMobilePreview = true"
   />
   <Sidebar
@@ -35,16 +35,23 @@
 </template>
 
 <script setup>
-  import { ref } from 'vue'
+  import { computed, ref } from 'vue'
   import PrimeButton from 'primevue/button'
   import Sidebar from 'primevue/sidebar'
   import CodePreview from './code-preview.vue'
 
-  defineProps({
+  const props = defineProps({
     updateObject: {
       type: Object,
       required: true
+    },
+    language: {
+      type: String
     }
+  })
+
+  const buttonClasses = computed(() => {
+    return props.language !== 'lua' ? 'flex md:hidden' : 'hidden'
   })
 
   const showMobilePreview = ref(false)


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Hide preview for lua functions in edit view
- Add lua as supported language by code-editor-block to improve lint

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/a259d800-ded5-43c0-a398-575fca084110

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
