### PR TITLE
[UXE-2342] refactor: rename the tittle of repurge dialog to Confirm Repurge

### DIFF
--- a/src/views/RealTimePurge/Dialog/index.vue
+++ b/src/views/RealTimePurge/Dialog/index.vue
@@ -64,7 +64,7 @@
       }"
     >
       <template #header>
-        <h5 class="text-lg not-italic font-bold leading-5">Confirme Purge</h5>
+        <h5 class="text-lg not-italic font-bold leading-5">Confirm Repurge</h5>
       </template>
       <div class="flex flex-col gap-3.5">
         <Message


### PR DESCRIPTION
## Pull Request
[UXE-2342]

### What is the new behavior introduced by this PR?
refactor: rename the tittle of repurge dialog to Confirm Repurge

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
![Captura de Tela 2024-05-22 às 18 03 58](https://github.com/aziontech/azion-console-kit/assets/110847590/7876c02f-61db-45f8-83a9-2cc5f74d4a47)

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2342]: https://aziontech.atlassian.net/browse/UXE-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ