### PR TITLE
[UXE-3789] test: create e2e test for credentials

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -83,10 +83,10 @@ To validate toasts (notifications) in tests:
 
 - Execute the custom command `verifyToast()`.
 
-> Note: the command receives the whole text string of the toast as an argument. 
+> Note: the command receives summary and detail as arguments. 
 
 Example:
 
 ```javascript
-cy.verifyToast('Success!')
+cy.verifyToast('Success!', 'User created successfully!');
 ```

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -81,12 +81,12 @@ const userName = generateUniqueName('username');
 
 To validate toasts (notifications) in tests:
 
-- Verify the presence and content of toasts.
-- Ensure toasts disappear after the expected time.
+- Execute the custom command `verifyToast()`.
+
+> Note: the command receives the whole text string of the toast as an argument. 
 
 Example:
 
 ```javascript
-cy.get('[data-testid="toast"]').should('be.visible').and('contain', 'Success message')
-cy.get('[data-testid="toast"]').should('not.exist')
+cy.verifyToast('Success!')
 ```

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -1,7 +1,6 @@
+import generateUniqueName from '../support/utils'
+
 const selectors = {
-  menu: {
-    credentials: 'li[aria-label="Credentials"] > .p-menuitem-content > .p-menuitem-link'
-  },
   list: {
     createCredentialBtn: '[data-testid="create_Credential_button"]',
     searchInput: '[data-testid="data-table-search-input"]',
@@ -19,8 +18,7 @@ const selectors = {
     deleteDialog: {
       confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]',
       deleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
-    },
-    toast: ':nth-child(4) > .p-toast-message-content'
+    }
   },
   form: {
     nameInput: '[data-testid="credentials-create-form__name-field__input"]',
@@ -31,15 +29,16 @@ const selectors = {
     tokenCopyButton: '[data-testid="credentials-create-form__token-field__copy-token-button"]',
     statusSwitch: '[data-testid="credentials-create-form__status-field__switch"]',
     actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
-    actionsCancelButton: '[data-testid="form-actions-cancel-button"]',
-    toast: ':nth-child(2) > .p-toast-message-content'
+    actionsCancelButton: '[data-testid="form-actions-cancel-button"]'
   }
 }
+
+const credentialName = generateUniqueName('Credential')
 
 describe('Credentials', () => {
   beforeEach(() => {
     cy.login()
-    cy.get(selectors.menu.credentials).click()
+    cy.openMenuItem('Credentials')
   })
 
   it('should create a credential from the table', () => {
@@ -59,18 +58,20 @@ describe('Credentials', () => {
     cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
 
     // Act
-    cy.get(selectors.form.nameInput).type('New Credential')
+    cy.get(selectors.form.nameInput).type(credentialName)
     cy.get(selectors.form.descriptionField).type('New Credential Description')
     cy.get(selectors.form.actionsSubmitButton).click()
 
     // Assert
-    cy.get(selectors.form.toast).should('contain', 'successYour credential token has been created')
+    cy.verifyToast('successYour credential token has been created')
+
     cy.get(selectors.form.tokenCopyButton).click()
+    cy.verifyToast('token copied')
 
     cy.get(selectors.form.actionsCancelButton).click()
 
-    cy.get(selectors.list.searchInput).type('New Credential')
-    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Credential')
+    cy.get(selectors.list.searchInput).type(credentialName)
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', credentialName)
     cy.get(selectors.list.filteredRow.lastEditorColumn).should(
       'have.text',
       Cypress.env('CYPRESS_EMAIL_STAGE')
@@ -83,6 +84,6 @@ describe('Credentials', () => {
     cy.get(selectors.list.filteredRow.actionsMenu.deleteAction).click()
     cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
     cy.get(selectors.list.deleteDialog.deleteButton).click()
-    cy.get(selectors.list.toast).should('have.text', 'Credential successfully deleted')
+    cy.verifyToast('Credential successfully deleted')
   })
 })

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -1,6 +1,40 @@
 const selectors = {
   menu: {
     credentials: 'li[aria-label="Credentials"] > .p-menuitem-content > .p-menuitem-link'
+  },
+  list: {
+    emptyPage: {
+      page: '[data-testid="credentials__list-view__empty-results-block"]',
+      createCredentialBtn: '[data-testid="create_Credential_button"]'
+    },
+    searchInput: '[data-testid="data-table-search-input"]',
+    filteredRow: {
+      nameColumn: '[data-testid="list-table-block__column__name__row"]',
+      lastEditorColumn: '[data-testid="list-table-block__column__lastEditor__row"]',
+      lastModifiedColumn: '[data-testid="list-table-block__column__lastModified__row"]',
+      statusColumn: '[data-testid="list-table-block__column__status__row"]',
+      actionsMenu: {
+        button: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
+        deleteAction: '.p-menuitem-content > .p-menuitem-link'
+      }
+    },
+    deleteDialog: {
+      confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]',
+      deleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
+    },
+    toast: ':nth-child(4) > .p-toast-message-content'
+  },
+  form: {
+    nameInput: '[data-testid="credentials-create-form__name-field__input"]',
+    nameErrorText: '[data-testid="credentials-create-form__name-field__error-text"]',
+    descriptionField: '[data-testid="credentials-create-form__description-field__textarea"]',
+    tokenInput: '[data-testid="credentials-create-form__token-field__input"]',
+    tokenErrorText: '[data-testid="credentials-create-form__token-field__error-text"]',
+    tokenCopyButton: '[data-testid="credentials-create-form__token-field__copy-token-button"]',
+    statusSwitch: '[data-testid="credentials-create-form__status-field__switch"]',
+    actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
+    actionsCancelButton: '[data-testid="form-actions-cancel-button"]',
+    toast: ':nth-child(2) > .p-toast-message-content'
   }
 }
 
@@ -10,5 +44,105 @@ describe('Credentials', () => {
     cy.get(selectors.menu.credentials).click()
   })
 
-  it('should create a credential from an empty page', () => {})
+  it('should create a credential from an empty page', () => {
+    // Arrange
+    cy.get(selectors.list.emptyPage.page).should(
+      'contain',
+      'No credentials have been generatedClick the button below to generate your first credential'
+    )
+    cy.get(selectors.list.emptyPage.createCredentialBtn).click()
+
+    cy.get(selectors.form.nameInput).type('N')
+    cy.get(selectors.form.nameInput).clear()
+    cy.get(selectors.form.nameErrorText)
+      .should('be.visible')
+      .and('have.text', 'Name is a required field')
+
+    cy.get(selectors.form.tokenCopyButton).should('be.disabled')
+
+    cy.get(selectors.form.statusSwitch).should('have.class', 'p-inputswitch-checked')
+
+    cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
+
+    // Act
+    cy.get(selectors.form.nameInput).type('New Credential')
+    cy.get(selectors.form.descriptionField).type('New Credential Description')
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.get(selectors.form.toast).should('contain', 'successYour credential token has been created')
+    cy.get(selectors.form.tokenCopyButton).click()
+
+    cy.get(selectors.form.actionsCancelButton).click()
+
+    cy.get(selectors.list.searchInput).type('New Credential')
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Credential')
+    cy.get(selectors.list.filteredRow.lastEditorColumn).should(
+      'have.text',
+      Cypress.env('CYPRESS_EMAIL_STAGE')
+    )
+    cy.get(selectors.list.filteredRow.lastModifiedColumn).should('not.be.empty')
+    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
+
+    // Cleanup
+    cy.get(selectors.list.filteredRow.actionsMenu.button).click()
+    cy.get(selectors.list.filteredRow.actionsMenu.deleteAction).click()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
+    cy.get(selectors.list.deleteDialog.deleteButton).click()
+    cy.get(selectors.list.toast).should('have.text', 'Credential successfully deleted')
+    cy.get(selectors.list.emptyPage.page).should(
+      'contain',
+      'No credentials have been generatedClick the button below to generate your first credential.'
+    )
+  })
+
+  it('should create a credential from an empty page', () => {
+    // Arrange
+    cy.get(selectors.list.emptyPage.page).should(
+      'contain',
+      'No credentials have been generatedClick the button below to generate your first credential'
+    )
+    cy.get(selectors.list.emptyPage.createCredentialBtn).click()
+
+    cy.get(selectors.form.nameInput).type('N')
+    cy.get(selectors.form.nameInput).clear()
+    cy.get(selectors.form.nameErrorText)
+      .should('be.visible')
+      .and('have.text', 'Name is a required field')
+
+    cy.get(selectors.form.tokenCopyButton).should('be.disabled')
+
+    cy.get(selectors.form.statusSwitch).should('have.class', 'p-inputswitch-checked')
+
+    cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
+
+    // Act
+    cy.get(selectors.form.nameInput).type('New Credential')
+    cy.get(selectors.form.descriptionField).type('New Credential Description')
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.get(selectors.form.toast).should('contain', 'successYour credential token has been created')
+    cy.get(selectors.form.tokenCopyButton).click()
+
+    cy.get(selectors.form.actionsCancelButton).click()
+
+    cy.get(selectors.list.searchInput).type('New Credential')
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Credential')
+    cy.get(selectors.list.filteredRow.lastEditorColumn).should(
+      'have.text',
+      Cypress.env('CYPRESS_EMAIL_STAGE')
+    )
+    cy.get(selectors.list.filteredRow.lastModifiedColumn).should('not.be.empty')
+    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
+    cy.get(selectors.list.filteredRow.actionsMenu.button).click()
+    cy.get(selectors.list.filteredRow.actionsMenu.deleteAction).click()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
+    cy.get(selectors.list.deleteDialog.deleteButton).click()
+    cy.get(selectors.list.toast).should('have.text', 'Credential successfully deleted')
+    cy.get(selectors.list.emptyPage.page).should(
+      'contain',
+      'No credentials have been generatedClick the button below to generate your first credential.'
+    )
+  })
 })

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -22,7 +22,7 @@ const selectors = {
   },
   form: {
     nameInput: '[data-testid="credentials-create-form__name-field__input"]',
-    nameErrorText: '[data-testid="credentials-create-form__name-field__error-text"]',
+    nameErrorText: '[data-testid="credentials-create-form__name-field__error-message"]',
     descriptionField: '[data-testid="credentials-create-form__description-field__textarea"]',
     tokenInput: '[data-testid="credentials-create-form__token-field__input"]',
     tokenErrorText: '[data-testid="credentials-create-form__token-field__error-text"]',
@@ -54,8 +54,6 @@ describe('Credentials', () => {
     cy.get(selectors.form.tokenCopyButton).should('be.disabled')
 
     cy.get(selectors.form.statusSwitch).should('have.class', 'p-inputswitch-checked')
-
-    cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
 
     // Act
     cy.get(selectors.form.nameInput).type(credentialName)

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -1,0 +1,14 @@
+const selectors = {
+  menu: {
+    credentials: 'li[aria-label="Credentials"] > .p-menuitem-content > .p-menuitem-link'
+  }
+}
+
+describe('Credentials', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.get(selectors.menu.credentials).click()
+  })
+
+  it('should create a new credential from an empty page', () => {})
+})

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -3,16 +3,14 @@ const selectors = {
     credentials: 'li[aria-label="Credentials"] > .p-menuitem-content > .p-menuitem-link'
   },
   list: {
-    emptyPage: {
-      page: '[data-testid="credentials__list-view__empty-results-block"]',
-      createCredentialBtn: '[data-testid="create_Credential_button"]'
-    },
+    createCredentialBtn: '[data-testid="create_Credential_button"]',
     searchInput: '[data-testid="data-table-search-input"]',
     filteredRow: {
       nameColumn: '[data-testid="list-table-block__column__name__row"]',
       lastEditorColumn: '[data-testid="list-table-block__column__lastEditor__row"]',
       lastModifiedColumn: '[data-testid="list-table-block__column__lastModified__row"]',
       statusColumn: '[data-testid="list-table-block__column__status__row"]',
+      empty: 'tr.p-datatable-emptymessage > td',
       actionsMenu: {
         button: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
         deleteAction: '.p-menuitem-content > .p-menuitem-link'
@@ -44,13 +42,9 @@ describe('Credentials', () => {
     cy.get(selectors.menu.credentials).click()
   })
 
-  it('should create a credential from an empty page', () => {
+  it('should create a credential from the table', () => {
     // Arrange
-    cy.get(selectors.list.emptyPage.page).should(
-      'contain',
-      'No credentials have been generatedClick the button below to generate your first credential'
-    )
-    cy.get(selectors.list.emptyPage.createCredentialBtn).click()
+    cy.get(selectors.list.createCredentialBtn).click()
 
     cy.get(selectors.form.nameInput).type('N')
     cy.get(selectors.form.nameInput).clear()
@@ -90,59 +84,5 @@ describe('Credentials', () => {
     cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
     cy.get(selectors.list.deleteDialog.deleteButton).click()
     cy.get(selectors.list.toast).should('have.text', 'Credential successfully deleted')
-    cy.get(selectors.list.emptyPage.page).should(
-      'contain',
-      'No credentials have been generatedClick the button below to generate your first credential.'
-    )
-  })
-
-  it('should create a credential from an empty page', () => {
-    // Arrange
-    cy.get(selectors.list.emptyPage.page).should(
-      'contain',
-      'No credentials have been generatedClick the button below to generate your first credential'
-    )
-    cy.get(selectors.list.emptyPage.createCredentialBtn).click()
-
-    cy.get(selectors.form.nameInput).type('N')
-    cy.get(selectors.form.nameInput).clear()
-    cy.get(selectors.form.nameErrorText)
-      .should('be.visible')
-      .and('have.text', 'Name is a required field')
-
-    cy.get(selectors.form.tokenCopyButton).should('be.disabled')
-
-    cy.get(selectors.form.statusSwitch).should('have.class', 'p-inputswitch-checked')
-
-    cy.get(selectors.form.actionsSubmitButton).should('be.disabled')
-
-    // Act
-    cy.get(selectors.form.nameInput).type('New Credential')
-    cy.get(selectors.form.descriptionField).type('New Credential Description')
-    cy.get(selectors.form.actionsSubmitButton).click()
-
-    // Assert
-    cy.get(selectors.form.toast).should('contain', 'successYour credential token has been created')
-    cy.get(selectors.form.tokenCopyButton).click()
-
-    cy.get(selectors.form.actionsCancelButton).click()
-
-    cy.get(selectors.list.searchInput).type('New Credential')
-    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Credential')
-    cy.get(selectors.list.filteredRow.lastEditorColumn).should(
-      'have.text',
-      Cypress.env('CYPRESS_EMAIL_STAGE')
-    )
-    cy.get(selectors.list.filteredRow.lastModifiedColumn).should('not.be.empty')
-    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
-    cy.get(selectors.list.filteredRow.actionsMenu.button).click()
-    cy.get(selectors.list.filteredRow.actionsMenu.deleteAction).click()
-    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
-    cy.get(selectors.list.deleteDialog.deleteButton).click()
-    cy.get(selectors.list.toast).should('have.text', 'Credential successfully deleted')
-    cy.get(selectors.list.emptyPage.page).should(
-      'contain',
-      'No credentials have been generatedClick the button below to generate your first credential.'
-    )
   })
 })

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -61,7 +61,7 @@ describe('Credentials', () => {
     cy.get(selectors.form.actionsSubmitButton).click()
 
     // Assert
-    cy.verifyToast('successYour credential token has been created')
+    cy.verifyToast('success', 'Your credential token has been created')
 
     cy.get(selectors.form.tokenCopyButton).click()
     cy.verifyToast('token copied')

--- a/cypress/e2e/credentials.cy.js
+++ b/cypress/e2e/credentials.cy.js
@@ -10,5 +10,5 @@ describe('Credentials', () => {
     cy.get(selectors.menu.credentials).click()
   })
 
-  it('should create a new credential from an empty page', () => {})
+  it('should create a credential from an empty page', () => {})
 })

--- a/cypress/e2e/digital-certificates.cy.js
+++ b/cypress/e2e/digital-certificates.cy.js
@@ -20,7 +20,7 @@ const selectors = {
     }
   },
   form: {
-    digitalCertificateName: '[data-testid="digital-certificate__name-field"]',
+    digitalCertificateName: '[data-testid="digital-certificate__name-field__input"]',
     submitButton: '[data-testid="form-actions-submit-button"]',
     editPageTitle: '[data-testid="page_title_Edit Digital Certificate"]'
   }
@@ -44,7 +44,7 @@ describe('Digital Certificates spec', () => {
     cy.get(selectors.form.submitButton).click()
 
     // Assert
-    cy.verifyToast('successYour digital certificate has been created!')
+    cy.verifyToast('success', 'Your digital certificate has been created!')
     cy.get(selectors.form.editPageTitle).should('have.text', 'Edit Digital Certificate')
     cy.get(selectors.list.breadcumbReturnToList).click()
     cy.get(selectors.list.searchInput).clear()

--- a/cypress/e2e/digital-certificates.cy.js
+++ b/cypress/e2e/digital-certificates.cy.js
@@ -1,3 +1,5 @@
+import generateUniqueName from '../support/utils'
+
 const selectors = {
   list: {
     breadcumbReturnToList: ':nth-child(3) > .p-menuitem-link',
@@ -21,12 +23,11 @@ const selectors = {
     digitalCertificateName: '[data-testid="digital-certificate__name-field"]',
     submitButton: '[data-testid="form-actions-submit-button"]',
     editPageTitle: '[data-testid="page_title_Edit Digital Certificate"]'
-  },
-  toast: {
-    createSuccessMessage: ':nth-child(2) > .p-toast-message-content > .flex-column > .text-sm',
-    deleteSuccessMessage: ':nth-child(3) > .p-toast-message-content > .flex-column > .flex > .text-color'
   }
 }
+
+const digitalCertificateName = generateUniqueName('Digital Certificate')
+
 describe('Digital Certificates spec', () => {
   beforeEach(() => {
     cy.login()
@@ -39,35 +40,23 @@ describe('Digital Certificates spec', () => {
 
     // Act
     cy.get(selectors.form.digitalCertificateName).clear()
-    cy.get(selectors.form.digitalCertificateName).type('EntityName')
+    cy.get(selectors.form.digitalCertificateName).type(digitalCertificateName)
     cy.get(selectors.form.submitButton).click()
 
     // Assert
-    cy.get(selectors.toast.createSuccessMessage).should(
-      'have.text',
-      'Your digital certificate has been created!'
-    )
-    cy.get(selectors.form.editPageTitle).should(
-      'have.text',
-      'Edit Digital Certificate'
-    )
+    cy.verifyToast('successYour digital certificate has been created!')
+    cy.get(selectors.form.editPageTitle).should('have.text', 'Edit Digital Certificate')
     cy.get(selectors.list.breadcumbReturnToList).click()
     cy.get(selectors.list.searchInput).clear()
-    cy.get(selectors.list.searchInput).type('EntityName')
-    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'EntityName')
-    cy.get(selectors.list.filteredRow.statusColum).should(
-      'have.text',
-      'Pending'
-    )
+    cy.get(selectors.list.searchInput).type(digitalCertificateName)
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', digitalCertificateName)
+    cy.get(selectors.list.filteredRow.statusColum).should('have.text', 'Pending')
 
     // Cleanup
     cy.get(selectors.list.actionsMenu.button).click()
     cy.get(selectors.list.actionsMenu.deleteAction).click()
     cy.get(selectors.list.deleteDialog.confirmInput).clear()
     cy.get(selectors.list.deleteDialog.confirmInput).type('delete{enter}')
-    cy.get(selectors.toast.deleteSuccessMessage).should(
-      'have.text',
-      'Digital certificate successfully deleted!'
-    )
+    cy.verifyToast('Digital certificate successfully deleted!')
   })
 })

--- a/cypress/e2e/edge-application.cy.js
+++ b/cypress/e2e/edge-application.cy.js
@@ -14,8 +14,8 @@ const selectors = {
   },
   edgeApplication: {
     createButton: '.p-datatable-header > .flex-wrap > .p-button > .p-button-label',
-    nameInput: '[data-testid="form-horizontal-general-name"]',
-    addressInput: '[data-testid="form-horizontal-default-origin-address-field-text"]',
+    nameInput: '[data-testid="form-horizontal-general-name__input"]',
+    addressInput: '[data-testid="form-horizontal-default-origin-address-field-text__input"]',
     saveButton: '[data-testid="form-actions-submit-button"]',
     cancelButton: '[data-testid="form-actions-cancel-button"]',
     searchInput: '[data-testid="data-table-search-input"]',
@@ -23,11 +23,12 @@ const selectors = {
     tableRowLastEditor: '[data-testid="list-table-block__column__lastEditor__row"]',
     rulesEngineTab: 'li:nth-child(6)',
     addRuleButton: '[data-testid="rules-engine-create-button"]',
-    ruleNameInput: '[data-testid="rule-form-general-name"]',
+    ruleNameInput: '[data-testid="rule-form-general-name__input"]',
     criteriaOperatorDropdown:
       '[data-testid="rule-form-criteria-item-conditional-operator"] > .p-dropdown-trigger',
     criteriaOperator: 'li[aria-label="is equal"]',
-    criteriaInputValue: '[data-testid="rule-form-criteria-item-conditional-input-field-text"]',
+    criteriaInputValue:
+      '[data-testid="rule-form-criteria-item-conditional-input-field-text__input"]',
     behaviorsDropdown: '[data-testid="rule-form-behaviors-item-name"] > .p-dropdown-trigger',
     behaviors: '#behaviors\\[0\\]\\.name_4',
     ruleTable: '.p-datatable-tbody > tr > :nth-child(2) > div',

--- a/cypress/e2e/edge-application.cy.js
+++ b/cypress/e2e/edge-application.cy.js
@@ -1,15 +1,16 @@
-import generateUniqueName from '../support/utils';
+import generateUniqueName from '../support/utils'
 
 const selectors = {
   login: {
     emailInput: '[data-testid="signin-block__email-input"]',
     nextButton: '[data-testid="signin-block__next-button"] > .p-button-label',
     passwordInput: '[data-testid="signin-block__password-input"] > .p-inputtext',
-    signInButton: '[data-testid="signin-block__signin-button"] > .p-button-label',
+    signInButton: '[data-testid="signin-block__signin-button"] > .p-button-label'
   },
   sidebar: {
     menuToggleButton: '[data-testid="sidebar-block__toggle-button"] > .p-button-icon',
-    edgeApplicationMenuItem: '[data-testid="sidebar-block__menu-item__edge-application"] > .p-menuitem-text',
+    edgeApplicationMenuItem:
+      '[data-testid="sidebar-block__menu-item__edge-application"] > .p-menuitem-text'
   },
   edgeApplication: {
     createButton: '.p-datatable-header > .flex-wrap > .p-button > .p-button-label',
@@ -23,7 +24,8 @@ const selectors = {
     rulesEngineTab: 'li:nth-child(6)',
     addRuleButton: '[data-testid="rules-engine-create-button"]',
     ruleNameInput: '[data-testid="rule-form-general-name"]',
-    criteriaOperatorDropdown: '[data-testid="rule-form-criteria-item-conditional-operator"] > .p-dropdown-trigger',
+    criteriaOperatorDropdown:
+      '[data-testid="rule-form-criteria-item-conditional-operator"] > .p-dropdown-trigger',
     criteriaOperator: 'li[aria-label="is equal"]',
     criteriaInputValue: '[data-testid="rule-form-criteria-item-conditional-input-value"]',
     behaviorsDropdown: '[data-testid="rule-form-behaviors-item-name"] > .p-dropdown-trigger',
@@ -36,19 +38,13 @@ const selectors = {
   }
 }
 
-const email = Cypress.env('CYPRESS_EMAIL_STAGE')
-const password = Cypress.env('CYPRESS_PASSWORD_STAGE')
 const edgeApplicationName = generateUniqueName('EdgeApp')
 const rulesEngineName = generateUniqueName('RulesEng')
 
 describe('Edge Application', () => {
   beforeEach(() => {
     // Login
-    cy.visit('/login')
-    cy.get(selectors.login.emailInput).type(email)
-    cy.get(selectors.login.nextButton).click()
-    cy.get(selectors.login.passwordInput).type(password)
-    cy.get(selectors.login.signInButton).click()
+    cy.login()
   })
 
   it('Create and delete an edge application, and create a rule', () => {
@@ -66,7 +62,9 @@ describe('Edge Application', () => {
 
     // Verify the edge application was created
     cy.get(selectors.edgeApplication.searchInput).type(edgeApplicationName)
-    cy.get(selectors.edgeApplication.tableRowName).should('be.visible').should('have.text', edgeApplicationName)
+    cy.get(selectors.edgeApplication.tableRowName)
+      .should('be.visible')
+      .should('have.text', edgeApplicationName)
 
     // Navigate to Rules Engine Tab
     cy.get(selectors.edgeApplication.tableRowLastEditor).click()
@@ -86,13 +84,17 @@ describe('Edge Application', () => {
 
     // Verify the rule was created
     cy.get(selectors.edgeApplication.searchInput).type(rulesEngineName)
-    cy.get(selectors.edgeApplication.ruleTable).should('be.visible').should('have.text', rulesEngineName)
+    cy.get(selectors.edgeApplication.ruleTable)
+      .should('be.visible')
+      .should('have.text', rulesEngineName)
 
     // Delete the edge application
     cy.visit('/edge-applications')
     cy.get(selectors.edgeApplication.searchInput).clear()
     cy.get(selectors.edgeApplication.searchInput).type(edgeApplicationName)
-    cy.get(selectors.edgeApplication.tableRowName).should('be.visible').should('have.text', edgeApplicationName)
+    cy.get(selectors.edgeApplication.tableRowName)
+      .should('be.visible')
+      .should('have.text', edgeApplicationName)
     cy.get(selectors.edgeApplication.actionsButton).click()
     cy.get(selectors.edgeApplication.deleteButton).click()
     cy.get(selectors.edgeApplication.deleteInput).type('delete')

--- a/cypress/e2e/teams-permissions.cy.js
+++ b/cypress/e2e/teams-permissions.cy.js
@@ -1,3 +1,5 @@
+import generateUniqueName from '../support/utils'
+
 const selectors = {
   list: {
     createTeamButton: '[data-testid="create_Team_button"]',
@@ -15,9 +17,6 @@ const selectors = {
     deleteDialog: {
       confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]',
       deleteButton: '[data-testid="delete-dialog-footer-delete-button"]'
-    },
-    toast: {
-      content: '.p-toast-message-content'
     }
   },
   form: {
@@ -31,23 +30,21 @@ const selectors = {
       '[data-testid="teams-permissions-form__permissions-field__picklist__item-View Content Delivery Settings"]',
 
     actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
-    actionsCancelButton: '[data-testid="form-actions-cancel-button"]',
-    toast: {
-      content: ':nth-child(2) > .p-toast-message-content',
-      closeBtn: ':nth-child(2) >.p-toast-message-content .p-toast-icon-close'
-    }
+    actionsCancelButton: '[data-testid="form-actions-cancel-button"]'
   }
 }
+
+const teamName = generateUniqueName('Team')
 
 describe('Teams Permissions', () => {
   beforeEach(() => {
     cy.login()
-    cy.openMenuItem('Teams Permissions');
+    cy.openMenuItem('Teams Permissions')
   })
 
   it('should create a new team', () => {
     // Arrange
-    cy.get(selectors.list.searchField).type('New Team')
+    cy.get(selectors.list.searchField).type(teamName)
     cy.get(selectors.list.filteredRow.empty)
       .should('be.visible')
       .and('have.text', 'No teams found.')
@@ -62,7 +59,7 @@ describe('Teams Permissions', () => {
 
     // Act
     // Test different permissions scenarios and verify whether form is enabled/disabled
-    cy.get(selectors.form.teamName).type('New Team')
+    cy.get(selectors.form.teamName).type(teamName)
     cy.get(selectors.form.allPermissionsToTarget).click()
     cy.get(selectors.form.actionsSubmitButton).should('be.enabled')
 
@@ -77,14 +74,12 @@ describe('Teams Permissions', () => {
     cy.get(selectors.form.actionsSubmitButton).click()
 
     // Assert
-    cy.get(selectors.form.toast.content)
-      .should('be.visible')
-      .and('contain', 'successYour Team Permission has been created')
+    cy.verifyToast('successYour Team Permission has been created')
 
     cy.get(selectors.form.actionsCancelButton).click()
 
-    cy.get(selectors.list.searchField).type('New Team')
-    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'New Team')
+    cy.get(selectors.list.searchField).type(teamName)
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', teamName)
     cy.get(selectors.list.filteredRow.permissionsColumn).should(
       'have.text',
       'View Content Delivery SettingsEdit Content Delivery SettingsShow more (46)'
@@ -92,7 +87,6 @@ describe('Teams Permissions', () => {
     cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
 
     // Cleanup
-    cy.get(selectors.form.toast.closeBtn).click()
     cy.get(selectors.list.actionsMenu.button).click()
     cy.get(selectors.list.actionsMenu.deleteAction).click()
 
@@ -100,12 +94,10 @@ describe('Teams Permissions', () => {
     cy.get(selectors.list.deleteDialog.deleteButton).click()
 
     cy.get(selectors.list.searchField).clear()
-    cy.get(selectors.list.searchField).type('New Team')
+    cy.get(selectors.list.searchField).type(teamName)
     cy.get(selectors.list.filteredRow.empty)
       .should('be.visible')
       .and('have.text', 'No teams found.')
-    cy.get(selectors.list.toast.content)
-      .should('be.visible')
-      .and('contain', 'Team Permission successfully deleted')
+    cy.verifyToast('Team Permission successfully deleted')
   })
 })

--- a/cypress/e2e/teams-permissions.cy.js
+++ b/cypress/e2e/teams-permissions.cy.js
@@ -20,7 +20,7 @@ const selectors = {
     }
   },
   form: {
-    teamName: '[data-testid="teams-permissions-form__name__field-text"]',
+    teamName: '[data-testid="teams-permissions-form__name__field-text__input"]',
     teamNameError: '[data-testid="teams-permissions-form__name__field-text__error-message"]',
     teamStatus: '[data-testid="teams-permissions-form__form-fields__status"]',
     allPermissionsToTarget: '[aria-label="Move All to Target"] > .p-icon',
@@ -73,8 +73,7 @@ describe('Teams Permissions', () => {
     cy.get(selectors.form.actionsSubmitButton).click()
 
     // Assert
-    cy.verifyToast('successYour Team Permission has been created')
-
+    cy.verifyToast('success', 'Your Team Permission has been created')
     cy.get(selectors.form.actionsCancelButton).click()
 
     cy.get(selectors.list.searchField).type(teamName)

--- a/cypress/e2e/your-settings.cy.js
+++ b/cypress/e2e/your-settings.cy.js
@@ -5,11 +5,8 @@ const selectors = {
     mobileCountryCodeOptions: '[data-testid="contact__mobile__country-code-options"]',
     countryCodeFilter: '.p-dropdown-filter',
     countryCodeOption: (countryCode) => `#countryCallCode_${countryCode}`,
-    submitButton: '[data-testid="form-actions-submit-button"]',
-  },
-  toast: {
-    content: '.p-toast-message-content',
-  },
+    submitButton: '[data-testid="form-actions-submit-button"]'
+  }
 }
 
 describe('Your Settings spec', () => {
@@ -38,6 +35,6 @@ describe('Your Settings spec', () => {
 
     // Assert
     cy.wait('@patchUser')
-    cy.get(selectors.toast.content).should('have.text', 'successYour user has been updated')
+    cy.verifyToast('successYour user has been updated')
   })
 })

--- a/cypress/e2e/your-settings.cy.js
+++ b/cypress/e2e/your-settings.cy.js
@@ -35,6 +35,6 @@ describe('Your Settings spec', () => {
 
     // Assert
     cy.wait('@patchUser')
-    cy.verifyToast('successYour user has been updated')
+    cy.verifyToast('success', 'Your user has been updated')
   })
 })

--- a/cypress/e2mock/your-settings.cy.js
+++ b/cypress/e2mock/your-settings.cy.js
@@ -102,7 +102,7 @@ describe('Your Settings spec', () => {
 
     // Assert
     cy.wait('@patchUser').its('request.body').should('deep.equal', payload)
-    cy.verifyToast('successYour user has been updated')
+    cy.verifyToast('success', 'Your user has been updated')
   })
 
   it('should edit user email', () => {
@@ -119,7 +119,8 @@ describe('Your Settings spec', () => {
     cy.wait('@patchUser')
 
     cy.verifyToast(
-      'Confirmation email sentCheck your inbox and follow the instructions to verify this new email.'
+      'Confirmation email sent',
+      'Check your inbox and follow the instructions to verify this new email.'
     )
   })
 })

--- a/cypress/e2mock/your-settings.cy.js
+++ b/cypress/e2mock/your-settings.cy.js
@@ -14,15 +14,15 @@ const payload = {
 const selectors = {
   profile: {
     firstNameInput: '[data-testid="profile__first-name__input"]',
-    firstNameError: '[data-testid="profile__first-name__input__error-message"]',
+    firstNameError: '[data-testid="profile__first-name__error-message"]',
     lastNameInput: '[data-testid="profile__last-name__input"]',
-    lastNameError: '[data-testid="profile__last-name__input__error-message"]',
+    lastNameError: '[data-testid="profile__last-name__error-message"]',
     timezoneOptions: '[data-testid="profile__timezone__options"]',
     language: '[data-testid="profile__language"]'
   },
   contact: {
     emailInput: '[data-testid="contact__email__input"]',
-    emailError: '[data-testid="contact__email__input__error-message"]',
+    emailError: '[data-testid="contact__email__error-message"]',
     mobileCountryCodeOptions: '[data-testid="contact__mobile__country-code-options"]',
     countryCodeFilter: '.p-dropdown-filter',
     countryCodeOption: (countryCode) => `#countryCallCode_${countryCode}`,

--- a/cypress/e2mock/your-settings.cy.js
+++ b/cypress/e2mock/your-settings.cy.js
@@ -18,7 +18,7 @@ const selectors = {
     lastNameInput: '[data-testid="profile__last-name__input"]',
     lastNameError: '[data-testid="profile__last-name__error-text"]',
     timezoneOptions: '[data-testid="profile__timezone__options"]',
-    language: '[data-testid="profile__language"]',
+    language: '[data-testid="profile__language"]'
   },
   contact: {
     emailInput: '[data-testid="contact__email__input"]',
@@ -27,21 +27,18 @@ const selectors = {
     countryCodeFilter: '.p-dropdown-filter',
     countryCodeOption: (countryCode) => `#countryCallCode_${countryCode}`,
     mobileInput: '[data-testid="contact__mobile__input"]',
-    mobileError: '[data-testid="contact__mobile__error-text"]',
+    mobileError: '[data-testid="contact__mobile__error-text"]'
   },
   security: {
     oldPasswordInput: '[data-testid="security__old-password__input"]',
     newPasswordInput: '[data-testid="security__new-password__input"]',
     confirmPasswordInput: '[data-testid="security__confirm-password__input"]',
     confirmPasswordError: '[data-testid="security__confirm-password__error-text"]',
-    twoFactorToggle: '.p-inputswitch-slider',
+    twoFactorToggle: '.p-inputswitch-slider'
   },
   form: {
-    submitButton: '[data-testid="form-actions-submit-button"]',
-  },
-  toast: {
-    content: '.p-toast-message-content',
-  },
+    submitButton: '[data-testid="form-actions-submit-button"]'
+  }
 }
 
 describe('Your Settings spec', () => {
@@ -105,7 +102,7 @@ describe('Your Settings spec', () => {
 
     // Assert
     cy.wait('@patchUser').its('request.body').should('deep.equal', payload)
-    cy.get(selectors.toast.content).should('have.text', 'successYour user has been updated')
+    cy.verifyToast('successYour user has been updated')
   })
 
   it('should edit user email', () => {
@@ -121,8 +118,7 @@ describe('Your Settings spec', () => {
     // Assert
     cy.wait('@patchUser')
 
-    cy.get(selectors.toast.content).should(
-      'have.text',
+    cy.verifyToast(
       'Confirmation email sentCheck your inbox and follow the instructions to verify this new email.'
     )
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -57,21 +57,21 @@ Cypress.Commands.add('openMenuItem', (menuItemLabel) => {
 })
 
 /**
- * Custom command to handle toast messages.
+ * Custom command to verify the visibility and content of a toast message.
  *
- * @param {string} message - The message to verify in the toast.
- * @example
- * cy.verifyToast('Your credential token has been created')
+ * @param {string} summary - The summary text of the toast message.
+ * @param {string} detail - The detail text of the toast message.
  */
-Cypress.Commands.add('verifyToast', (message) => {
-  const messageText = typeof message === 'string' ? message : message.text
-  cy.get(`[data-testid="toast-block__content__${messageText}"]`)
+Cypress.Commands.add('verifyToast', (summary, detail = '') => {
+  const customId = `[data-testid="toast-block__content__${summary}${detail}"]`
+  const messageText = `${summary}${detail}`
+  cy.get(customId)
     .should('be.visible')
     .and('contain', messageText)
     .then(($toast) => {
       $toast.siblings('div').find('.p-toast-icon-close').trigger('click')
     })
     .then(() => {
-      cy.get(`[data-testid="toast-block__content__${messageText}"]`).should('not.be.visible')
+      cy.get(customId).should('not.be.visible')
     })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -71,4 +71,7 @@ Cypress.Commands.add('verifyToast', (message) => {
     .then(($toast) => {
       $toast.siblings('div').find('.p-toast-icon-close').trigger('click')
     })
+    .then(() => {
+      cy.get(`[data-testid="toast-block__content__${messageText}"]`).should('not.be.visible')
+    })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,8 +63,9 @@ Cypress.Commands.add('openMenuItem', (menuItemLabel) => {
  * @param {string} detail - The detail text of the toast message.
  */
 Cypress.Commands.add('verifyToast', (summary, detail = '') => {
-  const customId = `[data-testid="toast-block__content__${summary}${detail}"]`
   const messageText = `${summary}${detail}`
+  const customId = `[data-testid="toast-block__content__${messageText}"]`
+
   cy.get(customId)
     .should('be.visible')
     .and('contain', messageText)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -5,52 +5,70 @@
 const selectors = {
   menu: {
     avatarIcon: '[data-testid="profile-block__avatar"]',
-    menuItem: (menuItemLabel) => `li[aria-label="${menuItemLabel}"] > .p-menuitem-content > .p-menuitem-link`,
+    menuItem: (menuItemLabel) =>
+      `li[aria-label="${menuItemLabel}"] > .p-menuitem-content > .p-menuitem-link`
   },
   login: {
     emailInput: '[data-testid="signin-block__email-input"]',
     nextButton: '[data-testid="signin-block__next-button"] > .p-button-label',
     passwordInput: '[data-testid="signin-block__password-input"] > .p-inputtext',
-    signInButton: '[data-testid="signin-block__signin-button"] > .p-button-label',
+    signInButton: '[data-testid="signin-block__signin-button"] > .p-button-label'
   },
   sidebar: {
     toggleButton: '[data-testid="sidebar-block__toggle-button"]',
-    menuItem: (productName) => `[data-testid="sidebar-block__menu-item__${productName}"]`,
-  },
-};
+    menuItem: (productName) => `[data-testid="sidebar-block__menu-item__${productName}"]`
+  }
+}
 
 // Disable test failure for all uncaught exceptions
 Cypress.on('uncaught:exception', (err, runnable) => {
-  console.log('Uncaught exception in test:', runnable.title);
-  console.error('Uncaught exception:', err);
-  return false;
-});
+  console.log('Uncaught exception in test:', runnable.title)
+  console.error('Uncaught exception:', err)
+  return false
+})
 
 // Function to perform login
 const login = (email, password) => {
-  cy.visit('/login');
-  cy.get(selectors.login.emailInput).type(email);
-  cy.get(selectors.login.nextButton).click();
-  cy.get(selectors.login.passwordInput).type(password);
-  cy.get(selectors.login.signInButton).click();
-};
+  cy.visit('/login')
+  cy.get(selectors.login.emailInput).type(email)
+  cy.get(selectors.login.nextButton).click()
+  cy.get(selectors.login.passwordInput).type(password, { log: false })
+  cy.get(selectors.login.signInButton).click()
+}
 
 // Custom command to perform login using environment variables
 Cypress.Commands.add('login', () => {
-  const email = Cypress.env('CYPRESS_EMAIL_STAGE');
-  const password = Cypress.env('CYPRESS_PASSWORD_STAGE');
-  cy.log(`🔐 Authenticating | ${email}`);
-  login(email, password);
-});
+  const email = Cypress.env('CYPRESS_EMAIL_STAGE')
+  const password = Cypress.env('CYPRESS_PASSWORD_STAGE')
+  cy.log(`🔐 Authenticating | ${email}`)
+  login(email, password)
+})
 
 // Custom command to open a product through the sidebar menu
 Cypress.Commands.add('openProductThroughSidebar', (productName) => {
-  cy.get(selectors.sidebar.toggleButton).click();
-  cy.get(selectors.sidebar.menuItem(productName)).click();
-});
+  cy.get(selectors.sidebar.toggleButton).click()
+  cy.get(selectors.sidebar.menuItem(productName)).click()
+})
 
 // Custom command to open a menu item
 Cypress.Commands.add('openMenuItem', (menuItemLabel) => {
-  cy.get(selectors.menu.avatarIcon).click();
-  cy.get(selectors.menu.menuItem(menuItemLabel)).click();
-});
+  cy.get(selectors.menu.avatarIcon).click()
+  cy.get(selectors.menu.menuItem(menuItemLabel)).click()
+})
+
+/**
+ * Custom command to handle toast messages.
+ *
+ * @param {string} message - The message to verify in the toast.
+ * @example
+ * cy.verifyToast('Your credential token has been created')
+ */
+Cypress.Commands.add('verifyToast', (message) => {
+  const messageText = typeof message === 'string' ? message : message.text
+  cy.get(`[data-testid="toast-block__content__${messageText}"]`)
+    .should('be.visible')
+    .and('contain', messageText)
+    .then(($toast) => {
+      $toast.siblings('div').find('.p-toast-icon-close').trigger('click')
+    })
+})

--- a/src/templates/form-fields-inputs/fieldText.vue
+++ b/src/templates/form-fields-inputs/fieldText.vue
@@ -39,9 +39,15 @@
   const attrs = useAttrs()
   const hasDescriptionSlot = !!slots.description
 
-  const testIdError = computed(() => {
-    const id = attrs['data-testid']
-    return id ? `${id}__error-message` : 'error-message'
+  const customTestId = computed(() => {
+    const id = attrs['data-testid'] || 'field-text'
+
+    return {
+      label: `${id}__label`,
+      input: `${id}__input`,
+      description: `${id}__description`,
+      error: `${id}__error-message`
+    }
   })
 
   const {
@@ -61,11 +67,13 @@
 <template>
   <label
     :for="props.name"
+    :data-testid="customTestId.label"
     class="text-color text-base font-medium leading-5"
   >
     {{ props.label }}
   </label>
   <InputText
+    :data-testid="customTestId.input"
     ref="inputRef"
     :id="name"
     v-model="inputValue"
@@ -77,11 +85,10 @@
     @input="handleChange"
     :class="{ 'p-invalid': errorMessage }"
     @blur="handleBlur"
-    v-bind="$attrs"
   />
   <small
     v-if="errorMessage"
-    :data-testid="testIdError"
+    :data-testid="customTestId.error"
     class="p-error text-xs font-normal leading-tight"
   >
     {{ errorMessage }}
@@ -89,6 +96,7 @@
   <small
     class="text-xs text-color-secondary font-normal leading-5"
     v-if="props.description || hasDescriptionSlot"
+    :data-testid="customTestId.description"
   >
     <slot name="description">
       {{ props.description }}

--- a/src/templates/form-fields-inputs/fieldTextArea.vue
+++ b/src/templates/form-fields-inputs/fieldTextArea.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { toRef, useSlots } from 'vue'
+  import { toRef, useSlots, useAttrs, computed } from 'vue'
   import { useField } from 'vee-validate'
   import TextArea from 'primevue/textarea'
 
@@ -51,16 +51,31 @@
   } = useField(name, undefined, {
     initialValue: props.value
   })
+
+  const attrs = useAttrs()
+
+  const customTestId = computed(() => {
+    const id = attrs['data-testid'] || 'field-text'
+
+    return {
+      label: `${id}__label`,
+      textarea: `${id}__textarea`,
+      description: `${id}__description`,
+      error: `${id}__error-message`
+    }
+  })
 </script>
 
 <template>
   <label
     :for="props.name"
+    :data-testid="customTestId.label"
     class="text-color text-base font-medium leading-5"
   >
     {{ props.label }}
   </label>
   <TextArea
+    :data-testid="customTestId.textarea"
     :id="name"
     v-model="inputValue"
     :name="props.name"
@@ -76,12 +91,14 @@
   />
   <small
     v-if="errorMessage"
+    :data-testid="customTestId.error"
     class="p-error text-xs font-normal leading-tight"
   >
     {{ errorMessage }}
   </small>
   <small
     class="text-xs text-color-secondary font-normal leading-5"
+    :data-testid="customTestId.description"
     v-if="props.description || hasDescriptionSlot"
   >
     <slot name="description">

--- a/src/templates/toast-block/index.vue
+++ b/src/templates/toast-block/index.vue
@@ -1,20 +1,27 @@
 <template>
   <Toast :pt="toastOptions">
     <template #message="{ message }">
-      <div class="flex flex-column flex-grow">
+      <div
+        class="flex flex-column flex-grow"
+        :data-testid="handleDataTestId(message)"
+      >
         <header class="flex gap-2 items-center h-8 w-[calc(100%-2.5em)] max-w-2xl">
           <Tag
             :icon="composeIconStyle(message.severity)"
             :severity="handleSeverity(message)"
             :pt="{ icon: { class: 'mr-0' }, root: { class: 'w-6 h-6' } }"
           />
-          <h5 class="text-color text-base font-semibold truncate">
+          <h5
+            class="text-color text-base font-semibold truncate"
+            :data-testid="handleDataTestIdInItem(message, 'title')"
+          >
             {{ parseText(message.summary, CHAR_LIMITS.SUMMARY) }}
           </h5>
         </header>
         <p
           class="text-sm text-color-secondary font-normal mt-3"
           v-if="message.detail"
+          :data-testid="handleDataTestIdInItem(message, 'detail')"
         >
           {{ parseText(message.detail, CHAR_LIMITS.DETAIL) }}
         </p>
@@ -24,6 +31,7 @@
         >
           <PrimeButton
             v-if="message.action.link"
+            :data-testid="handleDataTestIdInItem(message, 'link')"
             link
             size="small"
             :label="message.action.link.label"
@@ -31,6 +39,7 @@
           />
           <PrimeButton
             v-if="message.action.secondary"
+            :data-testid="handleDataTestIdInItem(message, 'secondary')"
             outlined
             size="small"
             :label="message.action.secondary.label"
@@ -39,6 +48,7 @@
           <PrimeButton
             severity="secondary"
             v-if="message.action.primary"
+            :data-testid="handleDataTestIdInItem(message, 'primary')"
             size="small"
             :label="message.action.primary.label"
             @click="handleClick(message, 'primary')"
@@ -77,13 +87,45 @@
     }
   }
 
+  const isString = (str) => typeof str === 'string'
+
   const parseText = (text, charLimit) => {
-    return text.substring(0, charLimit)
+    const existsAndIsString = text && isString(text)
+    return existsAndIsString && text.substring(0, charLimit)
   }
 
   const showActions = (message) => {
     if (!message?.action) return false
     return !!Object.keys(message.action).length
+  }
+
+  const handleDataTestId = (message) => {
+    const { summary, detail } = message || {}
+
+    const summaryExists = summary && isString(summary)
+    const detailExists = detail && isString(detail)
+
+    const prefix = 'toast-block__content'
+
+    if (summaryExists && detailExists) {
+      return `${prefix}__${summary}${detail}`
+    }
+
+    if (summaryExists) {
+      return `${prefix}__${summary}`
+    }
+
+    if (detailExists) {
+      return `${prefix}__${detail}`
+    }
+
+    return prefix
+  }
+
+  const handleDataTestIdInItem = (message, item) => {
+    const dataTestid = handleDataTestId(message)
+
+    return `${dataTestid}__${item}`
   }
 
   const handleSeverity = (message) => {

--- a/src/views/Credentials/CreateView.vue
+++ b/src/views/Credentials/CreateView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Create Credential"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Create Credential"
+        data-testid="credentials__create-view__page-heading"
+      />
     </template>
     <template #content>
       <CreateFormBlock

--- a/src/views/Credentials/EditView.vue
+++ b/src/views/Credentials/EditView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Edit Credential"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Edit Credential"
+        data-testid="credentials__edit-view__page-heading"
+      />
     </template>
     <template #content>
       <EditFormBlock

--- a/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
+++ b/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
@@ -34,15 +34,18 @@
   <FormHorizontal
     title="General"
     description="Create a credential to use and authenticate Edge Orchestrator services."
+    data-testid="credentials-form__section__general"
   >
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
+          data-testid="credentials-form__name-field__label"
           for="name"
           class="text-color text-base font-medium"
           >Name *</label
         >
         <InputText
+          data-testid="credentials-form__name-field__input"
           v-model="name"
           id="name"
           type="text"
@@ -51,6 +54,7 @@
         />
         <small
           v-if="nameError"
+          data-testid="credentials-form__name-field__error-text"
           class="p-error text-xs font-normal leading-tight"
           >{{ nameError }}</small
         >
@@ -58,11 +62,13 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
+          data-testid="credentials-form__description-field__label"
           for="description"
           class="text-color text-base font-medium"
           >Description</label
         >
         <PrimeTextarea
+          data-testid="credentials-form__description-field__textarea"
           v-model="description"
           id="description"
           rows="2"
@@ -70,7 +76,10 @@
           class="w-full"
           :disabled="props.generatedToken"
         />
-        <small class="text-xs text-color-secondary font-normal leading-5">
+        <small
+          class="text-xs text-color-secondary font-normal leading-5"
+          data-testid="credentials-form__description-field__description"
+        >
           Description and purpose of the credential.
         </small>
       </div>
@@ -79,10 +88,12 @@
   <FormHorizontal
     title="Token"
     description="Save the credential to generate the token for Edge Orchestrator."
+    data-testid="credentials-form__section__token"
   >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <label
+          data-testid="credentials-form__token-field__label"
           for="personalToken"
           class="text-color text-base font-medium"
         >
@@ -93,6 +104,7 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg flex-col items-start gap-2">
             <PrimePassword
+              data-testid="credentials-form__token-field__input"
               id="personalToken"
               v-model="tokenValue"
               type="text"
@@ -103,6 +115,7 @@
             />
           </span>
           <PrimeButton
+            data-testid="credentials-form__token-field__copy-token-button"
             icon="pi pi-clone"
             outlined
             type="button"
@@ -115,7 +128,10 @@
       </div>
     </template>
   </FormHorizontal>
-  <FormHorizontal title="Status">
+  <FormHorizontal
+    title="Status"
+    data-testid="credentials-form__section__status"
+  >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <div
@@ -123,12 +139,18 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg items-start gap-2 pb-3 pt-2">
             <InputSwitch
+              data-testid="credentials-form__status-field__switch"
               v-model="status"
               :disabled="props.generatedToken"
               id="active"
             />
             <div class="flex-col gap-1">
-              <div class="text-color text-sm font-normal leading-5">Active</div>
+              <div
+                class="text-color text-sm font-normal leading-5"
+                data-testid="credentials-form__status-field__label"
+              >
+                Active
+              </div>
             </div>
           </span>
         </div>

--- a/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
+++ b/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
@@ -39,6 +39,7 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
+          data-testid="credentials-create-form__name-field"
           label="Name *"
           name="name"
           :value="name"
@@ -47,6 +48,7 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldTextArea
+          data-testid="credentials-create-form__description-field"
           label="Description"
           name="description"
           :value="description"

--- a/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
+++ b/src/views/Credentials/FormFields/FormFieldsCreateCredentials.vue
@@ -34,18 +34,18 @@
   <FormHorizontal
     title="General"
     description="Create a credential to use and authenticate Edge Orchestrator services."
-    data-testid="credentials-form__section__general"
+    data-testid="credentials-create-form__section__general"
   >
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
-          data-testid="credentials-form__name-field__label"
+          data-testid="credentials-create-form__name-field__label"
           for="name"
           class="text-color text-base font-medium"
           >Name *</label
         >
         <InputText
-          data-testid="credentials-form__name-field__input"
+          data-testid="credentials-create-form__name-field__input"
           v-model="name"
           id="name"
           type="text"
@@ -54,7 +54,7 @@
         />
         <small
           v-if="nameError"
-          data-testid="credentials-form__name-field__error-text"
+          data-testid="credentials-create-form__name-field__error-text"
           class="p-error text-xs font-normal leading-tight"
           >{{ nameError }}</small
         >
@@ -62,13 +62,13 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
-          data-testid="credentials-form__description-field__label"
+          data-testid="credentials-create-form__description-field__label"
           for="description"
           class="text-color text-base font-medium"
           >Description</label
         >
         <PrimeTextarea
-          data-testid="credentials-form__description-field__textarea"
+          data-testid="credentials-create-form__description-field__textarea"
           v-model="description"
           id="description"
           rows="2"
@@ -78,7 +78,7 @@
         />
         <small
           class="text-xs text-color-secondary font-normal leading-5"
-          data-testid="credentials-form__description-field__description"
+          data-testid="credentials-create-form__description-field__description"
         >
           Description and purpose of the credential.
         </small>
@@ -88,12 +88,12 @@
   <FormHorizontal
     title="Token"
     description="Save the credential to generate the token for Edge Orchestrator."
-    data-testid="credentials-form__section__token"
+    data-testid="credentials-create-form__section__token"
   >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <label
-          data-testid="credentials-form__token-field__label"
+          data-testid="credentials-create-form__token-field__label"
           for="personalToken"
           class="text-color text-base font-medium"
         >
@@ -104,7 +104,7 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg flex-col items-start gap-2">
             <PrimePassword
-              data-testid="credentials-form__token-field__input"
+              data-testid="credentials-create-form__token-field__input"
               id="personalToken"
               v-model="tokenValue"
               type="text"
@@ -115,7 +115,7 @@
             />
           </span>
           <PrimeButton
-            data-testid="credentials-form__token-field__copy-token-button"
+            data-testid="credentials-create-form__token-field__copy-token-button"
             icon="pi pi-clone"
             outlined
             type="button"
@@ -130,7 +130,7 @@
   </FormHorizontal>
   <FormHorizontal
     title="Status"
-    data-testid="credentials-form__section__status"
+    data-testid="credentials-create-form__section__status"
   >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
@@ -139,7 +139,7 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg items-start gap-2 pb-3 pt-2">
             <InputSwitch
-              data-testid="credentials-form__status-field__switch"
+              data-testid="credentials-create-form__status-field__switch"
               v-model="status"
               :disabled="props.generatedToken"
               id="active"
@@ -147,7 +147,7 @@
             <div class="flex-col gap-1">
               <div
                 class="text-color text-sm font-normal leading-5"
-                data-testid="credentials-form__status-field__label"
+                data-testid="credentials-create-form__status-field__label"
               >
                 Active
               </div>

--- a/src/views/Credentials/FormFields/FormFieldsEditCredentials.vue
+++ b/src/views/Credentials/FormFields/FormFieldsEditCredentials.vue
@@ -18,15 +18,18 @@
   <FormHorizontal
     title="General"
     description="Edit a credential to use and authenticate Edge Orchestrator services."
+    data-testid="credentials-edit-form__section__general"
   >
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
+          data-testid="credentials-edit-form__name-field__label"
           for="name"
           class="text-color text-base font-medium"
           >Name *</label
         >
         <InputText
+          data-testid="credentials-edit-form__name-field__input"
           v-model="name"
           id="name"
           type="text"
@@ -34,6 +37,7 @@
         />
         <small
           v-if="nameError"
+          data-testid="credentials-edit-form__name-field__error-text"
           class="p-error text-xs font-normal leading-tight"
           >{{ nameError }}</small
         >
@@ -41,18 +45,23 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <label
+          data-testid="credentials-edit-form__description-field__label"
           for="description"
           class="text-color text-base font-medium"
           >Description</label
         >
         <PrimeTextarea
+          data-testid="credentials-edit-form__description-field__textarea"
           v-model="description"
           id="description"
           rows="2"
           cols="30"
           class="w-full"
         />
-        <small class="text-xs text-color-secondary font-normal leading-5">
+        <small
+          class="text-xs text-color-secondary font-normal leading-5"
+          data-testid="credentials-edit-form__description-field__description"
+        >
           Description of the credential.
         </small>
       </div>
@@ -61,10 +70,12 @@
   <FormHorizontal
     title="Token"
     description="Copy the credential token to use with Edge Orchestrator."
+    data-testid="credentials-edit-form__section__token"
   >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <label
+          data-testid="credentials-edit-form__token-field__label"
           for="personalToken"
           class="text-color text-base font-medium"
         >
@@ -75,6 +86,7 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg flex-col items-start gap-2">
             <PrimePassword
+              data-testid="credentials-edit-form__token-field__input"
               id="personalToken"
               v-model="token"
               type="text"
@@ -85,6 +97,7 @@
             />
           </span>
           <PrimeButton
+            data-testid="credentials-edit-form__token-field__copy-token-button"
             icon="pi pi-clone"
             outlined
             type="button"
@@ -96,7 +109,10 @@
       </div>
     </template>
   </FormHorizontal>
-  <FormHorizontal title="Status">
+  <FormHorizontal
+    title="Status"
+    data-testid="credentials-edit-form__section__status"
+  >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <div
@@ -104,11 +120,17 @@
         >
           <span class="p-input-icon-right w-full flex max-w-lg items-start gap-2 pb-3 pt-2">
             <InputSwitch
+              data-testid="credentials-edit-form__status-field__switch"
               v-model="status"
               id="active"
             />
             <div class="flex-col gap-1">
-              <div class="text-color text-sm font-normal leading-5">Active</div>
+              <div
+                class="text-color text-sm font-normal leading-5"
+                data-testid="credentials-edit-form__status-field__label"
+              >
+                Active
+              </div>
             </div>
           </span>
         </div>

--- a/src/views/Credentials/FormFields/FormFieldsEditCredentials.vue
+++ b/src/views/Credentials/FormFields/FormFieldsEditCredentials.vue
@@ -24,6 +24,7 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
+          data-testid="credentials-edit-form__name-field"
           label="Name *"
           name="name"
           :value="name"
@@ -32,6 +33,7 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldTextArea
+          data-testid="credentials-edit-form__description-field"
           label="Description"
           name="description"
           :value="description"

--- a/src/views/Credentials/ListView.vue
+++ b/src/views/Credentials/ListView.vue
@@ -1,7 +1,10 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Credentials"></PageHeadingBlock>
+      <PageHeadingBlock
+        pageTitle="Credentials"
+        data-testid="credentials__list-view__page-heading"
+      />
     </template>
     <template #content>
       <ListTableBlock
@@ -18,6 +21,7 @@
       />
       <EmptyResultsBlock
         v-else
+        data-testid="credentials__list-view__empty-results-block"
         title="No credentials have been generated"
         description="Click the button below to generate your first credential."
         createButtonLabel="Credential"

--- a/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
+++ b/src/views/YourSettings/FormFields/FormFieldsYourSettings.vue
@@ -100,7 +100,7 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
-          data-testid="profile__first-name__input"
+          data-testid="profile__first-name"
           label="First Name *"
           name="firstName"
           :value="firstName"
@@ -109,7 +109,7 @@
       </div>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
-          data-testid="profile__last-name__input"
+          data-testid="profile__last-name"
           label="Last Name *"
           name="lastName"
           :value="lastName"
@@ -176,7 +176,7 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
-          data-testid="contact__email__input"
+          data-testid="contact__email"
           label="Email *"
           name="email"
           :value="email"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Add data-testid to credentials related blocks and views
- Create e2e tests creation and deletion of credential 
- Create verifyToast command to verify text and auto close it
- Refactor other tests to use created utils and commands
- Document added command

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/6d7e2f27-fb74-47f9-ad9a-cd92a40f1ffa

### Does it have a link on Figma?
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
