### PR TITLE
[UXE-3394] fix: loop when trying to load the default rule engine in edge app

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -11,7 +11,7 @@
   import FieldGroupRadio from '@/templates/form-fields-inputs/fieldGroupRadio'
   import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
 
-  import { computed, ref, onMounted } from 'vue'
+  import { computed, ref, onMounted, watch } from 'vue'
   import { useToast } from 'primevue/usetoast'
 
   const props = defineProps({
@@ -44,7 +44,8 @@
       required: true
     },
     initialPhase: {
-      type: String
+      type: String,
+      default: 'default'
     },
     selectedRulesEngineToEdit: {
       type: Object,
@@ -262,7 +263,9 @@
     response: () => behaviorsResponseOptions.value
   }
 
-  const behaviorsOptions = computed(() => behaviorsOptionsMap[phase.value]() || [])
+  const behaviorsOptions = computed(() => {
+    return behaviorsOptionsMap[phase.value]() || []
+  })
 
   /**
    * Updates the 'requires' property of behavior options based on component props.
@@ -403,7 +406,9 @@
 
     let targetValue = behaviors.value[index].value.target
     if (!isEditDrawer.value) targetValue = ''
-    if (typeof targetValue == 'object' && Object.keys(targetValue).length === 0) targetValue = ''
+    if (targetValue && typeof targetValue == 'object' && Object.keys(targetValue).length === 0) {
+      targetValue = ''
+    }
 
     updateBehavior(index, { name: behaviorName, target: targetValue })
     setShowNewBehaviorButton(true)
@@ -578,18 +583,26 @@
     return behaviors.value.length >= MAXIMUM_NUMBER
   })
 
-  const phasesRadioOptions = [
-    {
-      title: 'Request Phase',
-      value: 'request',
-      subtitle: 'Configure the requests made to the edge.'
-    },
-    {
-      title: 'Response Phase',
-      value: 'response',
-      subtitle: 'Configure the responses delivered to end-users.'
+  const phasesRadioOptions = ref([])
+
+  watch(checkPhaseIsDefaultValue, () => {
+    if (!checkPhaseIsDefaultValue.value) {
+      phasesRadioOptions.value = [
+        {
+          title: 'Request Phase',
+          value: 'request',
+          subtitle: 'Configure the requests made to the edge.'
+        },
+        {
+          title: 'Response Phase',
+          value: 'response',
+          subtitle: 'Configure the responses delivered to end-users.'
+        }
+      ]
+    } else {
+      phasesRadioOptions.value = []
     }
-  ]
+  })
 
   onMounted(() => {
     updateBehaviorsOptionsRequires()


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
the loop was fixed when trying to open the drawer of a rule engine that was of the default rule type

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/4ceaf03a-9a39-4a4c-9bca-47c4483e9c8e


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
