### PR TITLE
[UXE-3308] fix: add divider to improve user experience in rules engine

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -599,6 +599,10 @@
 
   const phasesRadioOptions = ref([])
 
+  const isLastCriteria = (criteriaIndex) => {
+    return criteriaIndex == criteria.value.length - 1
+  }
+
   watch(
     checkPhaseIsDefaultValue,
     () => {
@@ -799,8 +803,17 @@
           v-if="props.isApplicationAcceleratorEnabled && !checkPhaseIsDefaultValue"
           class="flex items-center gap-2"
         >
-          <Divider type="solid" />
-
+          <Divider
+            v-if="isLastCriteria(criteriaIndex)"
+            type="solid"
+          />
+          <Divider
+            v-else
+            align="left"
+            type="dashed"
+          >
+            And
+          </Divider>
           <PrimeButton
             v-if="isNotFirstCriteria(criteriaIndex)"
             icon="pi pi-trash"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Add `AND` divider to improve user experience while adding criteria in rules engine.

### Does this PR introduce UI changes? Add a video or screenshots here.
![Screenshot 2024-06-19 at 10 17 36](https://github.com/aziontech/azion-console-kit/assets/95643165/e2a192d5-bcdb-4739-adb1-f7556fd2e931)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
