### PR TITLE
[UXE-2391] fix: adjusted the colors of the today color calendar

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/variables/_form.scss
+++ b/src/assets/themes/scss/themes/azion-dark/variables/_form.scss
@@ -410,7 +410,7 @@ $calendarCellDateBorderRadius: 50%;
 
 /// Border of a calendar date cell
 /// @group form
-$calendarCellDateBorder: 1px solid transparent;
+$calendarCellDateBorder: 2px solid transparent;
 
 /// Background of a calendar date cell in hover state
 /// @group form
@@ -418,15 +418,15 @@ $calendarCellDateHoverBg: rgba($primaryColor, 0.06);
 
 /// Background of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayBg: #f4f4f4;
+$calendarCellDateTodayBg: transparent;
 
 /// Border color of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayBorderColor: transparent;
+$calendarCellDateTodayBorderColor: rgba($primaryColor, 1);
 
 /// Text color of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayTextColor: #1e1e1e;
+$calendarCellDateTodayTextColor: $textColor;
 
 /// Padding of the calendar button bar
 /// @group form

--- a/src/assets/themes/scss/themes/azion-light/variables/_form.scss
+++ b/src/assets/themes/scss/themes/azion-light/variables/_form.scss
@@ -410,7 +410,7 @@ $calendarCellDateBorderRadius: 50%;
 
 /// Border of a calendar date cell
 /// @group form
-$calendarCellDateBorder: 1px solid transparent;
+$calendarCellDateBorder: 2px solid transparent;
 
 /// Background of a calendar date cell in hover state
 /// @group form
@@ -418,15 +418,15 @@ $calendarCellDateHoverBg: rgba($primaryColor, 0.06);
 
 /// Background of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayBg: #1e1e1e;
+$calendarCellDateTodayBg: transparent;
 
 /// Border color of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayBorderColor: transparent;
+$calendarCellDateTodayBorderColor: rgba($primaryColor, 1);
 
 /// Text color of a calendar date cell indicating today
 /// @group form
-$calendarCellDateTodayTextColor: #f4f4f4;
+$calendarCellDateTodayTextColor: $textColor;
 
 /// Padding of the calendar button bar
 /// @group form


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Alterado o estilo da célula de today nos calendários afim de garantir todos os estados de interação quando a célula estiver sendo marcada ou desabilitada.

Foi necessário alterar o estilo que antes com o fundo preenchido para borda, para que não fosse necessário alteração em extend, assim o problema foi resolvido apenas com a camada de variables do primevue.

### Does this PR introduce UI changes? Add a video or screenshots here.
**Bug:**

https://github.com/aziontech/azion-console-kit/assets/44036260/7ed8bb91-906b-4944-8870-1de556f9cc67



**Resolução:**

https://github.com/aziontech/azion-console-kit/assets/44036260/911f7646-02e8-4c4c-9998-21bd253eb7c7

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
