### PR TITLE
[UXE-2266] fix: add meta tag user-scale to avoid zoom-in when user clicks on form fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
     />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
+    
     <title>Azion Console</title>
 
     <!-- Font preloads -->


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Now, when the user interacts with a form field that has a font size of less than 16px, the browser will not zoom in to the form field.

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/6d5191b4-788d-4a10-b458-f6e4e697a788)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
