### PR TITLE
[UXE-2579] fix: adjustment in opacity of disabled elements

### DIFF
--- a/src/assets/themes/scss/themes/azion-dark/variables/_general.scss
+++ b/src/assets/themes/scss/themes/azion-dark/variables/_general.scss
@@ -74,7 +74,7 @@ $inlineSpacing: 0.5rem;
 
 /// Opacity of the disabled elements
 /// @group general
-$disabledOpacity: 0.3;
+$disabledOpacity: 0.5;
 
 /// Background of the modal layer
 /// @group general

--- a/src/assets/themes/scss/themes/azion-light/variables/_general.scss
+++ b/src/assets/themes/scss/themes/azion-light/variables/_general.scss
@@ -74,7 +74,7 @@ $inlineSpacing: 0.5rem;
 
 /// Opacity of the disabled elements
 /// @group general
-$disabledOpacity: 0.3;
+$disabledOpacity: 0.4;
 
 /// Background of the modal layer
 /// @group general


### PR DESCRIPTION
## Theme fix

Adjustment in opacity of disabled elements 

### Explain what was fixed and the correct behavior.

The opacity in disabled elements was too low, harming monitors and users with low vision. An adjustment was made to maintain identification and facilitate reading of disabled elements.

### Does this PR introduce UI changes? Add a video or screenshots here.

![image](https://github.com/aziontech/azion-console-kit/assets/44036260/05701f33-a74d-444a-aacd-59abd0a4a4ae)
![image](https://github.com/aziontech/azion-console-kit/assets/44036260/d7a24322-3abb-4a94-a1e0-9ab053ddeb15)


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
