### PR TITLE
[UXE-3585] refactor: replace on variables product switch to use field switch block 

### DIFF
--- a/src/views/Variables/FormFields/FormFieldsVariables.vue
+++ b/src/views/Variables/FormFields/FormFieldsVariables.vue
@@ -1,13 +1,13 @@
 <script setup>
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
-  import InputSwitch from 'primevue/inputswitch'
+  import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
+
   import InputText from 'primevue/inputtext'
   import { useField } from 'vee-validate'
   defineOptions({ name: 'form-fields-variables' })
 
   const { value: key, errorMessage: keyError } = useField('key')
   const { value: value, errorMessage: valueError } = useField('value')
-  const { value: secret } = useField('secret')
 </script>
 
 <template>
@@ -65,11 +65,13 @@
         >
       </div>
       <div class="flex gap-3 items-center">
-        <InputSwitch
-          id="secret"
-          v-model="secret"
+        <FieldSwitchBlock
+          nameField="secret"
+          name="secret"
+          auto
+          :isCard="false"
+          title="Secret"
         />
-        <label for="secret">Secret</label>
       </div>
     </template>
   </FormHorizontal>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

This PR add the switch field block to variables create page to increase maintainability.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/110847590/e877785c-9eda-4145-9838-bb8a83cfffcb


### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-3585]: https://aziontech.atlassian.net/browse/UXE-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ