### PR TITLE
[UXE-3264] fix: issues with checkbox disabled, tag in radio and empty list in real time purge

### DIFF
--- a/src/services/real-time-purge/list-real-time-purge-service.js
+++ b/src/services/real-time-purge/list-real-time-purge-service.js
@@ -48,7 +48,7 @@ const MAPTYPE = {
 }
 
 const adapt = (httpResponse) => {
-  const requestData = httpResponse.body.data.activityHistoryEvents.map((item, index) => {
+  const requestData = httpResponse.body.data?.activityHistoryEvents.map((item, index) => {
     const id = `${item.ts}-${index}`
     const [, type] = item.resourceType.split(':')
     const { items, layer } = JSON.parse(JSON.parse(item.requestData))

--- a/src/templates/form-fields-inputs/fieldCheckboxBlock.vue
+++ b/src/templates/form-fields-inputs/fieldCheckboxBlock.vue
@@ -97,7 +97,7 @@
   }
 
   const clickCard = (event) => {
-    if (props.binary) {
+    if (props.binary && !props.disabled) {
       stopPropagation(event)
       handleChange(!inputValue.value)
       return

--- a/src/templates/form-fields-inputs/fieldGroupRadio.vue
+++ b/src/templates/form-fields-inputs/fieldGroupRadio.vue
@@ -86,7 +86,7 @@
           @onRadioChange="emit('onRadioChange', item.value)"
         >
           <template #footer>
-            <slot :item="item" />
+            <slot name="footer" :item="item" />
           </template>
         </FieldRadioBlock>
         <PrimeDivider

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -387,7 +387,7 @@
   }
 
   watch(data, (currentState) => {
-    const hasData = currentState.length > 0
-    emit('on-load-data', hasData)
+    const hasData = currentState?.length > 0
+    emit('on-load-data', !!hasData)
   })
 </script>

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -111,8 +111,8 @@
   const layerFileOptimizationRadioOptions = computed(() => [
     {
       title: 'Edge Cache',
-      value: false,
-      disabled: l2CachingEnabled.value,
+      value: true,
+      disabled: showSliceConfigurationRange.value,
       nameField: 'isSliceEdgeCachingEnabled',
       binary: true
     },
@@ -221,10 +221,16 @@
   })
 
   watch(l2CachingEnabled, (value) => {
-    cdnCacheSettings.value = value ? 'override' : cdnCacheSettings.value
-    isSliceEdgeCachingEnabled.value = value
-    sliceConfigurationEnabled.value = value
-    isSliceL2CachingEnabled.value = !value
+    emit('l2-caching-enabled', value)
+
+    if (value) {
+      cdnCacheSettings.value = 'override'
+      isSliceEdgeCachingEnabled.value = true
+      sliceConfigurationEnabled.value = true
+      return
+    }
+
+    isSliceL2CachingEnabled.value = false
 
     const hasNotApplicationAcceleratorAndExceedMinimumValue =
       !props.isEnableApplicationAccelerator &&
@@ -233,8 +239,10 @@
     if (!value && hasNotApplicationAcceleratorAndExceedMinimumValue) {
       cdnCacheSettingsMaximumTtl.value = CDN_MAXIMUM_TTL_MAX_VALUE
     }
+  })
 
-    emit('l2-caching-enabled', value)
+  watch(sliceConfigurationEnabled, (value) => {
+    isSliceEdgeCachingEnabled.value = value
   })
 </script>
 
@@ -383,7 +391,9 @@
         :isCard="false"
         title="Active"
       />
+
       <FieldGroupCheckbox
+        v-if="showSliceConfigurationRange"
         label="Layer"
         :options="layerFileOptimizationRadioOptions"
         :isCard="false"

--- a/src/views/RealTimePurge/FormFields/FormFieldsCreateRealTimePurge.vue
+++ b/src/views/RealTimePurge/FormFields/FormFieldsCreateRealTimePurge.vue
@@ -1,6 +1,7 @@
 <script setup>
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
   import PrimeTextarea from 'primevue/textarea'
+  import PrimeTag from 'primevue/tag'
   import { useField } from 'vee-validate'
   import { computed, watch } from 'vue'
   import FieldGroupRadio from '@/templates/form-fields-inputs/fieldGroupRadio'
@@ -41,29 +42,33 @@
     }
   ]
 
-  const purgeTypeRadioOptions = computed(() => {
-    const isDisabledPurgeTypeInTieredCache = layer.value === 'tiered_cache'
+  const isLayerTieredCache = computed(() => layer.value === 'tiered_cache')
 
+  const purgeTypeRadioOptions = computed(() => {
     return [
       {
         title: 'Cache Key',
         value: 'cachekey',
         name: 'cachekey-purge-type',
-        disabled: isDisabledPurgeTypeInTieredCache,
-        subtitle: `Enter a list of content cache keys to be purged.`
+        disabled: isLayerTieredCache.value,
+        subtitle: `Enter a list of content cache keys to be purged.`,
+        tag: {
+          value: 'Automatically enabled in all accounts.',
+          icon: 'pi pi-lock'
+        }
       },
       {
         title: 'URL',
         value: 'url',
         name: 'url-purge-type',
-        hide: isDisabledPurgeTypeInTieredCache,
+        hide: isLayerTieredCache.value,
         subtitle: `Enter a list of content URLs to be purged. Asterisks (*) in URLs are considered characters.`
       },
       {
         title: 'Wildcard',
         value: 'wildcard',
         name: 'wildcard-purge-type',
-        hide: isDisabledPurgeTypeInTieredCache,
+        hide: isLayerTieredCache.value,
         subtitle: `Enter a list of content URLs to be purged. Asterisks (*) are considered wildcard expressions.`
       }
     ]
@@ -101,7 +106,17 @@
         nameField="purgeType"
         isCard
         :options="purgeTypeRadioOptions"
-      />
+      >
+        <template #footer="{ item }">
+          <PrimeTag
+            v-if="item?.tag && isLayerTieredCache"
+            :value="item.tag.value"
+            :icon="item.tag.icon"
+            severity="info"
+            class="mt-3"
+          />
+        </template>
+      </FieldGroupRadio>
     </template>
   </FormHorizontal>
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Fix: Address issues with checkbox, radio, and service data in Real Time Purge

This commit resolves several issues:

1. The checkbox was incorrectly toggling even when disabled. This has been fixed to ensure the checkbox remains static when disabled.

2. Adde tag to the disabled radio button in the Real Time Purge for better identification.

3. Resolved an error in the listing component that occurred when no data was received from the service. 
The component now handles empty data scenarios gracefully.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/8dd56836-6eda-42aa-b11e-b36983a7b264


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari
