### PR TITLE
[UXE-2397] fix: remove space between buttons when screend is medium

### DIFF
--- a/src/views/RealTimeMetrics/blocks/interval-filter-block.vue
+++ b/src/views/RealTimeMetrics/blocks/interval-filter-block.vue
@@ -160,8 +160,8 @@
 </script>
 
 <template>
-  <div class="flex flex-column gap-6 md:flex-row md:gap-6">
-    <div class="w-full md:max-w-xs max-w-full">
+  <div class="flex flex-column gap-6 md:flex-row md:gap-6 w-full">
+    <div class="w-full lg:max-w-xs max-w-full">
       <Dropdown
         appendTo="self"
         class="w-full"
@@ -174,7 +174,7 @@
       />
     </div>
     <div
-      class="w-full md:max-w-xs max-w-full"
+      class="w-full lg:max-w-xs max-w-full"
       v-if="isCustomDate"
     >
       <Calendar


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Change metrics time range selector responsiveness when screen is medium
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1006" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/6ff6ce44-40c0-4e29-b809-c900c46de539">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
