### PR TITLE
[UXE-2891] fix: request time filter with between operator breaks the query

### DIFF
--- a/src/modules/real-time-metrics/filters/extract-filters-and-variables.js
+++ b/src/modules/real-time-metrics/filters/extract-filters-and-variables.js
@@ -133,12 +133,12 @@ function extractAnd(filters) {
         }
         params.push({
           name: `$${filters.and.meta.fieldPrefix}${andFilter}_begin`,
-          type: 'Int!',
+          type: 'Float!',
           value: begin
         })
         params.push({
           name: `$${filters.and.meta.fieldPrefix}${andFilter}_end`,
-          type: 'Int!',
+          type: 'Float!',
           value: end
         })
         variables[`${filters.and.meta.fieldPrefix}${andFilter}_begin`] = begin


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
request time filter with between operator breaks the query

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/d0a44f2d-c85b-48a9-a290-9450c7d9e8d0

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
