### PR TITLE
[UXE-2081] feat: add event tracker in edit edge firewall

### DIFF
--- a/src/views/EdgeFirewall/EditView.vue
+++ b/src/views/EdgeFirewall/EditView.vue
@@ -2,8 +2,11 @@
   import ActionBarTemplate from '@/templates/action-bar-block/action-bar-with-teleport'
   import EditFormBlock from '@/templates/edit-form-block'
   import FormFieldsEdgeFirewall from '@/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall'
-  import { ref } from 'vue'
+  import { ref, inject } from 'vue'
   import * as yup from 'yup'
+
+  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   defineOptions({ name: 'edit-edge-firewall' })
   const emit = defineEmits(['updatedFirewall'])
@@ -35,6 +38,15 @@
     await onSubmit()
     emit('updatedFirewall', values)
   }
+
+  const handleTrackSuccessEdit = () => {
+    tracker.product
+      .productEdited({
+        productName: 'Edge Firewall',
+        tab: 'mainSettings'
+      })
+      .track()
+  }
 </script>
 
 <template>
@@ -46,6 +58,7 @@
       :updatedRedirect="updatedRedirect"
       disableRedirect
       :isTabs="true"
+      @on-edit-success="handleTrackSuccessEdit"
     >
       <template #form>
         <FormFieldsEdgeFirewall

--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -20,7 +20,7 @@
     :loadService="loadService"
     :editService="editService"
     :schema="validationSchema"
-    @onSuccess="emit('onSuccess')"
+    @onSuccess="handleSuccessEdit"
     :showBarGoBack="true"
     @onError="closeDrawerEdit"
     title="Edit Instance"
@@ -32,12 +32,14 @@
 </template>
 
 <script setup>
-  import { ref, onMounted, computed } from 'vue'
+  import { ref, onMounted, computed, inject } from 'vue'
   import * as yup from 'yup'
   import CreateDrawerBlock from '@templates/create-drawer-block'
   import FormFieldsDrawerFunction from '@/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions'
   import EditDrawerBlock from '@templates/edit-drawer-block'
   import { refDebounced } from '@vueuse/core'
+  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   defineOptions({ name: 'drawer-origin' })
 
@@ -107,6 +109,20 @@
       functionID: selectedFunctionToEdit.value
     })
     return functions
+  }
+
+  const handleSuccessEdit = () => {
+    emit('onSuccess')
+    handleTrackSuccessEdit()
+  }
+
+  const handleTrackSuccessEdit = () => {
+    tracker.product
+      .productEdited({
+        productName: 'Edge Firewall',
+        tab: 'functions'
+      })
+      .track()
   }
 
   const openDrawerCreate = () => {

--- a/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
+++ b/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
@@ -4,8 +4,11 @@
   import FormFieldsEdgeFirewallRulesEngine from '../FormFields/FormFieldsEdgeFirewallRulesEngine.vue'
   import { refDebounced } from '@vueuse/core'
   import * as yup from 'yup'
-  import { onMounted, ref } from 'vue'
+  import { onMounted, ref, inject } from 'vue'
   import { useToast } from 'primevue/usetoast'
+
+  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   defineOptions({
     name: 'edge-application-cache-settings-drawer'
@@ -134,7 +137,17 @@
 
   const handleEditWithSuccess = () => {
     emit('onSuccess')
+    handleTrackSuccessEdit()
     closeEditDrawer()
+  }
+
+  const handleTrackSuccessEdit = () => {
+    tracker.product
+      .productEdited({
+        productName: 'Edge Firewall',
+        tab: 'rulesEngine'
+      })
+      .track()
   }
 
   const listFunctionsServiceWithDecorator = async () => {


### PR DESCRIPTION
## Pull Request
[UXE-2081]

### What is the new behavior introduced by this PR?
feat: add event tracker in edit edge firewall

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1438" alt="Captura de Tela 2024-05-09 às 12 55 52" src="https://github.com/aziontech/azion-console-kit/assets/110847590/f419a7d8-3985-4b84-a3c8-6aba48addc03">
<img width="1438" alt="Captura de Tela 2024-05-09 às 12 57 03" src="https://github.com/aziontech/azion-console-kit/assets/110847590/306b307f-d48f-4a32-b17f-ac54c93ee665">
<img width="1438" alt="Captura de Tela 2024-05-09 às 12 57 33" src="https://github.com/aziontech/azion-console-kit/assets/110847590/71a20826-8a67-41c5-8a64-74f15561d21c">

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2081]: https://aziontech.atlassian.net/browse/UXE-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ