### PR TITLE
[ENG-2765] fix: return to list on EdgeApplicationErrorResponses cancel

### DIFF
--- a/src/views/EdgeApplicationsErrorResponses/EditView.vue
+++ b/src/views/EdgeApplicationsErrorResponses/EditView.vue
@@ -4,6 +4,7 @@
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import * as yup from 'yup'
   import { inject } from 'vue'
+  import { useRouter } from 'vue-router'
 
   /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
@@ -60,6 +61,11 @@
       })
     )
   })
+
+  const router = useRouter()
+  const gotToList = () => {
+    router.push({ name: 'list-edge-applications' })
+  }
 </script>
 
 <template>
@@ -76,10 +82,10 @@
         :listOriginsService="props.listOriginsService"
       />
     </template>
-    <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
+    <template #action-bar="{ onSubmit, formValid, loading }">
       <ActionBarBlockWithTeleport
         @onSubmit="onSubmit"
-        @onCancel="onCancel"
+        @onCancel="gotToList"
         :loading="loading"
         :submitDisabled="!formValid"
       />


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- replace the default router.go(-1) behavior in the error responses form with router.push() to return to list on canceling.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/e82d3547-f2aa-4461-90a2-02c4ff16aa85


### Does it have a link on Figma?
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
