### PR TITLE
[UXE-3462] fix: lets encrypt certificate editing validation

### DIFF
--- a/src/helpers/azion-documentation-catalog.js
+++ b/src/helpers/azion-documentation-catalog.js
@@ -49,5 +49,7 @@ export const documentationGuideProducts = {
     openDocumentationProducts('real-time-events/#activity-history'),
   edgeServicesResources: () =>
     openDocumentationProducts('edge-orchestrator/edge-services/#resources'),
-  edgeDnsRecordTypes: () => openDocumentationProducts('secure/edge-dns/#type')
+  edgeDnsRecordTypes: () => openDocumentationProducts('secure/edge-dns/#type'),
+  generateLetsEncryptCertificate: () =>
+    openDocumentationProducts('guides/how-to-generate-a-lets-encrypt-certificate')
 }

--- a/src/router/routes/digital-certificates-routes/index.js
+++ b/src/router/routes/digital-certificates-routes/index.js
@@ -56,7 +56,8 @@ export const digitalCertificatesRoutes = {
         editDigitalCertificateService: DigitalCertificatesService.editDigitalCertificateService,
         loadDigitalCertificateService: DigitalCertificatesService.loadDigitalCertificateService,
         updatedRedirect: 'list-digital-certificates',
-        clipboardWrite: Helpers.clipboardWrite
+        clipboardWrite: Helpers.clipboardWrite,
+        documentationService: Helpers.documentationGuideProducts.generateLetsEncryptCertificate
       },
       meta: {
         breadCrumbs: [

--- a/src/tests/helpers/azion-documentation-catalog-product-guide.test.js
+++ b/src/tests/helpers/azion-documentation-catalog-product-guide.test.js
@@ -161,4 +161,15 @@ describe('AzionDocumentation', () => {
       '_blank'
     )
   })
+  it('should open Lets Encrypt Certificate guide with correct link', () => {
+    const openWindowSpy = vi.spyOn(window, 'open')
+    const { sut } = makeSut()
+
+    sut.generateLetsEncryptCertificate()
+
+    expect(openWindowSpy).toHaveBeenCalledWith(
+      `https://www.azion.com/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate`,
+      '_blank'
+    )
+  })
 })

--- a/src/views/DigitalCertificates/EditView.vue
+++ b/src/views/DigitalCertificates/EditView.vue
@@ -11,7 +11,10 @@
         :updatedRedirect="props.updatedRedirect"
       >
         <template #form>
-          <FormFieldsEditDigitalCertificates :clipboardWrite="clipboardWrite" />
+          <FormFieldsEditDigitalCertificates
+            :clipboardWrite="clipboardWrite"
+            :documentationService="documentationService"
+          />
         </template>
         <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
           <ActionBarBlockWithTeleport
@@ -50,6 +53,10 @@
     clipboardWrite: {
       type: Function,
       required: true
+    },
+    documentationService: {
+      required: true,
+      type: Function
     }
   })
 
@@ -58,6 +65,11 @@
     certificateType: yup.string(),
     csr: yup.string(),
     certificate: yup.string(),
-    privateKey: yup.string()
+    privateKey: yup.string(),
+    managed: yup
+      .boolean()
+      .isFalse(
+        `This is a Let's Encrypt™ certificate automatically created and managed by Azion and can't be edited.`
+      )
   })
 </script>

--- a/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
+++ b/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
@@ -3,11 +3,17 @@
   import PrimeTextarea from 'primevue/textarea'
   import PrimeButton from 'primevue/button'
   import InputText from 'primevue/inputtext'
+  import FieldText from '@/templates/form-fields-inputs/fieldText'
   import { useField } from 'vee-validate'
   import { ref, watch } from 'vue'
+  import Divider from 'primevue/divider'
 
   const props = defineProps({
     clipboardWrite: {
+      type: Function,
+      required: true
+    },
+    documentationService: {
       type: Function,
       required: true
     }
@@ -19,11 +25,11 @@
   }
 
   const csrCopied = ref(false)
-
-  const { value: name, errorMessage: nameError } = useField('name')
+  const { value: name } = useField('name')
   const { value: certificate, errorMessage: certificateError } = useField('certificate')
   const { value: csr, errorMessage: csrError } = useField('csr')
   const { value: certificateType } = useField('certificateType')
+  const { value: managed } = useField('managed')
   const {
     value: privateKey,
     errorMessage: privateKeyError,
@@ -35,165 +41,205 @@
     csrCopied.value = true
   }
 
+  const openDocumentation = async () => {
+    props.documentationService()
+  }
+
   watch(privateKey, (privateKeyValue) => {
     if (privateKeyValue === '') setPrivateKeyValue(undefined)
   })
 </script>
 
 <template>
-  <FormHorizontal
-    v-if="csr"
-    title="Update CSR"
-    description="Submit the CSR to a certificate authority. Once the certificate is signed, paste the PEM-encoded certificate in the respective field. The current certificate is hidden to protect sensitive information."
-  >
-    <template #inputs>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Name *</label>
-        <InputText
-          v-model="name"
-          type="text"
-          placeholder="My digital certificate"
-          :class="{ 'p-invalid': nameError }"
-        />
-        <small
-          v-if="nameError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ nameError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Certificate </label>
-        <PrimeTextarea
-          v-model="certificate"
-          :class="{ 'p-invalid': certificateError }"
-          placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
-          rows="5"
-          cols="30"
-        />
-        <small
-          v-if="certificateError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ certificateError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Certificate Signing Request (CSR) </label>
-        <PrimeTextarea
-          disabled
-          v-model="csr"
-          :class="{ 'p-invalid': csrError }"
-          rows="5"
-          cols="30"
-        />
-        <small
-          v-if="csrError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ csrError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <PrimeButton
-          class="max-sm:w-full"
-          type="button"
-          severity="secondary"
-          :label="'Copy'"
-          @click="copyCSRToclipboard"
-        />
-        <small v-if="csrCopied">Copied successfully!</small>
-      </div>
-    </template>
-  </FormHorizontal>
-  <FormHorizontal
-    v-if="!csr && certificateType === certificateTypes.EDGE_CERTIFICATE"
-    title="Update a Server Certificate"
-    description="Paste the PEM-encoded TLS X.509 certificate and private key in the respective fields to update the certificate. The current certificate and private key are hidden to protect sensitive information."
-  >
-    <template #inputs>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Name *</label>
-        <InputText
-          v-model="name"
-          type="text"
-          placeholder="My digital certificate"
-          :class="{ 'p-invalid': nameError }"
-        />
-        <small
-          v-if="nameError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ nameError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Certificate </label>
-        <PrimeTextarea
-          v-model="certificate"
-          :class="{ 'p-invalid': certificateError }"
-          placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
-          rows="5"
-          cols="30"
-        />
-        <small
-          v-if="certificateError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ certificateError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Private Key </label>
-        <PrimeTextarea
-          v-model="privateKey"
-          :class="{ 'p-invalid': privateKeyError }"
-          placeholder="For security purposes, the current private key isn't exhibited, but it was correctly registered. Paste a new private key in this field to update it."
-          rows="5"
-          cols="30"
-        />
-        <small
-          v-if="privateKeyError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ privateKeyError }}</small
-        >
-      </div>
-    </template>
-  </FormHorizontal>
+  <template v-if="managed">
+    <FormHorizontal title="Let's encrypt certificate">
+      <template #description>
+        <p>This is a Let's Encrypt™ certificate automatically created and managed by Azion.</p>
 
-  <!-- Trusted case -->
-  <FormHorizontal
-    v-if="certificateType === certificateTypes.TRUSTED"
-    title="Update Trusted CA Certificate"
-    description="Paste the PEM-encoded Trusted CA certificate in the respective field to update the certificate. The current certificate is hidden to protect sensitive information."
-  >
-    <template #inputs>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Name *</label>
-        <InputText
-          v-model="name"
-          type="text"
-          :class="{ 'p-invalid': nameError }"
-        />
-        <small
-          v-if="nameError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ nameError }}</small
-        >
-      </div>
-      <div class="flex flex-col sm:max-w-lg w-full gap-2">
-        <label>Certificate </label>
-        <PrimeTextarea
-          v-model="certificate"
-          :class="{ 'p-invalid': certificateError }"
-          placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
-          rows="5"
-          cols="30"
-        />
-        <small class="text-xs text-color-secondary font-normal leading-5"
-          >Intermediate certificates are accepted.</small
-        >
-        <small
-          v-if="certificateError"
-          class="p-error text-xs font-normal leading-tight"
-          >{{ certificateError }}</small
-        >
-      </div>
-    </template>
-  </FormHorizontal>
+        <p>
+          Azion's Certificate Manager is currently verifying if the Domain is correctly pointed by
+          CNAME in the DNS.
+        </p>
+
+        <Divider />
+
+        <div class="flex flex-wrap items-center">
+          <p>
+            If you have not yet pointed a DNS zone, please check the
+            <PrimeButton
+              link
+              class="w-fit p-0 text-sm"
+              icon-pos="right"
+              icon="pi pi-external-link"
+              label="Documentation"
+              @click="openDocumentation"
+            />
+          </p>
+        </div>
+      </template>
+      <template #inputs>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <FieldText
+            label="Name *"
+            name="name"
+            disabled
+            :value="name"
+            placeholder="My digital certificate"
+          />
+        </div>
+      </template>
+    </FormHorizontal>
+  </template>
+
+  <template v-else>
+    <FormHorizontal
+      v-if="csr"
+      title="Update CSR"
+      description="Submit the CSR to a certificate authority. Once the certificate is signed, paste the PEM-encoded certificate in the respective field. The current certificate is hidden to protect sensitive information."
+    >
+      <template #inputs>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <FieldText
+            label="Name *"
+            name="name"
+            :value="name"
+            placeholder="My digital certificate"
+          ></FieldText>
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Certificate </label>
+          <PrimeTextarea
+            v-model="certificate"
+            :class="{ 'p-invalid': certificateError }"
+            placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
+            rows="5"
+            cols="30"
+          />
+          <small
+            v-if="certificateError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ certificateError }}</small
+          >
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Certificate Signing Request (CSR) </label>
+          <PrimeTextarea
+            disabled
+            v-model="csr"
+            :class="{ 'p-invalid': csrError }"
+            rows="5"
+            cols="30"
+          />
+          <small
+            v-if="csrError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ csrError }}</small
+          >
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <PrimeButton
+            class="max-sm:w-full"
+            type="button"
+            severity="secondary"
+            :label="'Copy'"
+            @click="copyCSRToclipboard"
+          />
+          <small v-if="csrCopied">Copied successfully!</small>
+        </div>
+      </template>
+    </FormHorizontal>
+    <FormHorizontal
+      v-if="!csr && certificateType === certificateTypes.EDGE_CERTIFICATE"
+      title="Update a Server Certificate"
+      description="Paste the PEM-encoded TLS X.509 certificate and private key in the respective fields to update the certificate. The current certificate and private key are hidden to protect sensitive information."
+    >
+      <template #inputs>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Name *</label>
+          <InputText
+            v-model="name"
+            type="text"
+            placeholder="My digital certificate"
+            :class="{ 'p-invalid': nameError }"
+          />
+          <small
+            v-if="nameError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ nameError }}</small
+          >
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Certificate </label>
+          <PrimeTextarea
+            v-model="certificate"
+            :class="{ 'p-invalid': certificateError }"
+            placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
+            rows="5"
+            cols="30"
+          />
+          <small
+            v-if="certificateError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ certificateError }}</small
+          >
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Private Key </label>
+          <PrimeTextarea
+            v-model="privateKey"
+            :class="{ 'p-invalid': privateKeyError }"
+            placeholder="For security purposes, the current private key isn't exhibited, but it was correctly registered. Paste a new private key in this field to update it."
+            rows="5"
+            cols="30"
+          />
+          <small
+            v-if="privateKeyError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ privateKeyError }}</small
+          >
+        </div>
+      </template>
+    </FormHorizontal>
+
+    <!-- Trusted case -->
+    <FormHorizontal
+      v-if="certificateType === certificateTypes.TRUSTED"
+      title="Update Trusted CA Certificate"
+      description="Paste the PEM-encoded Trusted CA certificate in the respective field to update the certificate. The current certificate is hidden to protect sensitive information."
+    >
+      <template #inputs>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Name *</label>
+          <InputText
+            v-model="name"
+            type="text"
+            :class="{ 'p-invalid': nameError }"
+          />
+          <small
+            v-if="nameError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ nameError }}</small
+          >
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <label>Certificate </label>
+          <PrimeTextarea
+            v-model="certificate"
+            :class="{ 'p-invalid': certificateError }"
+            placeholder="For security purposes, the current certificate isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
+            rows="5"
+            cols="30"
+          />
+          <small class="text-xs text-color-secondary font-normal leading-5"
+            >Intermediate certificates are accepted.</small
+          >
+          <small
+            v-if="certificateError"
+            class="p-error text-xs font-normal leading-tight"
+            >{{ certificateError }}</small
+          >
+        </div>
+      </template>
+    </FormHorizontal>
+  </template>
 </template>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
- Display an message to inform to the final user that Lets Encrypt Certificates, should not be able to be edited. 
-  Ensure to block action bar submit button and display as read-only the digital certificate name field.
- Add documentation service with new Url to  the lets encrypt documentation guide.

### Does this PR introduce UI changes? Add a video or screenshots here.
YES,


![image](https://github.com/aziontech/azion-console-kit/assets/101186721/a8c4236f-c31d-4609-bdec-e8c6b8fa61e0)


https://github.com/aziontech/azion-console-kit/assets/101186721/6d17b2fc-82f4-478a-a40c-0d72e9580b8b



<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
