### PR TITLE
[UXE-3463] fix: add sortField property to status column

### DIFF
--- a/src/views/DigitalCertificates/ListView.vue
+++ b/src/views/DigitalCertificates/ListView.vue
@@ -93,6 +93,7 @@
           {
             field: 'status',
             header: 'Status',
+            sortField: 'status.content',
             type: 'component',
             component: (columnData) =>
               columnBuilder({


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Add sortField prop to `status` column in Digital Certificates list to allow sorting

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/bc05d97d-950d-4afa-91d3-a3361a451e35

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
