### PR TITLE
[UXE-2817] fix: Creating Allowed Rule through Tuning is creating with wrong ruleId

### DIFF
--- a/src/services/waf-rules-services/list-waf-rules-tuning-attacks-service.js
+++ b/src/services/waf-rules-services/list-waf-rules-tuning-attacks-service.js
@@ -28,7 +28,7 @@ const adapt = (httpResponse) => {
           hitCount: event.hit_count,
           topIps: event.top_10_ips.map((ip) => ip.ip),
           id: index,
-          ruleId: event.rule_id,
+          ruleId: parseInt(event.rule_id),
           ipCount: event.ip_count,
           matchZone: event.match_zone,
           pathCount: event.path_count,

--- a/src/services/waf-rules-services/list-waf-rules-tuning-service.js
+++ b/src/services/waf-rules-services/list-waf-rules-tuning-service.js
@@ -56,6 +56,7 @@ const adapt = (httpResponse) => {
           hitCount: event.hit_count,
           topIps: event.top_10_ips[0][1],
           id: event.rule_id,
+          ruleId: event.rule_id,
           ruleIdDescription: `${event.rule_id} - ${event.rule_description}`,
           ipCount: event.ip_count,
           matchZone: event.match_zone,

--- a/src/tests/services/waf-rules-services/list-waf-rules-tuning-service.test.js
+++ b/src/tests/services/waf-rules-services/list-waf-rules-tuning-service.test.js
@@ -65,6 +65,7 @@ describe('WafRulesService', () => {
       {
         hitCount: fixtures.wafRulesMock.hit_count,
         topIps: '100.100.10',
+        ruleId: fixtures.wafRulesMock.rule_id,
         id: fixtures.wafRulesMock.rule_id,
         ruleIdDescription: `${fixtures.wafRulesMock.rule_id} - ${fixtures.wafRulesMock.rule_description}`,
         ipCount: fixtures.wafRulesMock.ip_count,

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -324,7 +324,11 @@
   }
 
   const selectedItems = (events) => {
-    selectedEvents.value = events
+    selectedEvents.value = events.map(event => ({
+      ruleId: event.id,
+      ...event
+    }))
+    
     cleanSelectData.value = null
   }
 

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -373,7 +373,7 @@
       }
 
       const payload = {
-        ruleId: event.id,
+        ruleId: parseInt(event.ruleId),
         matchZone: [matchZones],
         reason
       }

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -324,10 +324,7 @@
   }
 
   const selectedItems = (events) => {
-    selectedEvents.value = events.map((event) => ({
-      ruleId: event.id,
-      ...event
-    }))
+    selectedEvents.value = events
 
     cleanSelectData.value = null
   }
@@ -377,7 +374,7 @@
       }
 
       const payload = {
-        ruleId: parseInt(event.ruleId),
+        ruleId: event.ruleId,
         matchZone: [matchZones],
         reason
       }

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -324,11 +324,11 @@
   }
 
   const selectedItems = (events) => {
-    selectedEvents.value = events.map(event => ({
+    selectedEvents.value = events.map((event) => ({
       ruleId: event.id,
       ...event
     }))
-    
+
     cleanSelectData.value = null
   }
 


### PR DESCRIPTION
## Pull Request
[UXE-2817]

### What is the new behavior introduced by this PR?
Creating Allowed Rule through Tuning is creating with wrong ruleId

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/110847590/c242ed6f-c53f-4ec6-8045-287a03f81199


### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2817]: https://aziontech.atlassian.net/browse/UXE-2817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ