### PR TITLE
[UXE-3793] test: e2e personal tokens crud

### DIFF
--- a/cypress/e2e/personal-token.cy.js
+++ b/cypress/e2e/personal-token.cy.js
@@ -1,0 +1,60 @@
+import generateUniqueName from '../support/utils'
+
+const selectors = {
+  list: {
+    createTokenButton: '[data-testid="create_Personal Token_button"]',
+    searchInput: '[data-testid="data-table-search-input"]',
+    filteredRecord: {
+      nameColumn: '[data-testid="list-table-block__column__name__row"]',
+      menuButton: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
+      deleteButton: '.p-menuitem-content > .p-menuitem-link'
+    },
+    deleteDialog: {
+      confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]'
+    }
+  },
+  form: {
+    tokenName: '[data-testid="personal-token-form__name-field__input"]',
+    submitButton: '[data-testid="form-actions-submit-button"]',
+    copyTokenDialogHeader: '[data-testid="copy-token-dialog__header"] > .p-dialog-header',
+    copyTokenButton: '[data-testid="copy-token-dialog__token-field__copy-token-button"]',
+    closeCopyDialogButton: '[data-testid="copy-token-dialog__dialog-footer__confirm-button"]'
+  }
+}
+
+const personalTokenName = generateUniqueName('Personal Token')
+
+describe('Personal Token spec', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.openItemThroughMenuAccount('Personal Token')
+  })
+
+  it('should create and delete a personal token', () => {
+    // Arrange
+    cy.get(selectors.list.createTokenButton).click()
+    cy.get(selectors.form.tokenName).type(personalTokenName)
+
+    // Act
+    // Verify if copy token dialog is displayed after save
+    cy.get(selectors.form.submitButton).click()
+    cy.get(selectors.form.copyTokenDialogHeader).should(
+      'have.text',
+      'Personal token has been created'
+    )
+    cy.get(selectors.form.copyTokenButton).click()
+    cy.verifyToast('Personal Token copied to clipboard!')
+    cy.get(selectors.form.closeCopyDialogButton).click()
+
+    // Assert
+    cy.get(selectors.list.searchInput).type(personalTokenName)
+    cy.get(selectors.list.filteredRecord.nameColumn).should('have.text', personalTokenName)
+
+    // Cleanup
+    cy.get(selectors.list.filteredRecord.menuButton).click()
+    cy.get(selectors.list.filteredRecord.deleteButton).click()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).clear()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete{enter}')
+    cy.verifyToast('Personal token successfully deleted')
+  })
+})

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -161,7 +161,12 @@
           data-testid="data-table-empty-content"
         >
           <div class="my-4 flex flex-col gap-3 justify-center items-start">
-            <p class="text-md font-normal text-secondary">{{ emptyListMessage }}</p>
+            <p
+              class="text-md font-normal text-secondary"
+              data-testid="list-table-block__empty-message"
+            >
+              {{ emptyListMessage }}
+            </p>
           </div>
         </slot>
       </template>

--- a/src/templates/list-table-block/no-header.vue
+++ b/src/templates/list-table-block/no-header.vue
@@ -171,7 +171,12 @@
               class="my-4 flex flex-col gap-3 justify-center items-start"
               data-testid="data-table-empty-message-container"
             >
-              <p class="text-md font-normal text-secondary">{{ emptyListMessage }}</p>
+              <p
+                class="text-md font-normal text-secondary"
+                data-testid="table-block-no-header__empty-message"
+              >
+                {{ emptyListMessage }}
+              </p>
             </div>
           </slot>
         </template>

--- a/src/templates/list-table-block/with-lazy-and-dropdown-filter.vue
+++ b/src/templates/list-table-block/with-lazy-and-dropdown-filter.vue
@@ -115,7 +115,12 @@
         </Column>
         <template #empty>
           <div class="my-4 flex flex-col gap-3 justify-center items-start">
-            <p class="text-md font-normal text-secondary">{{ emptyListMessage }}</p>
+            <p
+              class="text-md font-normal text-secondary"
+              data-testid="table-block-with-lazy-and-dropdown-filter__empty-message"
+            >
+              {{ emptyListMessage }}
+            </p>
           </div>
         </template>
       </DataTable>

--- a/src/views/PersonalTokens/Dialog/CopyTokenDialog.vue
+++ b/src/views/PersonalTokens/Dialog/CopyTokenDialog.vue
@@ -6,9 +6,13 @@
     :closable="false"
     class="max-w-2xl"
     header="Personal token has been created"
+    data-testid="copy-token-dialog__header"
   >
     <div class="flex flex-col gap-3.5">
-      <InlineMessage severity="warn">
+      <InlineMessage
+        severity="warn"
+        data-testid="copy-token-dialog__warning__inline-message"
+      >
         This token will only be displayed once. Make sure to copy and store it safely.
       </InlineMessage>
 
@@ -16,6 +20,7 @@
         <label
           for="personalToken"
           class="text-color text-base font-medium"
+          data-testid="copy-token-dialog__token-field__label"
         >
           Personal Token
         </label>
@@ -33,8 +38,12 @@
             }"
             :feedback="false"
             toggleMask
+            data-testid="copy-token-dialog__token-field__password-input"
           />
-          <small class="text-xs text-color-secondary font-normal leading-5">
+          <small
+            class="text-xs text-color-secondary font-normal leading-5"
+            data-testid="copy-token-dialog__token-field__description"
+          >
             Once the dialog is closed, the token cannot be retrieved. It'll be necessary to generate
             a new one.
           </small>
@@ -49,6 +58,7 @@
           label="Copy"
           :disabled="!personalTokenValue"
           @click="params.copy"
+          data-testid="copy-token-dialog__token-field__copy-token-button"
         />
       </div>
     </div>
@@ -58,6 +68,7 @@
         label="Confirm"
         severity="secondary"
         @click="closeDialog"
+        data-testid="copy-token-dialog__dialog-footer__confirm-button"
       />
     </template>
   </PrimeDialog>

--- a/src/views/PersonalTokens/FormFields/FormFieldsPersonalToken.vue
+++ b/src/views/PersonalTokens/FormFields/FormFieldsPersonalToken.vue
@@ -106,7 +106,7 @@
 <template>
   <FormHorizontal
     title="General"
-    description=""
+    data-testid="personal-token-form__section__general"
   >
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
@@ -116,6 +116,7 @@
           :value="name"
           :disabled="disabledFields"
           description="Give a unique and descriptive name to identify the personal token."
+          data-testid="personal-token-form__name-field"
         />
       </div>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
@@ -127,6 +128,7 @@
           autoResize
           rows="1"
           :disabled="disabledFields"
+          data-testid="personal-token-form__description-field"
         />
       </div>
     </template>
@@ -141,11 +143,13 @@
         <label
           for="selectedExpiration"
           class="text-color text-base font-medium"
+          data-testid="personal-token-form__expiration-label"
           >Expires within *</label
         >
         <div class="flex sm:flex-row w-full flex-col gap-6">
           <div class="w-full sm:max-w-xs">
             <Dropdown
+              data-testid="personal-token-form__expiration-dropdown"
               appendTo="self"
               class="w-full"
               id="selectedExpiration"
@@ -167,6 +171,7 @@
           <div class="w-full sm:max-w-xs">
             <Calendar
               v-if="isCustomDateSelected"
+              data-testid="personal-token-form__expiration__calendar"
               class="w-full"
               @date-select="updateExpiration"
               v-model="customExpiration"
@@ -183,6 +188,7 @@
             />
             <small
               v-if="errorCustom"
+              data-testid="personal-token-form__expiration__error-message"
               class="p-error text-xs font-normal leading-tight"
             >
               {{ errorCustom }}


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* tests to create and delete personal tokens
* added data-testid to empty message in datatables

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/109550332/b6063326-859e-4540-b46b-53fcde155515

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] Safari
