### PR TITLE
[UXE-2051] refactor: adjusted empty block component ui following figma

### DIFF
--- a/src/templates/empty-results-block/index.vue
+++ b/src/templates/empty-results-block/index.vue
@@ -33,13 +33,13 @@
     :class="{ 'mt-4 pb-8': inTabs }"
   >
     <div
-      class="flex flex-col p-8 gap-7 justify-center items-center rounded-md"
+      class="flex flex-col gap-5 justify-center items-center rounded-md p-8 max-md:p-3"
       :class="{ 'border surface-border': !noBorder }"
     >
       <slot name="illustration">
         <Illustration />
       </slot>
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2 max-w-4xl">
         <p class="text-center text-color text-lg font-medium leading-7">
           {{ title }}
         </p>
@@ -47,12 +47,13 @@
           {{ description }}
         </p>
       </div>
-      <div class="flex flex-col gap-5 items-center">
-        <div class="flex flex-wrap gap-2">
+      <div class="flex flex-col gap-5 items-center w-full">
+        <div class="flex flex-wrap gap-2 justify-center w-full">
           <slot name="extraActionsLeft"></slot>
           <slot name="default">
             <PrimeButton
               v-if="props.createButtonLabel"
+              class="max-md:w-full w-fit"
               severity="secondary"
               icon="pi pi-plus"
               :label="createButtonLabel"

--- a/src/templates/error-page-block/index.vue
+++ b/src/templates/error-page-block/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="py-20 px-8 self-center items-center flex flex-col gap-10">
     <slot name="illustration" />
-    <div class="flex flex-col gap-6 max-w-3xl">
+    <div class="flex flex-col gap-6 max-w-4xl">
       <h1 class="text-center text-5xl font-medium">
         {{ title }}
       </h1>

--- a/src/views/ActivityHistory/ListView.vue
+++ b/src/views/ActivityHistory/ListView.vue
@@ -21,6 +21,7 @@
         </template>
         <template #default>
           <PrimeButton
+            class="max-md:w-full w-fit"
             severity="secondary"
             label="Go to Home"
             @click="navigateToHomePage"

--- a/src/views/EdgeApplicationsCacheSettings/ListView.vue
+++ b/src/views/EdgeApplicationsCacheSettings/ListView.vue
@@ -138,6 +138,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Cache Setting"

--- a/src/views/EdgeApplicationsDeviceGroups/ListView.vue
+++ b/src/views/EdgeApplicationsDeviceGroups/ListView.vue
@@ -149,6 +149,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         @click="openCreateDeviceGroupDrawer"
         severity="secondary"
         icon="pi pi-plus"

--- a/src/views/EdgeApplicationsFunctions/ListView.vue
+++ b/src/views/EdgeApplicationsFunctions/ListView.vue
@@ -37,6 +37,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Function Instance"

--- a/src/views/EdgeApplicationsOrigins/ListView.vue
+++ b/src/views/EdgeApplicationsOrigins/ListView.vue
@@ -174,6 +174,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Origin"

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -243,6 +243,7 @@
       >
         <template #default>
           <PrimeButton
+            class="max-md:w-full w-fit"
             @click="openCreateRulesEngineDrawerByPhase"
             severity="secondary"
             icon="pi pi-plus"

--- a/src/views/EdgeDNS/EditView.vue
+++ b/src/views/EdgeDNS/EditView.vue
@@ -337,6 +337,7 @@
             >
               <template #default>
                 <PrimeButton
+                  class="max-md:w-full w-fit"
                   severity="secondary"
                   icon="pi pi-plus"
                   label="Record"

--- a/src/views/EdgeFirewallFunctions/ListView.vue
+++ b/src/views/EdgeFirewallFunctions/ListView.vue
@@ -37,6 +37,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Function Instance"

--- a/src/views/EdgeFirewallRulesEngine/ListView.vue
+++ b/src/views/EdgeFirewallRulesEngine/ListView.vue
@@ -177,6 +177,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Rules Engine"

--- a/src/views/EdgeNode/ListViewTabServices.vue
+++ b/src/views/EdgeNode/ListViewTabServices.vue
@@ -124,6 +124,7 @@
     >
       <template #default>
         <PrimeButton
+          class="max-md:w-full w-fit"
           severity="secondary"
           icon="pi pi-plus"
           label="Service"

--- a/src/views/EdgeServices/ListViewTabResources.vue
+++ b/src/views/EdgeServices/ListViewTabResources.vue
@@ -138,6 +138,7 @@
     >
       <template #default>
         <PrimeButton
+          class="max-md:w-full w-fit"
           severity="secondary"
           icon="pi pi-plus"
           label="Resource"

--- a/src/views/PersonalTokens/ListView.vue
+++ b/src/views/PersonalTokens/ListView.vue
@@ -14,7 +14,8 @@
         createPagePath="personal-tokens/create"
         @on-load-data="handleLoadData"
         :enableEditClick="false"
-        emptyListMessage="No personal tokens found." />
+        emptyListMessage="No personal tokens found."
+      />
       <EmptyResultsBlock
         v-else
         title="No personal tokens have been generated"
@@ -25,8 +26,9 @@
       >
         <template #illustration>
           <Illustration />
-        </template> </EmptyResultsBlock
-    ></template>
+        </template>
+      </EmptyResultsBlock>
+    </template>
   </ContentBlock>
 </template>
 

--- a/src/views/RealTimeEventsDataStream/ListView.vue
+++ b/src/views/RealTimeEventsDataStream/ListView.vue
@@ -146,6 +146,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Data Stream"

--- a/src/views/RealTimeEventsEdgeDNS/ListView.vue
+++ b/src/views/RealTimeEventsEdgeDNS/ListView.vue
@@ -141,6 +141,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Edge DNS"

--- a/src/views/RealTimeEventsEdgeFunctions/ListView.vue
+++ b/src/views/RealTimeEventsEdgeFunctions/ListView.vue
@@ -139,6 +139,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Edge Functions"

--- a/src/views/RealTimeEventsEdgeFunctionsConsole/ListView.vue
+++ b/src/views/RealTimeEventsEdgeFunctionsConsole/ListView.vue
@@ -155,6 +155,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         label="Edge Functions"
         @click="goToEdgeFunction"

--- a/src/views/RealTimeEventsHTTPRequests/ListView.vue
+++ b/src/views/RealTimeEventsHTTPRequests/ListView.vue
@@ -138,6 +138,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Edge Application"
@@ -146,6 +147,7 @@
     </template>
     <template #extraActionsRight>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="WAF"

--- a/src/views/RealTimeEventsImageProcessor/ListView.vue
+++ b/src/views/RealTimeEventsImageProcessor/ListView.vue
@@ -141,6 +141,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         label="Edge Application"
         @click="goToEdgeApplication"

--- a/src/views/WafRules/ListWafRulesAllowed.vue
+++ b/src/views/WafRules/ListWafRulesAllowed.vue
@@ -30,12 +30,14 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         label="Create from Tuning"
         @click="goToWafRulesTuning"
       >
       </PrimeButton>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Allowed Rule"

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -67,6 +67,7 @@
   >
     <template #default>
       <PrimeButton
+        class="max-md:w-full w-fit"
         severity="secondary"
         icon="pi pi-plus"
         label="Domain"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Adjusted the UI of the empty block component following figma, and the width of the buttons in the mobile version

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/8eb2c274-e1b8-4109-acd5-220fdf3417f3)
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/07068cc2-eda5-459c-ab54-554458e4420d)

### Does it have a link on Figma?
[Figma](https://www.figma.com/design/y7j6SxH5xXZWQPwRa8igsO/Console-Kit-Blocks?node-id=1-12528&t=xlD3LYZhij5N0dBu-4)
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
