### PR TITLE
[UXE-1784] feat: increased lines in monaco on dataStream view

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -87,7 +87,7 @@
           language="json"
           :theme="theme"
           :options="optionsMonacoEditor"
-          class="min-h-[100px] surface-border border rounded-sm overflow-hidden"
+          class="min-h-[300px] surface-border border rounded-sm overflow-hidden"
         />
         <small class="text-xs text-color-secondary font-normal leading-5">
           Exhibits or allows writing the variables that'll be sent to the connector in a JSON
@@ -622,7 +622,7 @@
             language="json"
             :theme="theme"
             :options="optionsMonacoEditor"
-            class="min-h-[100px] surface-border border rounded-md overflow-hidden"
+            class="min-h-[300px] surface-border border rounded-md overflow-hidden"
           />
           <small class="text-xs text-color-secondary font-normal leading-5">
             JSON file provided by Google Cloud used to authenticate with Google services.


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
The height of the Monaco editor has been increased to display up to 15 lines without scrolling on the data stream screen.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/cc47b8bb-8383-47af-9cbd-8f55d6e6d138)

### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
