### PR TITLE
[UXE-3590] fix: dataset does not load custom a template in data stream

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -1351,7 +1351,9 @@
         dataSet.value = JSON.stringify(dataSetJSON, null, '\t')
       }
     } catch (exception) {
-      dataSet.value = listTemplates.value[index].template
+      if (!dataSet.value || templateID !== 'CUSTOM_TEMPLATE') {
+        dataSet.value = listTemplates.value[index].template
+      }
     }
   }
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
dataset does not load custom a template in data stream

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/d8f82dbb-d47d-4674-a856-57e9545cbae2

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
