### PR TITLE
[UXE-2496] fix: remove send feedback from help-center footer link options

### DIFF
--- a/src/templates/help-center-block/index.vue
+++ b/src/templates/help-center-block/index.vue
@@ -270,11 +270,6 @@
       label: 'Contact Support',
       link: `${makeContactSupportUrl()}/tickets/`,
       isLinkExternal: true
-    },
-    {
-      label: 'Send Feedback',
-      link: 'mailto:feedback@azion.com',
-      isLinkExternal: false
     }
   ])
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

### Does this PR introduce UI changes? Add a video or screenshots here.
Remove from help-center footer links the 'send feedback' link, since it is moved to the application top header bar.

![image](https://github.com/aziontech/azion-console-kit/assets/101186721/3bca36dc-aa6d-4b60-8ffc-246467915a90)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
