### PR TITLE
[NO-ISSUE] fix: ensure to create edge firewall with correct params with custom response rule engine

### DIFF
--- a/src/services/edge-firewall-rules-engine-services/create-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/create-edge-firewall-rules-engine-service.js
@@ -49,9 +49,11 @@ const parseBehaviors = (behaviors) => {
       case 'set_custom_response':
         return {
           name: behavior.name,
-          status_code: behavior.status_code,
-          content_type: behavior.content_type,
-          content_body: behavior.content_body
+          argument: {
+            status_code: behavior.status_code,
+            content_type: behavior.content_type,
+            content_body: behavior.content_body
+          }
         }
       default:
         return {

--- a/src/services/edge-firewall-rules-engine-services/edit-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/edit-edge-firewall-rules-engine-service.js
@@ -49,9 +49,11 @@ const parseBehaviors = (behaviors) => {
       case 'set_custom_response':
         return {
           name: behavior.name,
-          status_code: behavior.status_code,
-          content_type: behavior.content_type,
-          content_body: behavior.content_body
+          argument: {
+            status_code: behavior.status_code,
+            content_type: behavior.content_type,
+            content_body: behavior.content_body
+          }
         }
       default:
         return {


### PR DESCRIPTION

## Bug fix

### Explain what was fixed and the correct behavior.
When creating an rule engine in edge firewall product, the payload related to the behavior "set custom response" is now correctly passed inside a object property "argument". This will fix the create and edit service for edge firewall rules engine journey.
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/101186721/5012a0ea-c813-4a7d-b8f0-5528c6dc5e70


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
