### PR TITLE
[UXE-2869] fix: edit records in second page

### DIFF
--- a/src/services/edge-dns-records-services/load-records-service.js
+++ b/src/services/edge-dns-records-services/load-records-service.js
@@ -4,7 +4,7 @@ import { makeEdgeDNSRecordsBaseUrl } from './make-edge-dns-records-base-url'
 export const loadRecordsService = async ({ id, edgeDNSId }) => {
   const recordId = id
   let httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeEdgeDNSRecordsBaseUrl()}/${edgeDNSId}/records?id=${id}`,
+    url: `${makeEdgeDNSRecordsBaseUrl()}/${edgeDNSId}/records?page_size=200`,
     method: 'GET'
   })
 

--- a/src/tests/services/edge-dns-records-services/load-records-service.test.js
+++ b/src/tests/services/edge-dns-records-services/load-records-service.test.js
@@ -39,7 +39,7 @@ describe('EdgeDnsRecordsServices', () => {
     })
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/intelligent_dns/${edgeDNSMockId}/records?id=${dnsRecordMockId}`,
+      url: `${version}/intelligent_dns/${edgeDNSMockId}/records?page_size=200`,
       method: 'GET'
     })
   })


### PR DESCRIPTION
## Bug fix

edit records in second page

### Explain what was fixed and the correct behavior.

When the user is on the second page, they can't change

### Does this PR introduce UI changes? Add a video or screenshots here.


https://github.com/aziontech/azion-console-kit/assets/44036260/117ec964-6bc7-45fc-a528-f184109addb2



<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
