### PR TITLE
[UXE-3298] fix: parse load edge app service delivery protocol correctly

### DIFF
--- a/src/services/edge-application-services/load-edge-application-service.js
+++ b/src/services/edge-application-services/load-edge-application-service.js
@@ -21,10 +21,14 @@ const adapt = (httpResponse) => {
   body.https_port.forEach((port) => {
     httpsPorts.push(HTTPS_PORT_LIST_OPTIONS.find((el) => el.value == port))
   })
+
+  const isHttp3Protocol = body.delivery_protocol === 'http,https' && body.http3
+  const deliveryProtocol = isHttp3Protocol ? 'http3' : body.delivery_protocol
+
   const parsedBody = {
     id: body.id,
     name: body.name,
-    deliveryProtocol: body.delivery_protocol,
+    deliveryProtocol: deliveryProtocol,
     httpPort: httpPorts,
     httpsPort: httpsPorts,
     minimumTlsVersion: body.minimum_tls_version || 'none',


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
HTTP 3 in protocol usage did not appear in the edit when saved
* parse load edge app service delivery protocol correctly

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/109550332/f39103b1-d9af-4cf6-aa9c-5d8062d2bb91)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [ ] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
