### PR TITLE
[NO-ISSUE] fix: add fixed white background to improve qr code camera readability

### DIFF
--- a/src/templates/mfa-setup-block/index.vue
+++ b/src/templates/mfa-setup-block/index.vue
@@ -41,7 +41,7 @@
             :value="qrCode?.url"
             level="H"
             :size="250"
-            class="w-[10rem] h-[10rem] sm:w-[12.5rem] sm:h-[12.5rem] rounded-md surface-border border p-2"
+            class="bg-white w-[10rem] h-[10rem] sm:w-[12.5rem] sm:h-[12.5rem] rounded-md surface-border border p-2"
           />
         </div>
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Improve camera readability. Using a white background, always is better to camera readability. Now in light or dark mode, the background of QR Code -MFA is white.
### Does this PR introduce UI changes? Add a video or screenshots here.
yes but it could not be copied and paste here, due the QR code contain  real MFA.
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
