### PR TITLE
[UXE-2751] fix: ensure to display Azion SAN certificate for domains without certificate on domain list

### DIFF
--- a/src/services/domains-services/list-domains-service.js
+++ b/src/services/domains-services/list-domains-service.js
@@ -21,7 +21,7 @@ export const listDomainsService = async ({
 
 const adapt = async (httpResponse) => {
   const edgeApplications = await listEdgeApplications()
-
+  const DEFAULT_AZION_DIGITAL_CERTIFICATE = 'Azion (SAN)'
   const parsedDomains = httpResponse.body.results?.map((domain) => {
     return {
       id: domain.id,
@@ -42,7 +42,7 @@ const adapt = async (httpResponse) => {
       cnames: domain.cnames,
       edgeFirewallId: domain.edge_firewall_id,
       edgeApplicationName: getEdgeApplication(edgeApplications, domain.edge_application_id),
-      digitalCertificateId: domain.digital_certificate_id
+      digitalCertificateId: domain.digital_certificate_id || DEFAULT_AZION_DIGITAL_CERTIFICATE
     }
   })
 

--- a/src/tests/services/domains-services/list-domains-service.test.js
+++ b/src/tests/services/domains-services/list-domains-service.test.js
@@ -20,7 +20,7 @@ const fixtures = {
     cnames: ['CName 3', 'CName 4'],
     is_active: false,
     activeSort: false,
-    digital_certificate_id: '69870',
+    digital_certificate_id: null,
     edge_application_id: 'ea5678'
   },
   edgeApplicationsMock: [
@@ -104,7 +104,7 @@ describe('DomainsServices', () => {
         },
         activeSort: false,
         edgeApplicationName: fixtures.edgeApplicationsMock[1].name,
-        digitalCertificateId: fixtures.disabledDomainMock.digital_certificate_id
+        digitalCertificateId: 'Azion (SAN)'
       }
     ])
   })


### PR DESCRIPTION


## Bug fix

### Explain what was fixed and the correct behavior.
Azion console show Azion (SAN) for domain with default digital certificate. Those domains with a custom  digital certificate ( digital certificate create by the user) will show the domain ID.

### Does this PR introduce UI changes? Add a video or screenshots here.
Yes,
<img width="1403" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/101186721/b5b0adee-4d31-47a0-b14e-2e201932e18d">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
