### PR TITLE
[UXE-3247] test: e2e edge services crud

### DIFF
--- a/cypress/e2e/edge-services.cy.js
+++ b/cypress/e2e/edge-services.cy.js
@@ -1,13 +1,15 @@
+import generateUniqueName from '../support/utils'
+
 const selectors = {
   list: {
-    createServiceButton: '[data-testid="create_Service_button"] > .p-button-label',
+    createServiceButton: '[data-testid="create_Service_button"]',
     searchInput: '[data-testid="data-table-search-input"]',
     filteredRow: {
       nameColumn: '[data-testid="list-table-block__column__name__row"]',
       statusColumn: '[data-testid="list-table-block__column__labelActive__row"] > .p-tag-value'
     },
     actionsMenu: {
-      button: '[data-testid="data-table-actions-column-body-actions-menu-button"] > .p-button-icon',
+      button: '[data-testid="data-table-actions-column-body-actions-menu-button"]',
       deleteAction: '#overlay_menu_1 > .p-menuitem-content > .p-menuitem-link > .p-menuitem-text'
     },
     deleteDialog: {
@@ -15,16 +17,15 @@ const selectors = {
     }
   },
   form: {
-    serviceName: '[data-testid="edge-service-form__name-field"]',
-    nameRequiredLabel: '[data-testid="edge-service-form__name-field-error-message"]',
+    serviceName: '[data-testid="edge-service-form__name-field__input"]',
+    nameRequiredLabel: '[data-testid="edge-service-form__name-field__error-message"]',
     submitButton: '[data-testid="form-actions-submit-button"]',
-    pageTitle: '[data-testid="page_title_EntityName"]',
-    cancelButton: '[data-testid="form-actions-cancel-button"] > .p-button-label'
-  },
-  toast: {
-    createSuccessMessage: ':nth-child(2) > .p-toast-message-content > .flex-column > .text-sm'
+    pageTitle: (entityName) => `[data-testid="page_title_${entityName}"]`,
+    cancelButton: '[data-testid="form-actions-cancel-button"]'
   }
 }
+
+const edgeServiceName = generateUniqueName('EdgeService')
 
 describe('template spec', () => {
   beforeEach(() => {
@@ -37,21 +38,15 @@ describe('template spec', () => {
     cy.get(selectors.list.createServiceButton).click()
 
     // Act
-    cy.get(selectors.form.serviceName).type('TestRequired')
-    cy.get(selectors.form.serviceName).clear()
-    cy.get(selectors.form.nameRequiredLabel).should('have.text', 'Name is a required field')
-    cy.get(selectors.form.serviceName).type('EntityName')
+    cy.get(selectors.form.serviceName).type(edgeServiceName)
     cy.get(selectors.form.submitButton).click()
 
     // Assert
-    cy.get(selectors.toast.createSuccessMessage).should(
-      'have.text',
-      'Your Edge Service has been created'
-    )
-    cy.get(selectors.form.pageTitle).should('have.text', 'EntityName')
+    cy.verifyToast('success', 'Your Edge Service has been created')
+    cy.get(selectors.form.pageTitle(edgeServiceName)).should('have.text', edgeServiceName)
     cy.get(selectors.form.cancelButton).click()
-    cy.get(selectors.list.searchInput).type('EntityName')
-    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'EntityName')
+    cy.get(selectors.list.searchInput).type(edgeServiceName)
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', edgeServiceName)
 
     cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Inactive')
 
@@ -60,5 +55,6 @@ describe('template spec', () => {
     cy.get(selectors.list.actionsMenu.deleteAction).click()
     cy.get(selectors.list.deleteDialog.confirmationInputField).clear()
     cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete{enter}')
+    cy.verifyToast('Resource successfully deleted')
   })
 })

--- a/cypress/e2e/edge-services.cy.js
+++ b/cypress/e2e/edge-services.cy.js
@@ -1,0 +1,64 @@
+const selectors = {
+  list: {
+    createServiceButton: '[data-testid="create_Service_button"] > .p-button-label',
+    searchInput: '[data-testid="data-table-search-input"]',
+    filteredRow: {
+      nameColumn: '[data-testid="list-table-block__column__name__row"]',
+      statusColumn: '[data-testid="list-table-block__column__labelActive__row"] > .p-tag-value'
+    },
+    actionsMenu: {
+      button: '[data-testid="data-table-actions-column-body-actions-menu-button"] > .p-button-icon',
+      deleteAction: '#overlay_menu_1 > .p-menuitem-content > .p-menuitem-link > .p-menuitem-text'
+    },
+    deleteDialog: {
+      confirmationInputField: '[data-testid="delete-dialog-confirmation-input-field"]'
+    }
+  },
+  form: {
+    serviceName: '[data-testid="edge-service-form__name-field"]',
+    nameRequiredLabel: '.p-error',
+    submitButton: '[data-testid="form-actions-submit-button"]',
+    pageTitle: '[data-testid="page_title_EntityName"]',
+    cancelButton: '[data-testid="form-actions-cancel-button"] > .p-button-label'
+  },
+  toast: {
+    createSuccessMessage: ':nth-child(2) > .p-toast-message-content > .flex-column > .text-sm'
+  }
+}
+
+describe('template spec', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.openProductThroughSidebar('edge-services')
+  })
+
+  it('should create and delete an edge service', () => {
+    // Arrange
+    cy.get(selectors.list.createServiceButton).click()
+
+    // Act
+    cy.get(selectors.form.serviceName).type('TestRequired')
+    cy.get(selectors.form.serviceName).clear()
+    cy.get(selectors.form.nameRequiredLabel).should('have.text', 'Name is a required field')
+    cy.get(selectors.form.serviceName).type('EntityName')
+    cy.get(selectors.form.submitButton).click()
+
+    // Assert
+    cy.get(selectors.toast.createSuccessMessage).should(
+      'have.text',
+      'Your Edge Service has been created'
+    )
+    cy.get(selectors.form.pageTitle).should('have.text', 'EntityName')
+    cy.get(selectors.form.cancelButton).click()
+    cy.get(selectors.list.searchInput).type('EntityName')
+    cy.get(selectors.list.filteredRow.nameColumn).should('have.text', 'EntityName')
+
+    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Inactive')
+
+    // Cleanup
+    cy.get(selectors.list.actionsMenu.button).click()
+    cy.get(selectors.list.actionsMenu.deleteAction).click()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).clear()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete{enter}')
+  })
+})

--- a/cypress/e2e/edge-services.cy.js
+++ b/cypress/e2e/edge-services.cy.js
@@ -16,7 +16,7 @@ const selectors = {
   },
   form: {
     serviceName: '[data-testid="edge-service-form__name-field"]',
-    nameRequiredLabel: '.p-error',
+    nameRequiredLabel: '[data-testid="edge-service-form__name-field-error-message"]',
     submitButton: '[data-testid="form-actions-submit-button"]',
     pageTitle: '[data-testid="page_title_EntityName"]',
     cancelButton: '[data-testid="form-actions-cancel-button"] > .p-button-label'

--- a/src/views/EdgeServices/FormFields/FormFieldsEdgeService.vue
+++ b/src/views/EdgeServices/FormFields/FormFieldsEdgeService.vue
@@ -35,6 +35,7 @@
           placeholder="My service"
           :value="name"
           description="Give a unique and descriptive name to identify the service."
+          data-testid="edge-service-form__name-field"
         />
       </div>
     </template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* e2e test to create and delete an edge services 

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.


https://github.com/aziontech/azion-console-kit/assets/109550332/970b77d7-2c35-4429-a6aa-c00c0b4117fd




<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] Safari
