### PR TITLE
[UXE-2812] fix: adjust radio inputs with unexpected behavior

### DIFF
--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -481,12 +481,12 @@
             <RadioButton
               v-model="cacheByQueryString"
               :disabled="disabledQueryStringOptions(queryStringOption)"
-              :inputId="queryStringOption.value"
+              :inputId="`cbqs-${queryStringOption.value}`"
               name="cacheByQueryString"
               :value="queryStringOption.value"
             />
             <label
-              :for="queryStringOption.value"
+              :for="`cbqs-${queryStringOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ queryStringOption.label }}
@@ -624,12 +624,12 @@
             <RadioButton
               :disabled="disabledCookiesOptions(cookiesOption)"
               v-model="cacheByCookies"
-              :inputId="cookiesOption.value"
+              :inputId="`cbc-${cookiesOption.value}`"
               name="cacheByCookies"
               :value="cookiesOption.value"
             />
             <label
-              :for="cookiesOption.value"
+              :for="`cbc-${cookiesOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ cookiesOption.label }}
@@ -670,12 +670,12 @@
           >
             <RadioButton
               v-model="adaptiveDeliveryAction"
-              :inputId="deviceGroupCacheOption.value"
+              :inputId="`ad-${deviceGroupCacheOption.value}`"
               name="adaptiveDeliveryAction"
               :value="deviceGroupCacheOption.value"
             />
             <label
-              :for="deviceGroupCacheOption.value"
+              :for="`ad-${deviceGroupCacheOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ deviceGroupCacheOption.label }}

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -481,12 +481,12 @@
             <RadioButton
               v-model="cacheByQueryString"
               :disabled="disabledQueryStringOptions(queryStringOption)"
-              :inputId="`cbqs-${queryStringOption.value}`"
+              :inputId="`cache-by-query-string-${queryStringOption.value}`"
               name="cacheByQueryString"
               :value="queryStringOption.value"
             />
             <label
-              :for="`cbqs-${queryStringOption.value}`"
+              :for="`cache-by-query-string-${queryStringOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ queryStringOption.label }}
@@ -624,12 +624,12 @@
             <RadioButton
               :disabled="disabledCookiesOptions(cookiesOption)"
               v-model="cacheByCookies"
-              :inputId="`cbc-${cookiesOption.value}`"
+              :inputId="`cache-by-cookie-${cookiesOption.value}`"
               name="cacheByCookies"
               :value="cookiesOption.value"
             />
             <label
-              :for="`cbc-${cookiesOption.value}`"
+              :for="`cache-by-cookie-${cookiesOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ cookiesOption.label }}
@@ -670,12 +670,12 @@
           >
             <RadioButton
               v-model="adaptiveDeliveryAction"
-              :inputId="`ad-${deviceGroupCacheOption.value}`"
+              :inputId="`adaptative-delivery-${deviceGroupCacheOption.value}`"
               name="adaptiveDeliveryAction"
               :value="deviceGroupCacheOption.value"
             />
             <label
-              :for="`ad-${deviceGroupCacheOption.value}`"
+              :for="`adaptative-delivery-${deviceGroupCacheOption.value}`"
               class="text-color text-sm font-normal leading-tight"
             >
               {{ deviceGroupCacheOption.label }}


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Rename values for `inputId` and `for` in both radio and label in edgeApplicationCacheSettings form fields. The click on `Cache By Cookie` and `Adaptative Delivery` labels were triggering change in `Cache by Query String`.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
https://github.com/aziontech/azion-console-kit/assets/95643165/54756e18-d319-413f-ac31-cb6b325e95d9


### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
