### PR TITLE
[UXE-3745] fix: loop when trying to load the default rule engine in edge app

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -599,28 +599,24 @@
 
   const phasesRadioOptions = ref([])
 
-  watch(
-    checkPhaseIsDefaultValue,
-    () => {
-      if (!checkPhaseIsDefaultValue.value) {
-        phasesRadioOptions.value = [
-          {
-            title: 'Request Phase',
-            inputValue: 'request',
-            subtitle: 'Configure the requests made to the edge.'
-          },
-          {
-            title: 'Response Phase',
-            inputValue: 'response',
-            subtitle: 'Configure the responses delivered to end-users.'
-          }
-        ]
-      } else {
-        phasesRadioOptions.value = []
-      }
-    },
-    { immediate: true }
-  )
+  watch(checkPhaseIsDefaultValue, () => {
+    if (!checkPhaseIsDefaultValue.value) {
+      phasesRadioOptions.value = [
+        {
+          title: 'Request Phase',
+          inputValue: 'request',
+          subtitle: 'Configure the requests made to the edge.'
+        },
+        {
+          title: 'Response Phase',
+          inputValue: 'response',
+          subtitle: 'Configure the responses delivered to end-users.'
+        }
+      ]
+    } else {
+      phasesRadioOptions.value = []
+    }
+  })
 
   onMounted(async () => {
     updateBehaviorsOptionsRequires()


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
loop when trying to load the default rule engine in edge app

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
