### PR TITLE
[NO-ISSUE] refactor: remove text opacity from card text when selector is present

### DIFF
--- a/src/templates/form-fields-inputs/fieldGroupRadio.vue
+++ b/src/templates/form-fields-inputs/fieldGroupRadio.vue
@@ -76,6 +76,7 @@
         :key="index"
       >
         <FieldRadioBlock
+          v-show="!item.hide"
           :nameField="props.nameField"
           :name="item.name ?? `${props.nameField}-radio-${index}`"
           :auto="props.auto"

--- a/src/templates/selector-block/index.vue
+++ b/src/templates/selector-block/index.vue
@@ -13,7 +13,7 @@
         <div v-show="!hideSelector">
           <slot name="selector" />
         </div>
-        <div :class="classDisabled">
+        <div :class="{ 'p-disabled': props.disabled && hideSelector }">
           <div class="flex gap-3 items-center font-medium">
             <span
               v-if="!props.isCard"
@@ -114,9 +114,5 @@
     'border-orange-500': check.value,
     'border-orange-500/[.32]': props.disabled && check.value,
     'border rounded-md': props.isCard
-  }))
-
-  const classDisabled = computed(() => ({
-    'p-disabled': props.disabled
   }))
 </script>

--- a/src/views/RealTimePurge/FormFields/FormFieldsCreateRealTimePurge.vue
+++ b/src/views/RealTimePurge/FormFields/FormFieldsCreateRealTimePurge.vue
@@ -48,19 +48,22 @@
       {
         title: 'Cache Key',
         value: 'cachekey',
+        name: 'cachekey-purge-type',
         disabled: isDisabledPurgeTypeInTieredCache,
         subtitle: `Enter a list of content cache keys to be purged.`
       },
       {
         title: 'URL',
         value: 'url',
-        disabled: isDisabledPurgeTypeInTieredCache,
+        name: 'url-purge-type',
+        hide: isDisabledPurgeTypeInTieredCache,
         subtitle: `Enter a list of content URLs to be purged. Asterisks (*) in URLs are considered characters.`
       },
       {
         title: 'Wildcard',
         value: 'wildcard',
-        disabled: isDisabledPurgeTypeInTieredCache,
+        name: 'wildcard-purge-type',
+        hide: isDisabledPurgeTypeInTieredCache,
         subtitle: `Enter a list of content URLs to be purged. Asterisks (*) are considered wildcard expressions.`
       }
     ]


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* This commit updates the card component styles to maintain full text color intensity when a selector is included. The change enhances text readability and visual consistency across different card states.
* Hide v-show feature added to radioGroup

### Does this PR introduce breaking changes?
- [ ] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/b532a5e4-0dba-4ae4-88d8-8a6d717fee25


### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
