### PR TITLE
[UXE-2081] feat: add event tracker click to edit edge firewall

### DIFF
--- a/src/views/EdgeFirewall/ListView.vue
+++ b/src/views/EdgeFirewall/ListView.vue
@@ -73,6 +73,12 @@
       productName: 'Edge Firewall'
     })
   }
+
+  const handleTrackEditEvent = () => {
+    tracker.product.clickToEdit({
+      productName: 'Edge Firewall'
+    })
+  }
 </script>
 
 <template>
@@ -89,6 +95,8 @@
         editPagePath="/edge-firewall/edit"
         :listService="props.listEdgeFirewallService"
         :deleteService="props.deleteEdgeFirewallService"
+        @on-before-go-to-edit="handleTrackEditEvent"
+
         :columns="getColumns"
         @on-load-data="handleLoadData"
         emptyListMessage="No edge firewall found."

--- a/src/views/EdgeFirewall/ListView.vue
+++ b/src/views/EdgeFirewall/ListView.vue
@@ -96,7 +96,6 @@
         :listService="props.listEdgeFirewallService"
         :deleteService="props.deleteEdgeFirewallService"
         @on-before-go-to-edit="handleTrackEditEvent"
-
         :columns="getColumns"
         @on-load-data="handleLoadData"
         emptyListMessage="No edge firewall found."


### PR DESCRIPTION
## Pull Request
[UXE-2081]
### What is the new behavior introduced by this PR?
 feat: add event tracker click to edit edge firewall

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
![Captura de Tela 2024-05-06 às 16 47 26](https://github.com/aziontech/azion-console-kit/assets/110847590/2bd1cc34-be9f-4fe9-9f6d-ed00b9a74c9b)

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2081]: https://aziontech.atlassian.net/browse/UXE-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ