### PR TITLE
[UXE-2934] fix: adjustment of the visualization of large fields in the picklist

### DIFF
--- a/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
+++ b/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
@@ -120,8 +120,12 @@
               class="flex flex-wrap p-2 align-items-center gap-3"
               v-if="!loading"
             >
-              <div class="flex-1 flex flex-column gap-2">
-                <span class="font-normal">{{ slotProps.item.name }}</span>
+              <div class="flex-1 flex flex-column gap-2 max-w-xs overflow-hidden">
+                <span
+                  class="font-normal truncate"
+                  v-tooltip.top="slotProps.item.name"
+                  >{{ slotProps.item.name }}</span
+                >
               </div>
             </div>
             <Skeleton


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
adjustment of the visualization of large fields in the picklist

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes 

<!-- If this PR introduces any, describe what it will break -->

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/4fa75a9a-bfab-40d6-b347-6b3f4c5f9fb6

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (fix, feat, test, etc)
- [ ] User inputs are sanitized/protected against malicious attacks
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
