### PR TITLE
[UXE-2934] fix: domain selection is adapting incorrectly

### DIFF
--- a/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
+++ b/src/views/EdgeFirewall/FormFields/FormFieldsEdgeFirewall.vue
@@ -122,7 +122,7 @@
               class="flex flex-wrap p-2 pl-0 align-items-center gap-3 max-w-xs"
               v-if="!loading"
             >
-              <div class="flex-1 flex flex-column gap-2 overflow-hidden">
+              <div class="flex-1 flex flex-column gap-2 overflow-hidden pr-2">
                 <span
                   class="font-normal truncate"
                   v-tooltip.top="slotProps.item.name"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
the domain selection field is adapting incorrectly when there are domains with long names and when there are no domains in the selection.

### Does this PR introduce UI changes? Add a video or screenshots here.

Uploading Compartilhamento de tela - 2024-06-03 10h53min47s.mp4…

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] Safari
