### PR TITLE
[UXE-3307] fix: it is closing the drawer when an error occurs

### DIFF
--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -113,6 +113,7 @@
   }
 
   const handleSuccessEdit = () => {
+    showEditFunctionDrawer.value = false
     emit('onSuccess')
     handleTrackSuccessEdit()
   }
@@ -155,7 +156,6 @@
 
   const closeDrawerEdit = (error) => {
     handleFailedEditEdgeFirewallFunctions(error)
-    showEditFunctionDrawer.value = false
   }
 
   const handleCreateFunction = () => {


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-3307] fix: it is closing the drawer when an error occurs
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/110847590/57b1d771-099e-4827-a15e-bcefffac43dd


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-3307]: https://aziontech.atlassian.net/browse/UXE-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ