### PR TITLE
[UXE-1784] fix: adjusted the text resizing in the horizontal form block

### DIFF
--- a/src/services/edge-functions-services/edit-edge-functions-service.js
+++ b/src/services/edge-functions-services/edit-edge-functions-service.js
@@ -43,7 +43,6 @@ const extractApiError = (httpResponse) => {
   return errorMessage
 }
 
-
 /**
  * @param {Object} httpResponse - The HTTP response object.
  * @param {Object} httpResponse.body - The response body.

--- a/src/templates/create-form-block/form-horizontal.vue
+++ b/src/templates/create-form-block/form-horizontal.vue
@@ -4,7 +4,7 @@
     :class="{ 'lg:flex-nowrap xl:py-14 xl:p-14 lg:gap-16': !isDrawer }"
   >
     <!-- title and description -->
-    <div class="flex flex-col gap-2 flex-1 w-full md:min-w-[20rem]">
+    <div class="flex flex-col gap-2 flex-1 w-full md:min-w-[15rem]">
       <div class="text-color text-xl font-medium">{{ props.title }}</div>
       <div
         class="text-color-secondary text-sm font-normal flex flex-col gap-2"

--- a/src/views/EdgeFunctions/EditView.vue
+++ b/src/views/EdgeFunctions/EditView.vue
@@ -69,7 +69,7 @@
   const handleTrackSuccessEdit = () => {
     tracker.product
       .productEdited({
-        productName: 'Edge Functions',
+        productName: 'Edge Functions'
       })
       .track()
   }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Adjusted the text resizing in the horizontal form block to prevent the UI from breaking on small screens.

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/7cb0e3b2-cbd3-40ed-9f1e-6401a2caa3b5)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
