### PR TITLE
[UXE-2396] fix: add scroll when tabs are bigger than screen

### DIFF
--- a/src/views/RealTimeMetrics/blocks/dashboard-panel-block.vue
+++ b/src/views/RealTimeMetrics/blocks/dashboard-panel-block.vue
@@ -62,7 +62,7 @@
 <template>
   <div class="flex flex-column mt-8 gap-4">
     <SelectButton
-      class="w-fit"
+      class="w-full whitespace-nowrap overflow-x-scroll"
       :modelValue="selectedDashboard"
       :options="dashboards"
       optionLabel="label"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Add scroll to navigation tabs in metrics and add nowrap to whitespaces
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="463" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/2aa9a741-39de-462f-bbe9-298873c069b1">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
