### PR TITLE
[UXE-3823] fix: toggle menu with filtered table

### DIFF
--- a/cypress/e2e/edge_application.cy.js
+++ b/cypress/e2e/edge_application.cy.js
@@ -27,7 +27,7 @@ const selectors = {
     behaviorsDropdown: '[data-testid="rule-form-behaviors-item-name"] > .p-dropdown-trigger',
     behaviors: '#behaviors\\[0\\]\\.name_4',
     ruleTable: '.p-datatable-tbody > tr > :nth-child(2) > div',
-    actionsButton: 'table > tbody > tr:last-child > td.p-frozen-column > div > button',
+    actionsButton: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
     deleteButton: '[data-testid="data-table-actions-column-body-actions-menu"]',
     deleteInput: '[data-testid="delete-dialog-confirmation-input-field"]',
     confirmDeleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
@@ -94,6 +94,8 @@ describe('Edge Application', () => {
     // Delete the edge application
     cy.visit('/edge-applications')
     cy.get(selectors.edgeApplication.searchInput).clear()
+    cy.get(selectors.edgeApplication.searchInput).type(edgeApplicationName)
+    cy.get(selectors.edgeApplication.tableRowName).should('be.visible').should('have.text', edgeApplicationName)
     cy.get(selectors.edgeApplication.actionsButton).click()
     cy.get(selectors.edgeApplication.deleteButton).click()
     cy.get(selectors.edgeApplication.deleteInput).type('delete')

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -137,7 +137,7 @@
             data-testid="data-table-actions-column-body-actions"
           >
             <PrimeMenu
-              :ref="(document) => (menuRef[rowData.id] = document)"
+              :ref="assignMenuRef(rowData.id)"
               id="overlay_menu"
               v-bind:model="actionOptions(rowData)"
               :popup="true"
@@ -426,6 +426,14 @@
 
   const updatedTable = () => {
     loadData({ page: 1 })
+  }
+
+  const assignMenuRef = (id) => {
+    return (document) => {
+      if (document !== null) {
+        menuRef.value[id] = document
+      }
+    }
   }
 
   watch(data, (currentState) => {

--- a/src/templates/list-table-block/no-header.vue
+++ b/src/templates/list-table-block/no-header.vue
@@ -147,7 +147,7 @@
               data-testid="data-table-actions-column-body"
             >
               <PrimeMenu
-                ref="menu"
+                :ref="assignMenuRef(rowData.id)"
                 id="overlay_menu"
                 v-bind:model="actionOptions(rowData?.status)"
                 :popup="true"
@@ -386,11 +386,11 @@
     router.push(props.createPagePath)
   }
 
-  const menu = ref(null)
+  const menuRef = ref({})
   const toggleActionsMenu = (event, selectedItem) => {
     selectedItemData.value = selectedItem
     selectedId.value = selectedItem.id
-    menu.value.toggle(event)
+    menuRef.value[selectedItem.id].toggle(event)
   }
 
   const editItemSelected = ({ data: item, originalEvent }) => {
@@ -461,7 +461,13 @@
     emit('on-load-data', hasData)
   })
 
-  // to make a filter
+  const assignMenuRef = (id) => {
+    return (document) => {
+      if (document !== null) {
+        menuRef.value[id] = document
+      }
+    }
+  }
 
   watch(selectedItems, (selectedData) => {
     emit('on-select-data', selectedData)


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
* If there is only one filtered record in the table, the toggle menu does not work.
* Individual menu references were created for each record.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/069338d0-5fce-4817-9e2e-4ea492095bf0


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
