### PR TITLE
[UXE-3614] fix: add button in rules engine list open the drawer by the current phase

### DIFF
--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -84,7 +84,7 @@
     const { tab } = route.params
 
     let selectedTab = tab
-    if (!tab) selectedTab = 'mainSettings'
+    if (!tab) selectedTab = 'main-settings'
 
     edgeApplication.value = await handleLoadEdgeApplication()
     verifyTab(edgeApplication.value)

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -160,9 +160,6 @@
   }
 
   const drawerRulesEngineRef = ref('')
-  const openCreateRulesEngineDrawer = () => {
-    drawerRulesEngineRef.value.openDrawerCreate()
-  }
 
   const openCreateRulesEngineDrawerByPhase = () => {
     parsePhase[selectedPhase.value]
@@ -227,7 +224,7 @@
         <PrimeButton
           icon="pi pi-plus"
           label="Rule"
-          @click="openCreateRulesEngineDrawer"
+          @click="openCreateRulesEngineDrawerByPhase"
         />
       </div>
     </template>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
* now the add button in list open the drawer by the selected phase

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/29834468-31ae-44ad-a6e6-83a861d9acd4


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari
