### PR TITLE
[UXE-3179] refactor: change deploy timer to persist when the page is reloaded

### DIFF
--- a/src/stores/deploy.js
+++ b/src/stores/deploy.js
@@ -1,16 +1,26 @@
 import { defineStore } from 'pinia'
 
 export const useDeploy = defineStore('deploy', {
-  state: () => ({ applicationName: '' }),
+  state: () => ({ 
+    applicationName: '' ,
+    startTime: null
+  }),
   getters: {
-    getApplicationName: (state) => state.applicationName
+    getApplicationName: (state) => state.applicationName,
+    getStartTime: (state) => state.startTime,
   },
   actions: {
     addApplicationName(applicationName) {
       this.applicationName = applicationName
     },
+    addStartTime() {
+      this.startTime = Date.now()
+    },
     removeApplicationName() {
       this.applicationName = ''
+    },
+    removeStartTime() {
+      this.startTime = null
     }
   },
   persist: true

--- a/src/stores/deploy.js
+++ b/src/stores/deploy.js
@@ -1,13 +1,13 @@
 import { defineStore } from 'pinia'
 
 export const useDeploy = defineStore('deploy', {
-  state: () => ({ 
-    applicationName: '' ,
+  state: () => ({
+    applicationName: '',
     startTime: null
   }),
   getters: {
     getApplicationName: (state) => state.applicationName,
-    getStartTime: (state) => state.startTime,
+    getStartTime: (state) => state.startTime
   },
   actions: {
     addApplicationName(applicationName) {

--- a/src/templates/template-engine-block/index.vue
+++ b/src/templates/template-engine-block/index.vue
@@ -499,6 +499,7 @@
       if (formTools.value?.values?.application_name) {
         deployStore.addApplicationName(formTools.value.values.application_name)
       }
+      deployStore.addStartTime()
       emit('instantiate', response)
     } catch (error) {
       toast.add({

--- a/src/views/CreateNew/DeployView.vue
+++ b/src/views/CreateNew/DeployView.vue
@@ -159,15 +159,15 @@
   })
 
   const deployStore = useDeploy()
-
   const executionId = ref('')
   const applicationName = ref('')
+  const deployStartTime = ref()
+  const intervalRef = ref()
   const route = useRoute()
   const router = useRouter()
   const toast = useToast()
   const results = ref()
   const timer = ref(0)
-  const intervalRef = ref()
   const deployFailed = ref(false)
   const solutionStore = useSolutionStore()
   const failMessage =
@@ -194,6 +194,7 @@
   const handleFinish = async () => {
     try {
       const response = await props.getResultsService(route.params.id)
+      deployStore.removeStartTime()
       results.value = response.result
       toast.add({
         closable: true,
@@ -300,11 +301,15 @@
   }
 
   onMounted(() => {
+    executionId.value = route.params.id
+    applicationName.value = deployStore.getApplicationName
+    deployStartTime.value = deployStore.getStartTime
+    const MILISEC_IN_SEC = 1000
+    const startingTime = Math.trunc((Date.now() - deployStartTime.value)/MILISEC_IN_SEC)
+    timer.value = startingTime
     intervalRef.value = setInterval(() => {
       timer.value += 1
     }, 1000)
-    executionId.value = route.params.id
-    applicationName.value = deployStore.getApplicationName
   })
 
   onUnmounted(() => {

--- a/src/views/CreateNew/DeployView.vue
+++ b/src/views/CreateNew/DeployView.vue
@@ -288,6 +288,16 @@
     tracker.product.productCreated(trackerData).track()
   }
 
+  const startTimer = () => {
+    deployStartTime.value = deployStore.getStartTime
+    const MILISEC_IN_SEC = 1000
+    const timerInitialValue = Math.trunc((Date.now() - deployStartTime.value) / MILISEC_IN_SEC)
+    timer.value = timerInitialValue
+    intervalRef.value = setInterval(() => {
+      timer.value += 1
+    }, 1000)
+  }
+ 
   const retry = () => {
     router.go(-1)
   }
@@ -303,13 +313,7 @@
   onMounted(() => {
     executionId.value = route.params.id
     applicationName.value = deployStore.getApplicationName
-    deployStartTime.value = deployStore.getStartTime
-    const MILISEC_IN_SEC = 1000
-    const startingTime = Math.trunc((Date.now() - deployStartTime.value)/MILISEC_IN_SEC)
-    timer.value = startingTime
-    intervalRef.value = setInterval(() => {
-      timer.value += 1
-    }, 1000)
+    startTimer()
   })
 
   onUnmounted(() => {


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Add deploy start time to store to persist deploy timer when page is reloaded 

https://github.com/aziontech/azion-console-kit/assets/107002324/8892303d-fc12-4d9c-87c2-0e2c75e2aab0


### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
