### PR TITLE
[UXE-3096] fix: adding ordering of templates by name

### DIFF
--- a/src/services/marketplace-services/list-solutions-service.js
+++ b/src/services/marketplace-services/list-solutions-service.js
@@ -41,19 +41,21 @@ const adapt = (httpResponse) => {
   const parsedServices =
     isArray && httpResponse.body.length
       ? httpResponse.body.map((element) => ({
-          id: element.id,
-          name: element.name,
-          referenceId: element.solution_reference_id,
-          vendor: element.vendor,
-          slug: element.slug,
-          headline: element.headline,
-          featured: element.featured,
-          released: element.new_release,
-          instanceType: {
-            isTemplate: element.instance_type.is_template
-          }
-        }))
+        id: element.id,
+        name: element.name,
+        referenceId: element.solution_reference_id,
+        vendor: element.vendor,
+        slug: element.slug,
+        headline: element.headline,
+        featured: element.featured,
+        released: element.new_release,
+        instanceType: {
+          isTemplate: element.instance_type.is_template
+        }
+      }))
       : []
+
+  parsedServices.sort((serviceA, serviceB) => serviceA.name.localeCompare(serviceB.name))
 
   return {
     body: parsedServices,

--- a/src/services/marketplace-services/list-solutions-service.js
+++ b/src/services/marketplace-services/list-solutions-service.js
@@ -41,18 +41,18 @@ const adapt = (httpResponse) => {
   const parsedServices =
     isArray && httpResponse.body.length
       ? httpResponse.body.map((element) => ({
-        id: element.id,
-        name: element.name,
-        referenceId: element.solution_reference_id,
-        vendor: element.vendor,
-        slug: element.slug,
-        headline: element.headline,
-        featured: element.featured,
-        released: element.new_release,
-        instanceType: {
-          isTemplate: element.instance_type.is_template
-        }
-      }))
+          id: element.id,
+          name: element.name,
+          referenceId: element.solution_reference_id,
+          vendor: element.vendor,
+          slug: element.slug,
+          headline: element.headline,
+          featured: element.featured,
+          released: element.new_release,
+          instanceType: {
+            isTemplate: element.instance_type.is_template
+          }
+        }))
       : []
 
   parsedServices.sort((serviceA, serviceB) => serviceA.name.localeCompare(serviceB.name))

--- a/src/tests/services/marketplace-services/list-solutions-service.test.js
+++ b/src/tests/services/marketplace-services/list-solutions-service.test.js
@@ -129,6 +129,8 @@ describe('MarketplaceServices', () => {
 
     const result = await sut({})
 
+    result.sort((serviceA, serviceB) => serviceA.name.localeCompare(serviceB.name))
+
     expect(result).toEqual([
       {
         headline: fixtures.solutionSample.headline,

--- a/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
+++ b/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
@@ -476,7 +476,8 @@
                 placeholder="VARIABLE_KEY_NAME"
               />
               <small class="text-xs text-color-secondary font-normal leading-5">
-                Give a name or identifier for the variable. Accepts upper-case letters, numbers, and underscore.
+                Give a name or identifier for the variable. Accepts upper-case letters, numbers, and
+                underscore.
               </small>
             </div>
             <div class="flex flex-col sm:max-w-lg w-full gap-2">

--- a/src/views/Variables/FormFields/FormFieldsVariables.vue
+++ b/src/views/Variables/FormFields/FormFieldsVariables.vue
@@ -30,7 +30,8 @@
           :class="{ 'p-invalid': keyError }"
         />
         <small class="text-xs text-color-secondary font-normal leading-5">
-          Give a name or identifier for the variable. Accepts upper-case letters, numbers, and underscore.
+          Give a name or identifier for the variable. Accepts upper-case letters, numbers, and
+          underscore.
         </small>
         <small
           v-if="keyError"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
adding ordering of templates by name
templates are not ordered A > Z

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/e549bf90-0bc8-480e-91c4-9dda7b5bb609


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
