### PR TITLE
[UXE-1709] fix: change domain name validation to only ascii caracteres

### DIFF
--- a/src/views/Domains/CreateView.vue
+++ b/src/views/Domains/CreateView.vue
@@ -7,7 +7,6 @@
       <CreateFormBlock
         :createService="createDomainService"
         :cleanFormCallback="resetForm"
-        @on-response="handleTrackCreation"
         :schema="validationSchema"
         :initialValues="initialValues"
       >
@@ -31,7 +30,7 @@
 </template>
 
 <script setup>
-  import { ref, onMounted, inject } from 'vue'
+  import { ref, onMounted } from 'vue'
   import { useToast } from 'primevue/usetoast'
 
   import CreateFormBlock from '@/templates/create-form-block'
@@ -40,14 +39,9 @@
   import FormFieldsCreateDomains from './FormFields/FormFieldsCreateDomains.vue'
   import ActionBarTemplate from '@/templates/action-bar-block/action-bar-with-teleport'
   import { TOAST_LIFE } from '@/utils/constants'
-  import { useRoute } from 'vue-router'
-  const route = useRoute()
 
   import * as yup from 'yup'
 
-  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
-
-  const tracker = inject('tracker')
   const MTLS_VERIFICATION_ENFORCE = 'enforce'
 
   const props = defineProps({
@@ -67,16 +61,6 @@
   const edgeApps = ref([])
   const digitalCertificates = ref([])
   const toast = useToast()
-
-  const handleTrackCreation = () => {
-    tracker.product
-      .productCreated({
-        productName: 'Domains',
-        createdFrom: 'singleEntity',
-        from: route.query.origin
-      })
-      .track()
-  }
 
   const requestEdgeApplications = async () => {
     edgeApps.value = await props.listEdgeApplicationsService({})

--- a/src/views/Domains/CreateView.vue
+++ b/src/views/Domains/CreateView.vue
@@ -7,6 +7,7 @@
       <CreateFormBlock
         :createService="createDomainService"
         :cleanFormCallback="resetForm"
+        @on-response="handleTrackCreation"
         :schema="validationSchema"
         :initialValues="initialValues"
       >
@@ -30,7 +31,7 @@
 </template>
 
 <script setup>
-  import { ref, onMounted } from 'vue'
+  import { ref, onMounted, inject } from 'vue'
   import { useToast } from 'primevue/usetoast'
 
   import CreateFormBlock from '@/templates/create-form-block'
@@ -39,9 +40,14 @@
   import FormFieldsCreateDomains from './FormFields/FormFieldsCreateDomains.vue'
   import ActionBarTemplate from '@/templates/action-bar-block/action-bar-with-teleport'
   import { TOAST_LIFE } from '@/utils/constants'
+  import { useRoute } from 'vue-router'
+  const route = useRoute()
 
   import * as yup from 'yup'
 
+  /**@type {import('@/plugins/adapters/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+
+  const tracker = inject('tracker')
   const MTLS_VERIFICATION_ENFORCE = 'enforce'
 
   const props = defineProps({
@@ -61,6 +67,16 @@
   const edgeApps = ref([])
   const digitalCertificates = ref([])
   const toast = useToast()
+
+  const handleTrackCreation = () => {
+    tracker.product
+      .productCreated({
+        productName: 'Domains',
+        createdFrom: 'singleEntity',
+        from: route.query.origin
+      })
+      .track()
+  }
 
   const requestEdgeApplications = async () => {
     edgeApps.value = await props.listEdgeApplicationsService({})

--- a/src/views/Domains/CreateView.vue
+++ b/src/views/Domains/CreateView.vue
@@ -105,7 +105,10 @@
   }
 
   const validationSchema = yup.object({
-    name: yup.string().required(),
+    name: yup.string().required().test('only-ascii', 'The name contains characters not accepted.', function(value) {
+      const nameRegex = /^[\x20-\x7E]+$/
+      return nameRegex.test(value)
+    }),
     active: yup.boolean(),
     cnames: yup
       .string()


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
The name field in domains form should be filled only with ascii carachteres. 

Current regex validation Redos check:
<img width="733" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/a9afc7ae-805a-4027-ac5c-aa3aa4d16417">


### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/80aa9935-e069-4b64-8583-c0f76cf97ef3">


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
