### PR TITLE
[UXE-1874] fix: change more details box header in template page to fit content correctly

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_dialog.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_dialog.scss
@@ -4,6 +4,7 @@
   .p-dialog-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
+    min-height: 3.5rem !important;
     font-weight: 500 !important;
     padding-inline: 2rem !important;
     border-bottom: 1px solid var(--surface-border) !important;

--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_dialog.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_dialog.scss
@@ -4,7 +4,6 @@
   .p-dialog-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
-    height: 3.5rem !important;
     font-weight: 500 !important;
     padding-inline: 2rem !important;
     border-bottom: 1px solid var(--surface-border) !important;

--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_sidebar.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_sidebar.scss
@@ -3,7 +3,6 @@
   .p-sidebar-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
-    height: 3.5rem !important;
     font-weight: 500 !important;
     padding-left: 2rem !important;
     padding-right: 2rem !important;

--- a/src/assets/themes/scss/themes/azion-dark/extended-components/_sidebar.scss
+++ b/src/assets/themes/scss/themes/azion-dark/extended-components/_sidebar.scss
@@ -3,6 +3,7 @@
   .p-sidebar-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
+    min-height: 3.5rem !important;
     font-weight: 500 !important;
     padding-left: 2rem !important;
     padding-right: 2rem !important;

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_dialog.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_dialog.scss
@@ -4,6 +4,7 @@
   .p-dialog-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
+    min-height: 3.5rem !important;
     font-weight: 500 !important;
     padding-inline: 2rem !important;
     border-bottom: 1px solid var(--surface-border) !important;

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_dialog.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_dialog.scss
@@ -4,7 +4,6 @@
   .p-dialog-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
-    height: 3.5rem !important;
     font-weight: 500 !important;
     padding-inline: 2rem !important;
     border-bottom: 1px solid var(--surface-border) !important;

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_sidebar.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_sidebar.scss
@@ -3,7 +3,6 @@
   .p-sidebar-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
-    height: 3.5rem !important;
     font-weight: 500 !important;
     padding-left: 2rem !important;
     padding-right: 2rem !important;

--- a/src/assets/themes/scss/themes/azion-light/extended-components/_sidebar.scss
+++ b/src/assets/themes/scss/themes/azion-light/extended-components/_sidebar.scss
@@ -3,6 +3,7 @@
   .p-sidebar-header {
     justify-content: space-between;
     font-size: 1.25rem !important;
+    min-height: 3.5rem !important;
     font-weight: 500 !important;
     padding-left: 2rem !important;
     padding-right: 2rem !important;


### PR DESCRIPTION
## Pull Request
Remove sidebar and dialog fixed height to fit content correctly in template more details page

https://github.com/aziontech/azion-console-kit/assets/107002324/6103d603-d481-4b7e-ac8b-0a69b675a9a3




### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
