### PR TITLE
[UXE-3296] fix: ensure image optimization option is passed to rules engine edit

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/Drawer/index.vue
+++ b/src/views/EdgeApplicationsRulesEngine/Drawer/index.vue
@@ -216,7 +216,7 @@
         :listOriginsService="props.listOriginsService"
         :listCacheSettingsService="props.listCacheSettingsService"
         :hideApplicationAcceleratorInDescription="props.hideApplicationAcceleratorInDescription"
-        :isImageOptimization="isImageOptimization"
+        :isImageOptimization="props.isImageOptimization"
         :isEdgeFunctionEnabled="props.isEdgeFunctionEnabled"
       />
     </template>
@@ -241,6 +241,7 @@
         :isDeliveryProtocolHttps="props.isDeliveryProtocolHttps"
         :listEdgeApplicationFunctionsService="props.listEdgeApplicationFunctionsService"
         :listOriginsService="props.listOriginsService"
+        :isImageOptimization="props.isImageOptimization"
         :listCacheSettingsService="props.listCacheSettingsService"
         :hideApplicationAcceleratorInDescription="props.hideApplicationAcceleratorInDescription"
         :isEdgeFunctionEnabled="props.isEdgeFunctionEnabled"

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -60,7 +60,7 @@
   })
 
   const isEditDrawer = computed(() => !!props.selectedRulesEngineToEdit)
-
+  const isImageOptimizationEnabled = computed(() => !!props.isImageOptimization)
   const checkPhaseIsDefaultValue = computed(() => phase.value === 'default')
 
   const toast = useToast()
@@ -275,7 +275,7 @@
   const updateOptionRequires = (options) => {
     const conditionsMap = {
       redirect_http_to_https: !props.isDeliveryProtocolHttps,
-      optimize_images: !props.isImageOptimization,
+      optimize_images: !isImageOptimizationEnabled.value,
       run_function: !props.isEdgeFunctionEnabled
     }
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
* Resolved an issue where the image optimization setting was not being correctly propagated to the edit interface of the rules engine. This fix ensures that the state of the image optimization toggle is accurately reflected when editing rules.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/95a9a55f-e919-4c27-b775-1b50c6b28c9e


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
