### PR TITLE
[UXE-2931] fix: update resend email endpoint

### DIFF
--- a/src/services/signup-services/make-resend-email-base-url.js
+++ b/src/services/signup-services/make-resend-email-base-url.js
@@ -1,3 +1,4 @@
 export const makeResendEmailBaseUrl = () => {
-  return 'user/activation/request'
+  const version = 'v4'
+  return `${version}/iam/user/resend-activation-link`
 }

--- a/src/tests/services/signup-services/resend-email-service.test.js
+++ b/src/tests/services/signup-services/resend-email-service.test.js
@@ -23,7 +23,7 @@ describe('SignupServices', () => {
     await sut(emailPayloadMock)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: 'user/activation/request',
+      url: 'v4/iam/user/resend-activation-link',
       method: 'POST',
       body: emailPayloadMock
     })


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Update the url for resend email to avoid users being redirected to RTM. 

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
![Screenshot 2024-05-09 at 10 05 27](https://github.com/aziontech/azion-console-kit/assets/95643165/a7a89f56-07a9-4d60-a652-efc6d6901fd6)

https://github.com/aziontech/azion-console-kit/assets/95643165/9d488fbb-6d0e-4db1-8cbd-0b25fa3d2f41

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
