### PR TITLE
[UXE-1876] fix: remove then from divider and change match zone field label to si…

### DIFF
--- a/src/views/WafRules/FormFields/FormFieldsAllowed.vue
+++ b/src/views/WafRules/FormFields/FormFieldsAllowed.vue
@@ -144,9 +144,7 @@
       <Divider
         align="left"
         type="dashed"
-      >
-        Then
-      </Divider>
+      ></Divider>
       <div class="flex flex-col gap-8">
         <div
           v-for="(item, index) in matchZones"
@@ -178,7 +176,7 @@
             <label
               for="ruleid"
               class="text-color text-sm font-medium"
-              >Match Zones *</label
+              >Match Zone *</label
             >
             <Dropdown
               appendTo="self"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
In waf allowed rules drawer, the divider should not have the label then, and the match zone field label should be in singular
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/0c7fb2de-a43e-4afa-816e-32a608f4e635">


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
