### PR TITLE
[UXE-2214] refactor: add gap of 6 to mobile drawers in events

### DIFF
--- a/src/views/RealTimeEventsActivityHistory/Drawer/index.vue
+++ b/src/views/RealTimeEventsActivityHistory/Drawer/index.vue
@@ -52,7 +52,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="details.title"
           :date="details.ts"

--- a/src/views/RealTimeEventsDataStream/Drawer/index.vue
+++ b/src/views/RealTimeEventsDataStream/Drawer/index.vue
@@ -58,7 +58,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="details.url"
           :date="details.ts"

--- a/src/views/RealTimeEventsEdgeDNS/Drawer/index.vue
+++ b/src/views/RealTimeEventsEdgeDNS/Drawer/index.vue
@@ -52,7 +52,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="`Q Type - ${details.qtype}`"
           :date="details.ts"

--- a/src/views/RealTimeEventsEdgeFunctions/Drawer/index.vue
+++ b/src/views/RealTimeEventsEdgeFunctions/Drawer/index.vue
@@ -59,7 +59,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           title="Function Language"
           :date="details.ts"

--- a/src/views/RealTimeEventsEdgeFunctionsConsole/Drawer/index.vue
+++ b/src/views/RealTimeEventsEdgeFunctionsConsole/Drawer/index.vue
@@ -53,7 +53,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="`Line Source - ${details.lineSource}`"
           :date="details.ts"

--- a/src/views/RealTimeEventsHTTPRequests/Drawer/index.vue
+++ b/src/views/RealTimeEventsHTTPRequests/Drawer/index.vue
@@ -103,7 +103,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="details.host"
           :date="details.ts"

--- a/src/views/RealTimeEventsImageProcessor/Drawer/index.vue
+++ b/src/views/RealTimeEventsImageProcessor/Drawer/index.vue
@@ -71,7 +71,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="details.host"
           :date="details.ts"

--- a/src/views/RealTimeEventsTieredCache/Drawer/index.vue
+++ b/src/views/RealTimeEventsTieredCache/Drawer/index.vue
@@ -109,7 +109,7 @@
     title="More Details"
   >
     <template #body>
-      <div class="w-full flex flex-col gap-8">
+      <div class="w-full flex flex-col gap-8 max-md:gap-6">
         <InfoSection
           :title="details.proxyHost"
           :date="details.ts"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
add gap of 6 to mobile drawers in events

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/7a8e9774-934e-4eaa-9c72-3cb6b0ba6d7b)

### Does it have a link on Figma?
![figma](https://www.figma.com/design/0TY2pcUTBsndMlrs0ZUvQf/Console-UI?node-id=7976-165635&t=ggcH8CnB6xiI3U6W-0)
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
