### PR TITLE
[UXE-1871] refactor: account settings infinite loading in city and region fields

### DIFF
--- a/src/views/AccountSettings/FormFields/FormFieldsAccountSettings.vue
+++ b/src/views/AccountSettings/FormFields/FormFieldsAccountSettings.vue
@@ -7,7 +7,7 @@
   import TextArea from 'primevue/textarea'
   import { useToast } from 'primevue/usetoast'
   import { useField } from 'vee-validate'
-  import { onMounted, ref, watch } from 'vue'
+  import { onMounted, ref, watch, computed } from 'vue'
   import { TOAST_LIFE } from '@/utils/constants'
 
   const props = defineProps({
@@ -103,20 +103,41 @@
     }
   }
 
-  watch(country, (value) => {
-    setRegionsOptions(value)
-  })
+  watch(
+    [country, countriesOptions.value],
+    (value) => {
+      const countryId = value[0]
 
-  watch(region, (value) => {
-    if (value) {
-      setCitiesOptions(value)
-    }
-  })
+      if (countryId && countriesOptions.value.options.length) {
+        setRegionsOptions(countryId)
+      }
+    },
+    { deep: true }
+  )
+
+  watch(
+    [region, regionsOptions.value],
+    (value) => {
+      const regionId = value[0]
+
+      if (regionId && regionsOptions.value.options.length) {
+        setCitiesOptions(regionId)
+      }
+    },
+    { deep: true }
+  )
 
   const resetRegionAndCity = () => {
     region.value = ''
     city.value = ''
   }
+
+  const hasNoCountryListOrNotSelected = computed(
+    () => !countriesOptions.value.options.length || !country.value
+  )
+  const hasNoRegionListOrNotSelected = computed(
+    () => !citiesOptions.value.options.length || !region.value
+  )
 </script>
 
 <template>
@@ -309,6 +330,7 @@
             :options="regionsOptions.options"
             v-model="region"
             :loading="!regionsOptions.done"
+            :disabled="hasNoCountryListOrNotSelected"
           />
           <small class="text-xs text-color-secondary font-normal leading-5">
             Account owner's state or region.
@@ -337,6 +359,7 @@
             v-model="city"
             :class="{ 'p-invalid': cityError }"
             :loading="!citiesOptions.done"
+            :disabled="hasNoRegionListOrNotSelected"
           />
           <small class="text-xs text-color-secondary font-normal leading-5">
             Account owner's city.


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
* Now, the subsequent field remains disabled, waiting for the previous field to be filled.
 
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/fdf8a6c1-6dce-4b9b-8157-154439b6d95e


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
