### PR TITLE
[UXE-3135] fix: ensure to only catch once the fail creation of an variable

### DIFF
--- a/src/views/ImportGitHub/ImportGithubView.vue
+++ b/src/views/ImportGitHub/ImportGithubView.vue
@@ -96,61 +96,52 @@
   }
 
   const templateId = ref(null)
-  const handleExecuteScriptRunner = async (formValues) => {
-    try {
-      if (formValues.newVariables) {
-        await Promise.all(
-          formValues.newVariables.map((variable) => props.createVariablesService(variable))
-        )
-      }
-
-      const inputSchema = [
-        {
-          field: 'platform_feature__vcs_integration__uuid',
-          instantiation_data_path: '',
-          value: formValues.gitScope
-        },
-        {
-          field: 'az_name',
-          instantiation_data_path: 'envs.[0].value',
-          value: formValues.applicationName
-        },
-        {
-          field: 'git_url_external',
-          instantiation_data_path: 'envs.[1].value',
-          value: formValues.repository
-        },
-        {
-          field: 'vulcan_preset',
-          instantiation_data_path: 'envs.[2].value',
-          value: formValues.preset
-        },
-        {
-          field: 'vulcan_mode',
-          instantiation_data_path: 'envs.[3].value',
-          value: formValues.mode
-        },
-        {
-          field: 'az_command',
-          instantiation_data_path: 'envs.[4].value',
-          value: formValues.installCommand
-        },
-        {
-          field: 'az_root_directory',
-          instantiation_data_path: 'envs.[5].value',
-          value: formValues.rootDirectory
-        }
-      ]
-
-      return props.instantiateTemplateService(templateId.value, inputSchema)
-    } catch (error) {
-      toast.add({
-        closable: true,
-        severity: 'error',
-        summary: 'error',
-        detail: error
-      })
+  const createServiceWithVariablesDecorator = async (formValues) => {
+    if (formValues.newVariables) {
+      await Promise.all(
+        formValues.newVariables.map((variable) => props.createVariablesService(variable))
+      )
     }
+
+    const inputSchema = [
+      {
+        field: 'platform_feature__vcs_integration__uuid',
+        instantiation_data_path: '',
+        value: formValues.gitScope
+      },
+      {
+        field: 'az_name',
+        instantiation_data_path: 'envs.[0].value',
+        value: formValues.applicationName
+      },
+      {
+        field: 'git_url_external',
+        instantiation_data_path: 'envs.[1].value',
+        value: formValues.repository
+      },
+      {
+        field: 'vulcan_preset',
+        instantiation_data_path: 'envs.[2].value',
+        value: formValues.preset
+      },
+      {
+        field: 'vulcan_mode',
+        instantiation_data_path: 'envs.[3].value',
+        value: formValues.mode
+      },
+      {
+        field: 'az_command',
+        instantiation_data_path: 'envs.[4].value',
+        value: formValues.installCommand
+      },
+      {
+        field: 'az_root_directory',
+        instantiation_data_path: 'envs.[5].value',
+        value: formValues.rootDirectory
+      }
+    ]
+
+    return props.instantiateTemplateService(templateId.value, inputSchema)
   }
 
   const loadSolutionByVendor = async () => {
@@ -187,7 +178,7 @@
     <template #content>
       <CreateFormBlock
         :disableAfterCreateToastFeedback="true"
-        :createService="handleExecuteScriptRunner"
+        :createService="createServiceWithVariablesDecorator"
         :schema="validationSchema"
         :initialValues="initialValues"
       >


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Ensure to catch correctly the fail event when creating variables before call the service of instantiate a project from github. This ensure to only show one fail event and avoid the redirection to the deploy view.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

No

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/101186721/d9758b3e-3093-4c74-bab9-c78fba0c3e4d



### Does it have a link on Figma?
NO.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
