### PR TITLE
[UXE-3122] fix: remove unnecessary toast from import from Github to deploy view and add variable key validation

### DIFF
--- a/src/templates/create-form-block/index.vue
+++ b/src/templates/create-form-block/index.vue
@@ -24,6 +24,10 @@
       type: Boolean,
       default: false
     },
+    disableAfterCreateToastFeedback: {
+      type: Boolean,
+      default: false
+    },
     cleanForm: {
       type: Boolean,
       default: true
@@ -61,7 +65,10 @@
   }
 
   const showFeedback = (feedback = 'created successfully') => {
-    const feedbackMessage = feedback || 'created successfully'
+    const feedbackMessage = feedback
+    if (props.disableAfterCreateToastFeedback) {
+      return
+    }
     showToast('success', feedbackMessage)
   }
 
@@ -78,9 +85,9 @@
 
   const onSubmit = handleSubmit(async (values) => {
     try {
+      blockViewRedirection.value = false
       const response = await props.createService(values)
       handleSuccess(response)
-      blockViewRedirection.value = false
     } catch (error) {
       showToast('error', error)
       emit('on-response-fail', error)

--- a/src/templates/form-fields-inputs/fieldText.vue
+++ b/src/templates/form-fields-inputs/fieldText.vue
@@ -67,6 +67,7 @@
     @input="handleChange"
     @blur="handleBlur"
     :class="inputClass"
+    v-bind="$attrs"
   />
   <small
     v-if="errorMessage"

--- a/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
+++ b/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
@@ -463,7 +463,6 @@
               icon="pi pi-trash"
               outlined
               type="button"
-              aria-label="Remove Origin"
               @click="removeVariable(index)"
             />
           </div>
@@ -471,6 +470,7 @@
             <div class="flex flex-col sm:max-w-lg w-full gap-2">
               <FieldText
                 label="Key *"
+                autocapitalize="characters"
                 :name="`newVariables[${index}].key`"
                 :value="newVariables[index].key"
               />

--- a/src/views/ImportGitHub/ImportGithubView.vue
+++ b/src/views/ImportGitHub/ImportGithubView.vue
@@ -74,7 +74,11 @@
     gitScope: yup.string().required().label('Git Scope'),
     newVariables: yup.array().of(
       yup.object().shape({
-        key: yup.string().required().label('Key'),
+        key: yup
+          .string()
+          .required()
+          .label('Key')
+          .matches(/^[A-Z0-9_]+$/, 'Only accepts upper-case letters, numbers, and underscore.'),
         value: yup.string().required().label('Value')
       })
     )

--- a/src/views/ImportGitHub/ImportGithubView.vue
+++ b/src/views/ImportGitHub/ImportGithubView.vue
@@ -204,6 +204,7 @@
     </template>
     <template #content>
       <CreateFormBlock
+        :disableAfterCreateToastFeedback="true"
         :createService="handleExecuteScriptRunner"
         :schema="validationSchema"
         :initialValues="initialValues"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Add validation to key field for each variable created on import from Github journey to avoid invalid keys
- No longer display an  success toast after initialize the integration from Github  


### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/101186721/0ffdf25a-5752-41cc-bf2f-d0598446e162



![image](https://github.com/aziontech/azion-console-kit/assets/101186721/f4fb60b7-7665-4107-83c8-6ccc3b66cee4)
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/ba220a66-a6ba-4d5c-9f59-3ed16be694e0)


### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
