### PR TITLE
[UXE-1673] fix: apply read only behavior edge pulse editors

### DIFF
--- a/src/views/EdgePulse/FormFields/FormFieldsDefault.vue
+++ b/src/views/EdgePulse/FormFields/FormFieldsDefault.vue
@@ -36,13 +36,20 @@
     description="The script waits until the loading event is completed before downloading and running the RUM Client. The loading event isn’t interrupted and doesn’t affect the user experience."
   >
     <template #inputs>
-      <vue-monaco-editor
-        v-model:value="defaultTagCode"
-        language="javascript"
-        :theme="theme"
-        :options="editorOptions"
-        class="min-h-[200px] overflow-clip surface-border border rounded-md"
-      />
+      <div>
+        <div class="flex flex-col gap-2">
+          <vue-monaco-editor
+            v-model:value="defaultTagCode"
+            language="javascript"
+            :theme="theme"
+            :options="editorOptions"
+            class="min-h-[200px] overflow-clip surface-border border rounded-md p-disabled"
+          />
+          <small class="text-xs text-color-secondary font-normal leading-5">
+            Cannot edit in read-only editor
+          </small>
+        </div>
+      </div>
       <div>
         <PrimeButton
           label="Copy"

--- a/src/views/EdgePulse/FormFields/FormFieldsDefault.vue
+++ b/src/views/EdgePulse/FormFields/FormFieldsDefault.vue
@@ -37,7 +37,7 @@
   >
     <template #inputs>
       <div>
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-2 w-[99.9%]">
           <vue-monaco-editor
             v-model:value="defaultTagCode"
             language="javascript"

--- a/src/views/EdgePulse/FormFields/FormFieldsTag.vue
+++ b/src/views/EdgePulse/FormFields/FormFieldsTag.vue
@@ -29,7 +29,7 @@
   >
     <template #inputs>
       <div>
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-2 w-[99.9%]">
           <vue-monaco-editor
             v-model:value="preLoadingTagCode"
             language="javascript"

--- a/src/views/EdgePulse/FormFields/FormFieldsTag.vue
+++ b/src/views/EdgePulse/FormFields/FormFieldsTag.vue
@@ -28,13 +28,20 @@
     description="The script executes before the load event is fired. Recommended when using Content Security Policy settings that prevent the use of inline JavaScript."
   >
     <template #inputs>
-      <vue-monaco-editor
-        v-model:value="preLoadingTagCode"
-        language="javascript"
-        :theme="theme"
-        :options="editorOptions"
-        class="min-h-[56px] surface-border overflow-clip border rounded-md"
-      />
+      <div>
+        <div class="flex flex-col gap-2">
+          <vue-monaco-editor
+            v-model:value="preLoadingTagCode"
+            language="javascript"
+            :theme="theme"
+            :options="editorOptions"
+            class="min-h-[56px] surface-border overflow-clip border rounded-md p-disabled"
+          />
+          <small class="text-xs text-color-secondary font-normal leading-5">
+            Cannot edit in read-only editor
+          </small>
+        </div>
+      </div>
       <div>
         <PrimeButton
           icon="pi pi-copy"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Add `p-disabled` custom class and support text to code editors in edge pulse tabs as they are read-only.

** The extra div and the w-[99.9%] were needed to handle responsiveness, as monaco editor behaves a little too strange in this aspect

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/be56e935-eb88-46b6-a301-5582f3bf8948

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
