### PR TITLE
[UXE-3594] fix: default values not load in edit data stream

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -1196,6 +1196,7 @@
   import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
   import { useField } from 'vee-validate'
   import { computed, onMounted, ref, watch } from 'vue'
+  import { useRoute } from 'vue-router'
 
   import { useAccountStore } from '@/stores/account'
 
@@ -1213,6 +1214,8 @@
       required: false
     }
   })
+
+  const route = useRoute()
 
   // Variables
   const listDataSources = ref([
@@ -1492,6 +1495,27 @@
       inputValue: '0'
     }
   ]
+
+  const setDefaultValuesWhenChangeTheEndpointInEdit = (isFirstRender) => {
+    if (route.name === 'edit-data-stream' && !isFirstRender) {
+      if (endpoint.value === 'standard') {
+        maxSize.value = 1000000
+        lineSeparator.value = '\\n'
+        payloadFormat.value = '$dataset'
+        headers.value = [{ value: '', deleted: false }]
+      }
+
+      if (endpoint.value === 's3') {
+        contentType.value = 'plain/text'
+      }
+    }
+  }
+
+  // eslint-disable-next-line id-length
+  watch(endpoint, (_, oldValue) => {
+    const isFirstRender = !oldValue
+    setDefaultValuesWhenChangeTheEndpointInEdit(isFirstRender)
+  })
 
   onMounted(() => {
     initializeFormValues()


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
default values not load in edit data stream

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/a798a26d-f10b-454c-94cd-560293be5b10

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
