### PR TITLE
[QA-2018] test: dynamically define names of entities to be created by E2E

### DIFF
--- a/cypress/e2e/edge_application.cy.js
+++ b/cypress/e2e/edge_application.cy.js
@@ -1,3 +1,5 @@
+import generateUniqueName from '../support/utils';
+
 const selectors = {
   login: {
     emailInput: '[data-testid="signin-block__email-input"]',
@@ -33,11 +35,6 @@ const selectors = {
     confirmDeleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
   }
 }
-
-const generateUniqueName = (prefix) => {
-  const timestamp = Date.now()
-  return `${prefix}-${timestamp}`
-};
 
 const email = Cypress.env('CYPRESS_EMAIL_STAGE')
 const password = Cypress.env('CYPRESS_PASSWORD_STAGE')

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './utils'
 import '@cypress/code-coverage/support';
 
 // Alternatively you can use CommonJS syntax:

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,0 +1,14 @@
+// Function to generate unique names with a formatted timestamp
+const generateUniqueName = (prefix) => {
+    const timestamp = new Date();
+    const formattedTimestamp = timestamp.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).replace(/\//g, '').replace(/:/g, '').replace(/, /g, '');
+    return `${prefix}${formattedTimestamp}`;
+  };
+  
+  export default generateUniqueName;


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Dynamically define names of entities to be created by E2E tests to avoid collisions

### Does this PR introduce breaking changes?
- [X] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
No

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [X] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
