### PR TITLE
[UXE-3762] fix: load originId field in error responses edition

### DIFF
--- a/src/services/edge-application-error-responses-services/list-error-responses-service.js
+++ b/src/services/edge-application-error-responses-services/list-error-responses-service.js
@@ -16,7 +16,7 @@ const adapt = (httpResponse) => {
   const parsedErrorResponses = {
     id: response.id,
     name: response.name,
-    originId: response.origin_id,
+    originId: response.origin_id.toString(),
     errorResponses: response.error_responses.map((element) => {
       return {
         code: element.code.toString(),

--- a/src/tests/services/edge-application-error-responses/list-error-responses-service.test.js
+++ b/src/tests/services/edge-application-error-responses/list-error-responses-service.test.js
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 const fixtures = {
   errorResponseSample: {
-    id: '123',
+    id: 123,
     origin_id: '12',
     error_responses: [
       {
@@ -60,7 +60,7 @@ describe('EdgeApplicationErrorResponsesServices', () => {
     const [errorResponse] = fixtures.errorResponseSample.error_responses
     expect(result).toEqual({
       id: fixtures.errorResponseSample.id,
-      originId: fixtures.errorResponseSample.origin_id,
+      originId: fixtures.errorResponseSample.origin_id.toString(),
       errorResponses: [
         {
           code: fixtures.parsedCode,


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Load correctly the origin id field in edge application error responses tab
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/107002324/be11ba64-703d-4bcc-99fb-ae7150d0c410


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
