### PR TITLE
[UXE-3311] fix: add width in input filter for dropdown

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdown.vue
+++ b/src/templates/form-fields-inputs/fieldDropdown.vue
@@ -118,8 +118,9 @@
   <label
     :for="props.name"
     class="text-color text-sm font-medium leading-5"
-    >{{ props.label }} {{ labelSufix }}</label
   >
+    {{ props.label }} {{ labelSufix }}
+  </label>
   <Dropdown
     appendTo="self"
     :id="name"

--- a/src/views/Users/FormsFields/FormFieldsUsers.vue
+++ b/src/views/Users/FormsFields/FormFieldsUsers.vue
@@ -300,6 +300,11 @@
               :class="{ 'p-invalid': errorCountryCallCode }"
               class="surface-border border-r-0 w-1/4"
               v-model="countryCallCode"
+              :pt="{
+                filterInput: {
+                  class: 'w-full'
+                }
+              }"
             >
               <template #option="{ option }">
                 {{ option.label }}

--- a/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
+++ b/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
@@ -243,6 +243,11 @@
               :class="{ 'p-invalid': errorCountryCallCode }"
               class="w-2/3 surface-border border-r-0"
               v-model="selectedCountryCallCode"
+              :pt="{
+                filterInput: {
+                  class: 'w-full'
+                }
+              }"
             >
               <template #option="{ option }">
                 {{ option.label }}


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
A class named "w-full" was added to the dropdown to fix the bug affecting the search input width.

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101672576/7cc77715-4daf-474d-bc99-a05f671451ba)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
