### PR TITLE
[UXE-2868] fix: all types of Records limited to 3600, change to 604800

### DIFF
--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 
-// Assuming they're exported from a module called 'constants.js'
 import * as constants from '@/utils/constants'
 
 describe('Constants Test', () => {

--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -1,26 +1,22 @@
 import { describe, it, expect } from 'vitest'
 
-import {
-  CDN_MAXIMUM_TTL_MAX_VALUE,
-  CDN_MAXIMUM_TTL_MIN_VALUE,
-  TOAST_LIFE,
-  TTL_MAX_VALEU_RECORDS
-} from '@/utils/constants'
+// Assuming they're exported from a module called 'constants.js'
+import * as constants from '@/utils/constants'
 
-describe('Constants', () => {
-  it('CDN_MAXIMUM_TTL_MAX_VALUE should be 60', () => {
-    expect(CDN_MAXIMUM_TTL_MAX_VALUE).toBe(60)
-  })
+describe('Constants Test', () => {
+    it('CDN_MAXIMUM_TTL_MAX_VALUE should be 60', () => {
+        expect(constants.CDN_MAXIMUM_TTL_MAX_VALUE).toBe(60);
+    });
 
-  it('CDN_MAXIMUM_TTL_MIN_VALUE should be 3', () => {
-    expect(CDN_MAXIMUM_TTL_MIN_VALUE).toBe(3)
-  })
+    it('CDN_MAXIMUM_TTL_MIN_VALUE should be 3', () => {
+        expect(constants.CDN_MAXIMUM_TTL_MIN_VALUE).toBe(3);
+    });
 
-  it('TOAST_LIFE should be 30000', () => {
-    expect(TOAST_LIFE).toBe(30000)
-  })
+    it('TOAST_LIFE should be 30000', () => {
+        expect(constants.TOAST_LIFE).toBe(30000);
+    });
 
-  it('TTL_MAX_VALEU_RECORDS should be 604800', () => {
-    expect(TTL_MAX_VALEU_RECORDS).toBe(604800)
-  })
-})
+    it('TTL_MAX_VALEU_RECORDS should be 604800', () => {
+        expect(constants.TTL_MAX_VALUE_RECORDS).toBe(604800);
+    });
+});

--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  CDN_MAXIMUM_TTL_MAX_VALUE,
+  CDN_MAXIMUM_TTL_MIN_VALUE,
+  TOAST_LIFE,
+  TTL_MAX_VALEU_RECORDS
+} from '@/utils/constants'
+
+describe('Constants', () => {
+  it('CDN_MAXIMUM_TTL_MAX_VALUE should be 60', () => {
+    expect(CDN_MAXIMUM_TTL_MAX_VALUE).toBe(60)
+  })
+
+  it('CDN_MAXIMUM_TTL_MIN_VALUE should be 3', () => {
+    expect(CDN_MAXIMUM_TTL_MIN_VALUE).toBe(3)
+  })
+
+  it('TOAST_LIFE should be 30000', () => {
+    expect(TOAST_LIFE).toBe(30000)
+  })
+
+  it('TTL_MAX_VALEU_RECORDS should be 604800', () => {
+    expect(TTL_MAX_VALEU_RECORDS).toBe(604800)
+  })
+})

--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -4,19 +4,19 @@ import { describe, it, expect } from 'vitest'
 import * as constants from '@/utils/constants'
 
 describe('Constants Test', () => {
-    it('CDN_MAXIMUM_TTL_MAX_VALUE should be 60', () => {
-        expect(constants.CDN_MAXIMUM_TTL_MAX_VALUE).toBe(60);
-    });
+  it('CDN_MAXIMUM_TTL_MAX_VALUE should be 60', () => {
+    expect(constants.CDN_MAXIMUM_TTL_MAX_VALUE).toBe(60)
+  })
 
-    it('CDN_MAXIMUM_TTL_MIN_VALUE should be 3', () => {
-        expect(constants.CDN_MAXIMUM_TTL_MIN_VALUE).toBe(3);
-    });
+  it('CDN_MAXIMUM_TTL_MIN_VALUE should be 3', () => {
+    expect(constants.CDN_MAXIMUM_TTL_MIN_VALUE).toBe(3)
+  })
 
-    it('TOAST_LIFE should be 30000', () => {
-        expect(constants.TOAST_LIFE).toBe(30000);
-    });
+  it('TOAST_LIFE should be 30000', () => {
+    expect(constants.TOAST_LIFE).toBe(30000)
+  })
 
-    it('TTL_MAX_VALEU_RECORDS should be 604800', () => {
-        expect(constants.TTL_MAX_VALUE_RECORDS).toBe(604800);
-    });
-});
+  it('TTL_MAX_VALEU_RECORDS should be 604800', () => {
+    expect(constants.TTL_MAX_VALUE_RECORDS).toBe(604800)
+  })
+})

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,4 @@
 export const CDN_MAXIMUM_TTL_MAX_VALUE = 60
 export const CDN_MAXIMUM_TTL_MIN_VALUE = 3
 export const TOAST_LIFE = 30000
+export const TTL_MAX_VALEU_RECORDS = 604800

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
 export const CDN_MAXIMUM_TTL_MAX_VALUE = 60
 export const CDN_MAXIMUM_TTL_MIN_VALUE = 3
 export const TOAST_LIFE = 30000
-export const TTL_MAX_VALEU_RECORDS = 604800
+export const TTL_MAX_VALUE_RECORDS = 604800

--- a/src/views/Domains/CreateView.vue
+++ b/src/views/Domains/CreateView.vue
@@ -131,10 +131,17 @@
   }
 
   const validationSchema = yup.object({
-    name: yup.string().required().test('only-ascii', 'Invalid characters. Use letters, numbers, and standard symbols, with no accents.', function(value) {
-      const nameRegex = /^[\x20-\x7E]+$/
-      return nameRegex.test(value)
-    }),
+    name: yup
+      .string()
+      .required()
+      .test(
+        'only-ascii',
+        'Invalid characters. Use letters, numbers, and standard symbols, with no accents.',
+        function (value) {
+          const nameRegex = /^[\x20-\x7E]+$/
+          return nameRegex.test(value)
+        }
+      ),
     active: yup.boolean(),
     cnames: yup
       .string()

--- a/src/views/EdgeDNS/EditView.vue
+++ b/src/views/EdgeDNS/EditView.vue
@@ -19,6 +19,7 @@
   import FormFieldsRecords from './FormFields/FormFieldsRecords'
   import { generateCurrentTimestamp } from '@/helpers/generate-timestamp'
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
+  import { TTL_MAX_VALEU_RECORDS } from '@/utils/constants'
 
   const props = defineProps({
     loadEdgeDNSService: { type: Function, required: true },
@@ -118,7 +119,7 @@
       .when('selectedRecordType', {
         is: RECORD_TYPE_WITHOUT_TTL,
         then: (schema) => schema.notRequired(),
-        otherwise: (schema) => schema.min(0).max(3600).required()
+        otherwise: (schema) => schema.min(0).max(TTL_MAX_VALEU_RECORDS).required()
       }),
     selectedPolicy: yup.string().required('Please select an option').default('simple'),
     weight: yup
@@ -139,7 +140,7 @@
     name: '',
     selectedRecordType: 'A',
     value: '',
-    ttl: 3600,
+    ttl: TTL_MAX_VALEU_RECORDS,
     selectedPolicy: 'simple',
     weight: '100',
     description: '',

--- a/src/views/EdgeDNS/EditView.vue
+++ b/src/views/EdgeDNS/EditView.vue
@@ -19,7 +19,7 @@
   import FormFieldsRecords from './FormFields/FormFieldsRecords'
   import { generateCurrentTimestamp } from '@/helpers/generate-timestamp'
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
-  import { TTL_MAX_VALEU_RECORDS } from '@/utils/constants'
+  import { TTL_MAX_VALUE_RECORDS } from '@/utils/constants'
 
   const props = defineProps({
     loadEdgeDNSService: { type: Function, required: true },
@@ -119,7 +119,7 @@
       .when('selectedRecordType', {
         is: RECORD_TYPE_WITHOUT_TTL,
         then: (schema) => schema.notRequired(),
-        otherwise: (schema) => schema.min(0).max(TTL_MAX_VALEU_RECORDS).required()
+        otherwise: (schema) => schema.min(0).max(TTL_MAX_VALUE_RECORDS).required()
       }),
     selectedPolicy: yup.string().required('Please select an option').default('simple'),
     weight: yup
@@ -140,7 +140,7 @@
     name: '',
     selectedRecordType: 'A',
     value: '',
-    ttl: TTL_MAX_VALEU_RECORDS,
+    ttl: TTL_MAX_VALUE_RECORDS,
     selectedPolicy: 'simple',
     weight: '100',
     description: '',

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -9,6 +9,7 @@
   import { documentationGuideProducts } from '@/helpers'
   import { useField } from 'vee-validate'
   import { computed, ref } from 'vue'
+  import { TTL_MAX_VALEU_RECORDS } from '@/utils/constants'
 
   const { value: name, errorMessage: errorName } = useField('name')
   const { value: selectedPolicy, errorMessage: errorSelectedPolicy } = useField('selectedPolicy')
@@ -191,7 +192,7 @@
             v-model="ttl"
             id="ttl"
             :min="0"
-            :max="3600"
+            :max="TTL_MAX_VALEU_RECORDS"
             :step="1"
             :class="{ 'p-invalid': errorTtl }"
           />

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -9,7 +9,7 @@
   import { documentationGuideProducts } from '@/helpers'
   import { useField } from 'vee-validate'
   import { computed, ref } from 'vue'
-  import { TTL_MAX_VALEU_RECORDS } from '@/utils/constants'
+  import { TTL_MAX_VALUE_RECORDS } from '@/utils/constants'
 
   const { value: name, errorMessage: errorName } = useField('name')
   const { value: selectedPolicy, errorMessage: errorSelectedPolicy } = useField('selectedPolicy')
@@ -192,7 +192,7 @@
             v-model="ttl"
             id="ttl"
             :min="0"
-            :max="TTL_MAX_VALEU_RECORDS"
+            :max="TTL_MAX_VALUE_RECORDS"
             :step="1"
             :class="{ 'p-invalid': errorTtl }"
           />


### PR DESCRIPTION
## Bug fix
[UXE-2868] fix: all types of Records limited to 3600, change to 604800

### Explain what was fixed and the correct behavior.

Change the maximum value of the TTL input on the records page

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/110847590/3df0a898-050b-4bd4-bee6-2b519f23b2ef


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2868]: https://aziontech.atlassian.net/browse/UXE-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ