### PR TITLE
[UXE-2647] fix: add button behavior disabled value based on latest behavior

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/return-in-computed-property -->
 <script setup>
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
   import { useField, useFieldArray } from 'vee-validate'
@@ -350,16 +351,6 @@
     }
   }
 
-  const showNewBehaviorButton = ref(true)
-
-  /**
-   * Updates the 'showNewBehaviorButton' ref.
-   * @param {boolean} isShow - Whether to show the new behavior button.
-   */
-  const setShowNewBehaviorButton = (isShow) => {
-    showNewBehaviorButton.value = isShow
-  }
-
   /**
    * Updates the 'showTargetField' property of the behavior at the specified index.
    * @param {boolean} isShow - Whether to show the target field.
@@ -379,6 +370,36 @@
       removeBehavior(index)
     }
   }
+
+  const disableAddBehaviorButtonComputed = computed(() => {
+    const MAXIMUM_NUMBER_OF_BEHAVIORS = 10
+    const disableAddBehaviorButton = true
+    const behaviorHasNotBeenLoaded = !behaviors || !behaviors.value
+    if (behaviorHasNotBeenLoaded) {
+      return disableAddBehaviorButton
+    }
+    if (behaviors.value.length === 0) {
+      return disableAddBehaviorButton
+    }
+    if (behaviors.value.length >= MAXIMUM_NUMBER_OF_BEHAVIORS) {
+      return disableAddBehaviorButton
+    }
+
+    const lastBehavior = behaviors.value[behaviors.value.length - 1]
+    const isLastBehaviorEmpty = !lastBehavior.value.name
+    if (isLastBehaviorEmpty) {
+      return disableAddBehaviorButton
+    }
+    const optionsThatDisableAddBehaviors = [
+      'deliver',
+      'redirect_to_301',
+      'redirect_to_302',
+      'deny',
+      'no_content'
+    ]
+
+    return optionsThatDisableAddBehaviors.includes(lastBehavior.value.name)
+  })
 
   /**
    * Changes the type of the behavior at the specified index and updates related properties.
@@ -411,7 +432,6 @@
     }
 
     updateBehavior(index, { name: behaviorName, target: targetValue })
-    setShowNewBehaviorButton(true)
 
     switch (behaviorName) {
       case 'run_function':
@@ -434,7 +454,6 @@
         const isAddBehaviorButtonEnabled = !disableAddBehaviorButtonOptions.includes(behaviorName)
 
         setShowBehaviorTargetField(isBehaviorTargetFieldEnabled, index)
-        setShowNewBehaviorButton(isAddBehaviorButtonEnabled)
 
         if (!isAddBehaviorButtonEnabled) {
           removeBehaviorsFromIndex(index)
@@ -576,11 +595,6 @@
   const maximumCriteriaReached = computed(() => {
     const MAXIMUM_ALLOWED = 5
     return criteria.value.length >= MAXIMUM_ALLOWED
-  })
-
-  const MaximumBehaviorsAllowed = computed(() => {
-    const MAXIMUM_NUMBER = 10
-    return behaviors.value.length >= MAXIMUM_NUMBER
   })
 
   const phasesRadioOptions = ref([])
@@ -925,20 +939,17 @@
           </div>
         </div>
       </div>
-
-      <template v-if="showNewBehaviorButton">
-        <Divider type="solid" />
-        <div>
-          <PrimeButton
-            icon="pi pi-plus-circle"
-            label="Add Behavior"
-            size="small"
-            outlined
-            :disabled="MaximumBehaviorsAllowed"
-            @click="addNewBehavior"
-          />
-        </div>
-      </template>
+      <Divider type="solid" />
+      <div>
+        <PrimeButton
+          :disabled="disableAddBehaviorButtonComputed"
+          icon="pi pi-plus-circle"
+          label="Add Behavior"
+          size="small"
+          outlined
+          @click="addNewBehavior"
+        />
+      </div>
     </template>
   </FormHorizontal>
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Add button show be enabled when the latest behavior isn't a 'final behavior'. This show behave on adding a new behavior and also removing or editing a behavior on the list.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/101186721/49d5d5d1-f5ae-4c97-9c71-0df50bdff142




<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
