### PR TITLE
[UXE-1709] fix: change regex from name field validation and add the same validat…

### DIFF
--- a/src/views/Domains/CreateView.vue
+++ b/src/views/Domains/CreateView.vue
@@ -138,7 +138,7 @@
         'only-ascii',
         'Invalid characters. Use letters, numbers, and standard symbols, with no accents.',
         function (value) {
-          const nameRegex = /^[\x20-\x7E]+$/
+          const nameRegex = /^[\x20-\x21\x23-\x7E]+$/
           return nameRegex.test(value)
         }
       ),

--- a/src/views/Domains/EditView.vue
+++ b/src/views/Domains/EditView.vue
@@ -133,7 +133,17 @@
 
   const validationSchema = yup.object({
     id: yup.string().required(),
-    name: yup.string().required(),
+    name: yup
+      .string()
+      .required()
+      .test(
+        'only-ascii',
+        'Invalid characters. Use letters, numbers, and standard symbols, with no accents.',
+        function (value) {
+          const nameRegex = /^[\x20-\x21\x23-\x7E]+$/
+          return nameRegex.test(value)
+        }
+      ),
     domainName: yup.string().required(),
     active: yup.boolean(),
     cnames: yup


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Change domains name field validation regex and add this validation to edit form
<img width="825" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/0db7db72-e009-4536-8b1c-4f7450d80808">

<img width="825" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/d13d8afa-073d-4710-9e03-dc504a978acf">


### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
