### PR TITLE
[UXE-3462] fix: hide action bar for lets encrypt  certificate on Edit Digital Certificate view

### DIFF
--- a/src/views/DigitalCertificates/EditView.vue
+++ b/src/views/DigitalCertificates/EditView.vue
@@ -16,8 +16,9 @@
             :documentationService="documentationService"
           />
         </template>
-        <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
+        <template #action-bar="{ onSubmit, formValid, onCancel, loading, values }">
           <ActionBarBlockWithTeleport
+            v-if="!values.managed"
             @onSubmit="onSubmit"
             @onCancel="onCancel"
             :loading="loading"
@@ -31,7 +32,7 @@
 
 <script setup>
   import EditFormBlock from '@/templates/edit-form-block'
-  import ActionBarBlockWithTeleport from '@/templates/action-bar-block/action-bar-with-teleport'
+  import ActionBarBlockWithTeleport from '@/templates/action-bar-block/action-bar-with-teleport.vue'
   import ContentBlock from '@/templates/content-block'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import FormFieldsEditDigitalCertificates from './FormFields/FormFieldsEditDigitalCertificates.vue'


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
- Hide action bar on edit view for  digital certificate of type Lets Encrypt.

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/aziontech/azion-console-kit/assets/101186721/36b2108e-ed16-4f96-b22a-9e541da40cd3)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
