### PR TITLE
[UXE-2859] fix: releasing behavior selection in the default rule

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -844,7 +844,6 @@
               :value="behaviors[behaviorIndex].value.name"
               inputClass="w-full"
               @onChange="(newValue) => changeBehaviorType(newValue, behaviorIndex)"
-              :disabled="checkPhaseIsDefaultValue && behaviorItem.key === 0"
             />
           </div>
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
show enabled the  behavior section fields in the default rule to enable to user edit an default rule.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/92529166/dc03b5d7-272a-4974-83f8-69a3e8e635af


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
