### PR TITLE
[UXE-3616] fix: Hide sampling section from datastreaming form

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -152,6 +152,7 @@
   <FormHorizontal
     v-if="domainOption === '1'"
     title="Sampling"
+    class="hidden"
     description="Enable this option to reduce costs of data collection and analysis."
   >
     <template #inputs>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Hide sampling section from datastreaming form
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/aziontech/azion-console-kit/assets/107002324/a77a9ea1-f939-49b4-9f19-4f5a90f8e71b">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
