### PR TITLE
[UXE-3791] test: create e2e test for team permissions

### DIFF
--- a/cypress/e2e/teams-permissions.cy.js
+++ b/cypress/e2e/teams-permissions.cy.js
@@ -1,0 +1,115 @@
+const selectors = {
+  menu: {
+    teamsPermissionsMenuItem:
+      'li[aria-label="Teams Permissions"] > .p-menuitem-content > .p-menuitem-link'
+  },
+  list: {
+    createTeamButton: '[data-testid="create_Team_button"]',
+    searchField: '[data-testid="data-table-search-input"]',
+    filteredRow: {
+      nameColumn: '.p-selectable-row > :nth-child(1)',
+      permissionsColumn: '.p-selectable-row > :nth-child(2)',
+      statusColumn: '.p-selectable-row > :nth-child(3)',
+      empty: 'tr.p-datatable-emptymessage > td'
+    },
+    actionsMenu: {
+      button: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
+      deleteAction: '.p-menuitem-content > .p-menuitem-link'
+    },
+    deleteDialog: {
+      confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]',
+      deleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
+    },
+    toast: {
+      content: '.p-toast-message-content'
+    }
+  },
+  form: {
+    teamName: '[data-testid="teams-permissions__name-field__input"]',
+    teamNameError: '[data-testid="teams-permissions__name-field__error-text"]',
+    teamStatus: '[data-testid="teams-permissions__form-fields__status"]',
+    allPermissionsToTarget: '[aria-label="Move All to Target"] > .p-icon',
+    allPermissionsToSource: '[aria-label="Move All to Source"] > .p-icon',
+    singlePermissionToTarget: '[aria-label="Move to Target"] > .p-icon > path',
+    viewContentDeliverySettingsPermission:
+      '[data-testid="teams-permissions__permissions-field__picklist__item-View Content Delivery Settings"]',
+
+    actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
+    actionsCancelButton: '[data-testid="form-actions-cancel-button"]',
+    toast: {
+      content: ':nth-child(2) > .p-toast-message-content',
+      closeBtn: ':nth-child(2) >.p-toast-message-content .p-toast-icon-close'
+    }
+  }
+}
+
+describe('Teams Permissions', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.get(selectors.menu.teamsPermissionsMenuItem).click()
+  })
+
+  it('should create a new team', () => {
+    // Arrange
+    cy.get(selectors.list.searchField).type('New Team')
+    cy.get(selectors.list.filteredRow.empty)
+      .should('be.visible')
+      .and('have.text', 'No teams found.')
+
+    cy.get(selectors.list.createTeamButton).click()
+
+    cy.get(selectors.form.teamName).type('A')
+    cy.get(selectors.form.teamName).clear()
+    cy.get(selectors.form.teamNameError)
+      .should('be.visible')
+      .and('have.text', 'Name is a required field')
+
+    // Act
+    // Test different permissions scenarios and verify whether form is enabled/disabled
+    cy.get(selectors.form.teamName).type('New Team')
+    cy.get(selectors.form.allPermissionsToTarget).click()
+    cy.get(selectors.form.actionsSubmitButton).should('be.enabled')
+
+    cy.get(selectors.form.allPermissionsToSource).click()
+    cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
+
+    cy.get(selectors.form.viewContentDeliverySettingsPermission).click()
+    cy.get(selectors.form.singlePermissionToTarget).click()
+    cy.get(selectors.form.actionsSubmitButton).should('be.enabled')
+
+    cy.get(selectors.form.allPermissionsToTarget).click()
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.get(selectors.form.toast.content)
+      .should('be.visible')
+      .and('contain', 'successYour Team Permission has been created')
+
+    cy.get(selectors.form.actionsCancelButton).click()
+
+    cy.get(selectors.list.searchField).type('New Team')
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Team')
+    cy.get(selectors.list.filteredRow.permissionsColumn).should(
+      'have.text',
+      'View Content Delivery SettingsEdit Content Delivery SettingsShow more (46)'
+    )
+    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
+
+    // Cleanup
+    cy.get(selectors.form.toast.closeBtn).click()
+    cy.get(selectors.list.actionsMenu.button).click()
+    cy.get(selectors.list.actionsMenu.deleteAction).click()
+
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
+    cy.get(selectors.list.deleteDialog.deleteButton).click()
+
+    cy.get(selectors.list.searchField).clear()
+    cy.get(selectors.list.searchField).type('New Team')
+    cy.get(selectors.list.filteredRow.empty)
+      .should('be.visible')
+      .and('have.text', 'No teams found.')
+    cy.get(selectors.list.toast.content)
+      .should('be.visible')
+      .and('contain', 'Team Permission successfully deleted')
+  })
+})

--- a/cypress/e2e/teams-permissions.cy.js
+++ b/cypress/e2e/teams-permissions.cy.js
@@ -25,14 +25,14 @@ const selectors = {
     }
   },
   form: {
-    teamName: '[data-testid="teams-permissions__name-field__input"]',
-    teamNameError: '[data-testid="teams-permissions__name-field__error-text"]',
-    teamStatus: '[data-testid="teams-permissions__form-fields__status"]',
+    teamName: '[data-testid="teams-permissions-form__name-field__input"]',
+    teamNameError: '[data-testid="teams-permissions-form__name-field__error-text"]',
+    teamStatus: '[data-testid="teams-permissions-form__form-fields__status"]',
     allPermissionsToTarget: '[aria-label="Move All to Target"] > .p-icon',
     allPermissionsToSource: '[aria-label="Move All to Source"] > .p-icon',
     singlePermissionToTarget: '[aria-label="Move to Target"] > .p-icon > path',
     viewContentDeliverySettingsPermission:
-      '[data-testid="teams-permissions__permissions-field__picklist__item-View Content Delivery Settings"]',
+      '[data-testid="teams-permissions-form__permissions-field__picklist__item-View Content Delivery Settings"]',
 
     actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
     actionsCancelButton: '[data-testid="form-actions-cancel-button"]',

--- a/src/views/TeamsPermissions/CreateView.vue
+++ b/src/views/TeamsPermissions/CreateView.vue
@@ -3,7 +3,7 @@
     <template #heading>
       <PageHeadingBlock
         pageTitle="Create Team"
-        data-testid="teams-permissions__create__page-heading"
+        data-testid="teams-permissions__create-view__page-heading"
       />
     </template>
     <template #content>

--- a/src/views/TeamsPermissions/CreateView.vue
+++ b/src/views/TeamsPermissions/CreateView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Create Team"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Create Team"
+        data-testid="teams-permissions__create__page-heading"
+      />
     </template>
     <template #content>
       <CreateFormBlock
@@ -11,9 +14,7 @@
         :initialValues="initialValues"
       >
         <template #form>
-          <FormFieldsTeamPermissions
-            :listPermissionService="props.listPermissionService"
-          ></FormFieldsTeamPermissions>
+          <FormFieldsTeamPermissions :listPermissionService="props.listPermissionService" />
         </template>
         <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/TeamsPermissions/EditView.vue
+++ b/src/views/TeamsPermissions/EditView.vue
@@ -3,7 +3,7 @@
     <template #heading>
       <PageHeadingBlock
         pageTitle="Edit Team"
-        data-testid="teams-permissions__edit__page-heading"
+        data-testid="teams-permissions__edit-view__page-heading"
       />
     </template>
     <template #content>

--- a/src/views/TeamsPermissions/EditView.vue
+++ b/src/views/TeamsPermissions/EditView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Edit Team"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Edit Team"
+        data-testid="teams-permissions__edit__page-heading"
+      />
     </template>
     <template #content>
       <EditFormBlock
@@ -11,9 +14,7 @@
         :schema="validationSchema"
       >
         <template #form>
-          <FormFieldsTeamPermissions
-            :listPermissionService="props.listPermissionService"
-          ></FormFieldsTeamPermissions>
+          <FormFieldsTeamPermissions :listPermissionService="props.listPermissionService" />
         </template>
         <template #action-bar="{ onSubmit, formValid, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/TeamsPermissions/FormFields/FormFieldsTeamPermissions.vue
+++ b/src/views/TeamsPermissions/FormFields/FormFieldsTeamPermissions.vue
@@ -57,7 +57,7 @@
 </script>
 <template>
   <FormHorizontal
-    data-testid="teams-permissions__form-fields__general"
+    data-testid="teams-permissions-form__section__general"
     title="General"
     description="Use permissions to manage and oversee users by defining access levels of client accounts.
 "
@@ -65,13 +65,13 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
-          data-testid="teams-permissions__name-field__label"
+          data-testid="teams-permissions-form__name-field__label"
           for="name"
           class="text-color text-base font-medium"
           >Name *
         </label>
         <InputText
-          data-testid="teams-permissions__name-field__input"
+          data-testid="teams-permissions-form__name-field__input"
           v-model="name"
           type="text"
           id="name"
@@ -79,13 +79,13 @@
         />
         <small
           class="text-xs text-color-secondary font-normal leading-5"
-          data-testid="teams-permissions__name-field__description"
+          data-testid="teams-permissions-form__name-field__description"
         >
           Give a unique and descriptive name to identify the team.
         </small>
         <small
           v-if="errorName"
-          data-testid="teams-permissions__name-field__error-text"
+          data-testid="teams-permissions-form__name-field__error-text"
           class="p-error text-xs font-normal leading-tight"
           >{{ errorName }}</small
         >
@@ -93,7 +93,7 @@
     </template>
   </FormHorizontal>
   <FormHorizontal
-    data-testid="teams-permissions__form-fields__permissions"
+    data-testid="teams-permissions-form__section__permissions"
     title="Permissions"
     description="Determine the access level of accounts and assign permissions according to their team. Teams can be based on the role and tasks of account users.
 "
@@ -101,13 +101,13 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-3xl w-full gap-2">
         <label
-          data-testid="teams-permissions__permissions-field__label"
+          data-testid="teams-permissions-form__permissions-field__label"
           for="value"
           class="text-color text-base font-medium"
           >Permissions *
         </label>
         <PickList
-          data-testid="teams-permissions__permissions-field__picklist"
+          data-testid="teams-permissions-form__permissions-field__picklist"
           v-model="permissionsList"
           :pt="{
             sourceList: { class: ['h-80'] },
@@ -125,7 +125,7 @@
               <div>
                 <span
                   class="font-normal"
-                  :data-testid="`teams-permissions__permissions-field__picklist__item-${slotProps.item.name}`"
+                  :data-testid="`teams-permissions-form__permissions-field__picklist__item-${slotProps.item.name}`"
                   >{{ slotProps.item.name }}</span
                 >
               </div>
@@ -134,7 +134,7 @@
         </PickList>
         <small
           class="text-xs text-color-secondary font-normal leading-5"
-          data-testid="teams-permissions__permissions-field__description"
+          data-testid="teams-permissions-form__permissions-field__description"
         >
           Select an item from the list and then use the arrows to move it between the available and
           selected permissions boxes. Use the double-line arrows to move all items or press the
@@ -145,11 +145,11 @@
   </FormHorizontal>
   <FormHorizontal
     title="Status"
-    data-testid="teams-permissions__form-fields__status"
+    data-testid="teams-permissions-form__section__status"
   >
     <template #inputs>
       <FieldSwitchBlock
-        data-testid="teams-permissions__status-field__switch"
+        data-testid="teams-permissions-form__status-field__switch"
         nameField="isActive"
         name="active"
         auto

--- a/src/views/TeamsPermissions/FormFields/FormFieldsTeamPermissions.vue
+++ b/src/views/TeamsPermissions/FormFields/FormFieldsTeamPermissions.vue
@@ -57,6 +57,7 @@
 </script>
 <template>
   <FormHorizontal
+    data-testid="teams-permissions__form-fields__general"
     title="General"
     description="Use permissions to manage and oversee users by defining access levels of client accounts.
 "
@@ -64,21 +65,27 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
+          data-testid="teams-permissions__name-field__label"
           for="name"
           class="text-color text-base font-medium"
           >Name *
         </label>
         <InputText
+          data-testid="teams-permissions__name-field__input"
           v-model="name"
           type="text"
           id="name"
           :class="{ 'p-invalid': errorName }"
         />
-        <small class="text-xs text-color-secondary font-normal leading-5">
+        <small
+          class="text-xs text-color-secondary font-normal leading-5"
+          data-testid="teams-permissions__name-field__description"
+        >
           Give a unique and descriptive name to identify the team.
         </small>
         <small
           v-if="errorName"
+          data-testid="teams-permissions__name-field__error-text"
           class="p-error text-xs font-normal leading-tight"
           >{{ errorName }}</small
         >
@@ -86,6 +93,7 @@
     </template>
   </FormHorizontal>
   <FormHorizontal
+    data-testid="teams-permissions__form-fields__permissions"
     title="Permissions"
     description="Determine the access level of accounts and assign permissions according to their team. Teams can be based on the role and tasks of account users.
 "
@@ -93,11 +101,13 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-3xl w-full gap-2">
         <label
+          data-testid="teams-permissions__permissions-field__label"
           for="value"
           class="text-color text-base font-medium"
           >Permissions *
         </label>
         <PickList
+          data-testid="teams-permissions__permissions-field__picklist"
           v-model="permissionsList"
           :pt="{
             sourceList: { class: ['h-80'] },
@@ -113,12 +123,19 @@
           <template #item="slotProps">
             <div>
               <div>
-                <span class="font-normal">{{ slotProps.item.name }}</span>
+                <span
+                  class="font-normal"
+                  :data-testid="`teams-permissions__permissions-field__picklist__item-${slotProps.item.name}`"
+                  >{{ slotProps.item.name }}</span
+                >
               </div>
             </div>
           </template>
         </PickList>
-        <small class="text-xs text-color-secondary font-normal leading-5">
+        <small
+          class="text-xs text-color-secondary font-normal leading-5"
+          data-testid="teams-permissions__permissions-field__description"
+        >
           Select an item from the list and then use the arrows to move it between the available and
           selected permissions boxes. Use the double-line arrows to move all items or press the
           <code>ctrl</code> or <code>command</code> keys to select multiple items.
@@ -126,9 +143,13 @@
       </div>
     </template>
   </FormHorizontal>
-  <FormHorizontal title="Status">
+  <FormHorizontal
+    title="Status"
+    data-testid="teams-permissions__form-fields__status"
+  >
     <template #inputs>
       <FieldSwitchBlock
+        data-testid="teams-permissions__status-field__switch"
         nameField="isActive"
         name="active"
         auto

--- a/src/views/TeamsPermissions/ListView.vue
+++ b/src/views/TeamsPermissions/ListView.vue
@@ -3,7 +3,7 @@
     <template #heading>
       <PageHeadingBlock
         pageTitle="Teams Permissions"
-        data-testid="teams-permissions__list__page-heading"
+        data-testid="teams-permissions__list-view__page-heading"
       />
     </template>
     <template #content>
@@ -22,7 +22,7 @@
       </ListTableBlock>
       <EmptyResultsBlock
         v-else
-        data-testid="teams-permissions__list__empty-results-block"
+        data-testid="teams-permissions__list-view__empty-results-block"
         title="No teams have been created"
         description="Click the button below to create your first team and add permissions."
         createButtonLabel="Team"

--- a/src/views/TeamsPermissions/ListView.vue
+++ b/src/views/TeamsPermissions/ListView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Teams Permissions"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Teams Permissions"
+        data-testid="teams-permissions__list__page-heading"
+      />
     </template>
     <template #content>
       <ListTableBlock
@@ -19,6 +22,7 @@
       </ListTableBlock>
       <EmptyResultsBlock
         v-else
+        data-testid="teams-permissions__list__empty-results-block"
         title="No teams have been created"
         description="Click the button below to create your first team and add permissions."
         createButtonLabel="Team"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Add data-testid to teams permissions elements in views
- Create e2e test for creation e deletion of teams permissions 

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
No

https://github.com/aziontech/azion-console-kit/assets/95643165/0d2d920d-a697-4f27-975f-80aa2a3a2f15

### Does it have a link on Figma?
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
