### PR TITLE
[UXE-2500] fix: add font-medium in waf drawer and big number block

### DIFF
--- a/src/templates/info-drawer-block/info-labels/big-number.vue
+++ b/src/templates/info-drawer-block/info-labels/big-number.vue
@@ -22,7 +22,7 @@
 
 <template>
   <div class="flex flex-col w-full">
-    <label class="flex text-sm gap-1 items-center">
+    <label class="flex text-sm gap-1 items-center font-medium">
       {{ props.label }}
 
       <span class="just-hover">

--- a/src/views/WafRules/Drawer/index.vue
+++ b/src/views/WafRules/Drawer/index.vue
@@ -154,7 +154,7 @@
         <div class="flex flex-col sm:flex-row w-full gap-3 sm:gap-8">
           <div class="w-full sm:w-1/2 flex flex-col gap-3">
             <div class="flex justify-between w-full gap-3">
-              <span class="w-1/2 text-color">Domain</span>
+              <span class="w-1/2 text-color font-medium">Domain</span>
               <div class="flex flex-col w-1/2">
                 <span
                   class="w-full text-color-secondary break-all"
@@ -165,17 +165,17 @@
               </div>
             </div>
             <div class="flex justify-between w-full gap-3">
-              <span class="w-1/2 text-color">IP Address</span>
+              <span class="w-1/2 text-color font-medium">IP Address</span>
               <span class="w-1/2 text-color-secondary"></span>
             </div>
           </div>
           <div class="w-full sm:w-1/2 flex flex-col gap-3">
             <div class="flex justify-between w-full gap-3">
-              <span class="w-1/2 text-color">Network List</span>
+              <span class="w-1/2 text-color font-medium">Network List</span>
               <span class="w-1/2 text-color-secondary">{{ netWorkList }}</span>
             </div>
             <div class="flex justify-between w-full gap-3">
-              <span class="w-1/2 text-color">Country</span>
+              <span class="w-1/2 text-color font-medium">Country</span>
               <span class="w-1/2 text-color-secondary"></span>
             </div>
           </div>
@@ -233,7 +233,7 @@
                   <div class="flex flex-col sm:flex-row gap-3 sm:gap-8">
                     <div class="flex w-full sm:w-1/2 flex-col gap-3">
                       <div class="w-full flex justify-between">
-                        <div class="w-1/2 flex flex-col text-color">
+                        <div class="w-1/2 flex flex-col text-color font-medium">
                           <span>Top 10 IPs Address</span>
                         </div>
                         <div class="flex w-1/2 flex-col text-color-secondary">
@@ -245,7 +245,7 @@
                         </div>
                       </div>
                       <div class="flex justify-between">
-                        <div class="flex flex-col text-color w-1/2">
+                        <div class="flex flex-col text-color font-medium w-1/2">
                           <span>Top 10 Paths</span>
                         </div>
                         <div class="flex flex-col w-1/2">
@@ -264,7 +264,7 @@
                     </div>
                     <div class="flex w-full sm:w-1/2 flex-col gap-3">
                       <div class="w-full flex justify-between">
-                        <div class="flex w-1/2 flex-col text-color">
+                        <div class="flex w-1/2 flex-col text-color font-medium">
                           <span>Top 10 Countries</span>
                         </div>
                         <div class="flex w-1/2 flex-col text-color-secondary">
@@ -276,7 +276,7 @@
                         </div>
                       </div>
                       <div class="w-full flex justify-between">
-                        <div class="flex w-1/2 gap-3 flex-col text-color">
+                        <div class="flex w-1/2 gap-3 flex-col text-color font-medium">
                           <span>Total Hits</span>
                           <span>Total IPs</span>
                           <span>Total Countries</span>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

[UXE-2500] fix: add font-medium in waf drawer and big number block

### Does this PR introduce UI changes? Add a video or screenshots here.

<img width="1440" alt="Captura de Tela 2024-06-04 às 16 19 31" src="https://github.com/aziontech/azion-console-kit/assets/110847590/ca4ffead-320b-4f9e-af6c-644376a70bbf">


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2500]: https://aziontech.atlassian.net/browse/UXE-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ