### PR TITLE
[UXE-3301] refactor: edge app rules engine page selectors radio and switch changed to new blocks

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -4,13 +4,14 @@
   import FieldText from '@/templates/form-fields-inputs/fieldText'
   import FieldTextArea from '@/templates/form-fields-inputs/fieldTextArea'
   import FieldDropdown from '@/templates/form-fields-inputs/fieldDropdown'
-  import PrimeRadio from 'primevue/radiobutton'
   import PrimeButton from 'primevue/button'
   import PrimeMenu from 'primevue/menu'
-  import InputSwitch from 'primevue/inputswitch'
   import InlineMessage from 'primevue/inlinemessage'
   import Divider from 'primevue/divider'
   import AutoComplete from 'primevue/autocomplete'
+  import FieldGroupRadio from '@/templates/form-fields-inputs/fieldGroupRadio'
+  import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
+
   import { computed, ref, onMounted } from 'vue'
   import { useToast } from 'primevue/usetoast'
 
@@ -196,20 +197,7 @@
   } = useFieldArray('behaviors')
   const { value: phase } = useField('phase')
   const { value: description } = useField('description')
-  const { value: isActive } = useField('isActive')
-
-  const phasesList = [
-    {
-      label: 'Request Phase',
-      value: 'request',
-      description: 'Configure the requests made to the edge.'
-    },
-    {
-      label: 'Response Phase',
-      value: 'response',
-      description: 'Configure the responses delivered to end-users.'
-    }
-  ]
+  useField('isActive')
 
   const DEFAULT_OPERATOR = {
     variable: '${uri}',
@@ -665,9 +653,18 @@
     return behaviors.value.length >= MAXIMUM_NUMBER
   })
 
-  const isNotTheSelectedPhase = (phaseItem) => {
-    return isEditDrawer.value && phaseItem !== phase.value
-  }
+  const phasesRadioOptions = computed(() => [
+    {
+      title: 'Request Phase',
+      value: 'request',
+      subtitle: 'Configure the requests made to the edge.'
+    },
+    {
+      title: 'Response Phase',
+      value: 'response',
+      subtitle: 'Configure the responses delivered to end-users.'
+    }
+  ])
 
   onMounted(() => {
     updateBehaviorsOptionsRequires()
@@ -736,31 +733,11 @@
         must create a new rule.
       </InlineMessage>
 
-      <div class="flex flex-col gap-2">
-        <template
-          v-for="item in phasesList"
-          :key="item.value"
-        >
-          <div
-            class="w-full border-1 rounded-md surface-border flex align-items-center justify-between p-4 gap-2"
-            :class="{ 'border-radio-card-active': phase === item.value }"
-          >
-            <label
-              class="font-medium"
-              :class="{ 'opacity-30': isNotTheSelectedPhase(item.value) }"
-            >
-              {{ item.label }}
-              <div class="text-color-secondary text-sm font-normal">{{ item.description }}</div>
-            </label>
-
-            <PrimeRadio
-              v-model="phase"
-              :disabled="isNotTheSelectedPhase(item.value)"
-              :value="item.value"
-            />
-          </div>
-        </template>
-      </div>
+      <FieldGroupRadio
+        nameField="phase"
+        isCard
+        :options="phasesRadioOptions"
+      />
     </template>
   </FormHorizontal>
 
@@ -1047,17 +1024,13 @@
     title="Status"
   >
     <template #inputs>
-      <div class="flex gap-3 items-center">
-        <InputSwitch
-          id="active"
-          v-model="isActive"
-        />
-        <label
-          for="active"
-          class="text-base"
-          >Active</label
-        >
-      </div>
+      <FieldSwitchBlock
+        nameField="isActive"
+        name="active"
+        auto
+        :isCard="false"
+        title="Active"
+      />
     </template>
   </FormHorizontal>
 </template>

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -177,6 +177,10 @@
   const descriptionEmptyState = computed(
     () => `Click the button below to create your first ${selectedPhase.value} rule.`
   )
+
+  const removeReorderForRequestPhaseFirstItem = computed(
+    () => selectedPhase.value === 'Response phase'
+  )
 </script>
 
 <template>
@@ -211,6 +215,7 @@
       thead: { class: !hasContentToList && 'hidden' }
     }"
     emptyListMessage="No rules have been created."
+    :isReorderAllEnabled="removeReorderForRequestPhaseFirstItem"
   >
     <template #addButton>
       <div class="flex gap-4">


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
<!-- Describe your changes in detail -->

* rules engine page selectors changed to new blocks
	* Radio
	* Switch
* solved bug in [UXE-3302](https://aziontech.atlassian.net/browse/UXE-3302) Ordering does not appear for the first item in the Response Phase listing

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.
<!-- If this PR introduces any, post some screenshots -->
<img width="887" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/109550332/26927224-edf1-4e7e-930f-4ab01dc2d1df">
<img width="887" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/109550332/5c39116b-fce5-428c-8b36-ec172872d0de">

### Does it have a link on Figma?
<!-- [Link to Figma](https://figmaexample.com) -->
[Link to Figma](https://www.figma.com/design/0TY2pcUTBsndMlrs0ZUvQf/Console-UI?node-id=10635-45389&t=nH0s5eLy1GvDX7wn-0)
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [x] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-3302]: https://aziontech.atlassian.net/browse/UXE-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ