### PR TITLE
[UXE-2265] fix: add class to prevent line break in breadcrumb

### DIFF
--- a/src/templates/page-heading-block-tabs/index.vue
+++ b/src/templates/page-heading-block-tabs/index.vue
@@ -4,6 +4,9 @@
       :home="generateHomeBreadCrumb"
       :model="generateBreadCrumbs"
       class="-ml-1.5"
+      :pt="{
+        label: { class: 'whitespace-nowrap' }
+      }"
     />
     <div class="flex flex-wrap w-full py-4 items-end justify-between">
       <div

--- a/src/templates/page-heading-block/index.vue
+++ b/src/templates/page-heading-block/index.vue
@@ -4,6 +4,9 @@
       :home="generateHomeBreadCrumb"
       :model="breadcrumbs.items"
       class="-ml-1.5 overflow-auto w-full"
+      :pt="{
+        label: { class: 'whitespace-nowrap' }
+      }"
     />
     <div class="flex w-full py-4 items-center justify-between flex-wrap gap-3">
       <div


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
The "whitespace-nowrap" class was added to avoid line breaks in the breadcrumb in older mobile applications

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/76f62d8d-d4c2-4ef4-86b4-d723897881b3)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
