### PR TITLE
[UXE-3351] fix: handle toast in submit method in your settings

### DIFF
--- a/src/services/users-services/edit-users-service.js
+++ b/src/services/users-services/edit-users-service.js
@@ -45,9 +45,10 @@ const parseHttpResponse = (httpResponse) => {
       return 'Your user has been updated'
     case 401:
       throw new Errors.InvalidApiTokenError().message
-    case 400:
+    case 400: {
       const apiError = getFirstApiError(httpResponse.body)
       throw new Error(apiError).message
+    }
     case 403:
       throw new Errors.PermissionError().message
     case 404:

--- a/src/views/YourSettings/EditView.vue
+++ b/src/views/YourSettings/EditView.vue
@@ -106,17 +106,22 @@
     return changedKeys.length === 1 && changedKeys[0] === 'email'
   }
 
+  const showEmailToast = () => {
+    showToast('info', 'We have sent you a confirmation email.', 'Confirmation email')
+  }
+
   const formSubmit = async (values) => {
     try {
       const feedback = await props.editUsersService(values)
+
       if (isEmailChangedOnly(values)) {
-        return showToast('info', 'We have sent you a confirmation email.', 'Confirmation email')
+        return showEmailToast()
       }
 
       showToast('success', feedback)
 
       if (values.email !== userData.value.email) {
-        showToast('info', 'We have sent you a confirmation email.', 'Confirmation email')
+        showEmailToast()
       }
     } catch (error) {
       showToast('error', error)

--- a/src/views/YourSettings/EditView.vue
+++ b/src/views/YourSettings/EditView.vue
@@ -16,7 +16,7 @@
             :listCountriesPhoneService="listCountriesPhoneService"
           />
         </template>
-        <template #action-bar="{ formValid, onCancel, loading, values }">
+        <template #action-bar="{ formValid, onCancel, values }">
           <ActionBarBlockWithTeleport
             @onSubmit="formSubmit(values)"
             @onCancel="onCancel"
@@ -63,6 +63,7 @@
   })
 
   const userData = ref({})
+  const loading = ref(false)
 
   const loadUser = async () => {
     userData.value = await props.loadUserService()
@@ -111,6 +112,7 @@
   }
 
   const formSubmit = async (values) => {
+    loading.value = true
     try {
       const feedback = await props.editUsersService(values)
 
@@ -125,6 +127,8 @@
       }
     } catch (error) {
       showToast('error', error)
+    } finally {
+      loading.value = false
     }
   }
   const passwordRequirementsList = ref([

--- a/src/views/YourSettings/EditView.vue
+++ b/src/views/YourSettings/EditView.vue
@@ -43,8 +43,6 @@
 
   const toast = useToast()
 
-  const currentEmail = ref('')
-
   const props = defineProps({
     loadUserService: {
       type: Function,
@@ -64,12 +62,12 @@
     }
   })
 
+  const userData = ref({})
+
   const loadUser = async () => {
-    const userData = await props.loadUserService()
+    userData.value = await props.loadUserService()
 
-    currentEmail.value = userData.email
-
-    return userData
+    return userData.value
   }
 
   const showToast = (severity, detail, summary = severity) => {
@@ -89,11 +87,35 @@
     toast.add(options)
   }
 
+  const isEmailChangedOnly = (values) => {
+    const keysToCheck = [
+      'firstName',
+      'lastName',
+      'timezone',
+      'language',
+      'countryCallCode',
+      'mobile',
+      'email',
+      'twoFactorEnabled',
+      'password',
+      'oldPassword',
+      'confirmPassword'
+    ]
+
+    const changedKeys = keysToCheck.filter((key) => values[key] !== userData.value[key])
+    return changedKeys.length === 1 && changedKeys[0] === 'email'
+  }
+
   const formSubmit = async (values) => {
     try {
       const feedback = await props.editUsersService(values)
+      if (isEmailChangedOnly(values)) {
+        return showToast('info', 'We have sent you a confirmation email.', 'Confirmation email')
+      }
+
       showToast('success', feedback)
-      if (values.email !== currentEmail.value) {
+
+      if (values.email !== userData.value.email) {
         showToast('info', 'We have sent you a confirmation email.', 'Confirmation email')
       }
     } catch (error) {


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
- Change email confirmation toast from warning to info type
- Better handling of error and success toasts
- Displays only email info toast when only email is changed 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/5d06b314-3ac8-4e87-865a-120714653ad1

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
