### PR TITLE
[UXE-3941] test: create e2e test for new selectors in data stream

### DIFF
--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -288,6 +288,46 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it('should create a data stream with the datadog connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const datadogOption = 7
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(datadogOption)).click()
+
+    cy.get(selectors.dataStream.datadogConnector.urlInput).type(
+      'https://http-intake.logs.datadoghq.com/v1/input'
+    )
+    cy.get(selectors.dataStream.datadogConnector.apiKeyTextarea).type(
+      'ij9076f1ujik17a81f938yhru5g713422'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'datadog')
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -245,6 +245,49 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it('should create a data stream with the awsKinesis connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const awsKinesisOption = 6
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(awsKinesisOption)).click()
+
+    cy.get(selectors.dataStream.awsKinesisConnector.streamNameInput).type('MyKDFConnector')
+    cy.get(selectors.dataStream.awsKinesisConnector.regionInput).type('us-east-1')
+    cy.get(selectors.dataStream.awsKinesisConnector.accessKeyInput).type('ORIA5ZEH9MW4NL5OITY4')
+    cy.get(selectors.dataStream.awsKinesisConnector.secretKeyInput).type(
+      '+PLjkUWJyOLth3anuWXcLLVrMLeiiiThIokaPEiw'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should(
+      'have.text',
+      'aws_kinesis_firehose'
+    )
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -162,7 +162,7 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
-  it.only('should create a data stream with the elasticsearch connector', () => {
+  it('should create a data stream with the elasticsearch connector', () => {
     // Arrange
     cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
 
@@ -176,10 +176,10 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.connectorDropdown).click()
     cy.get(selectors.dataStream.connectorOption(elasticsearchOption)).click()
 
-    cy.get(selectors.dataStream.elasticSearchConnector.urlInput).type(
+    cy.get(selectors.dataStream.elasticsearchConnector.urlInput).type(
       'https://elasticsearch-domain.com/myindex'
     )
-    cy.get(selectors.dataStream.elasticSearchConnector.apiKeyTextarea).type(
+    cy.get(selectors.dataStream.elasticsearchConnector.apiKeyTextarea).type(
       'VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw'
     )
 
@@ -202,6 +202,46 @@ describe('Data Stream spec', () => {
       'have.text',
       'elasticsearch'
     )
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
+  it.only('should create a data stream with the splunk connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const splunkOption = 5
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(splunkOption)).click()
+
+    cy.get(selectors.dataStream.splunkConnector.urlInput).type(
+      'https://inputs.splunk-client.splunkcloud.com:123456/services/collector'
+    )
+    cy.get(selectors.dataStream.splunkConnector.apiKeyTextarea).type(
+      'crfe25d2-23j8-48gf-a9ks-6b75w3ska674'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'splunk')
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -205,7 +205,7 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
-  it.only('should create a data stream with the splunk connector', () => {
+  it('should create a data stream with the splunk connector', () => {
     // Arrange
     cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
 

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -162,6 +162,49 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it.only('should create a data stream with the elasticsearch connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const elasticsearchOption = 4
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(elasticsearchOption)).click()
+
+    cy.get(selectors.dataStream.elasticSearchConnector.urlInput).type(
+      'https://elasticsearch-domain.com/myindex'
+    )
+    cy.get(selectors.dataStream.elasticSearchConnector.apiKeyTextarea).type(
+      'VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should(
+      'have.text',
+      'elasticsearch'
+    )
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -410,6 +410,50 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it('should create a data stream with the azureBlobStorage connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const azureBlobStorageOption = 10
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(azureBlobStorageOption)).click()
+
+    cy.get(selectors.dataStream.azureBlobStorageConnector.storageAccountInput).type(
+      'mystorageaccount'
+    )
+    cy.get(selectors.dataStream.azureBlobStorageConnector.containerNameInput).type('mycontainer')
+    cy.get(selectors.dataStream.azureBlobStorageConnector.blobSasTokenInput).type(
+      'sp=oiuwdl&st=2022-04-14T18:05:08Z&se=2026-03-02T02:05:08Z&sv=2020-08-04&sr=c&sig=YUi0TBEt7XTlxXex4Jui%2Fc88h6qAgMmCY4XIXeMvxa0%3F'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should(
+      'have.text',
+      'azure_blob_storage'
+    )
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -13,7 +13,10 @@ describe('Data Stream spec', () => {
 
   it('should create a data stream with the standard connector', () => {
     // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
     cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
 
     // Act
     cy.get(selectors.dataStream.nameInput).type(dataStreamName)
@@ -36,6 +39,41 @@ describe('Data Stream spec', () => {
       'Template teste'
     )
     cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'standard')
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
+  it.only('should create a data stream with the kafka connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const kafkaOption = 1
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(kafkaOption)).click()
+    cy.get(selectors.dataStream.kafkaConnector.serverTextarea).type('localhost:80')
+    cy.get(selectors.dataStream.kafkaConnector.topicInput).type('cluster.test.pages.0')
+    cy.get(selectors.dataStream.kafkaConnector.useTlsSlider).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'kafka')
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -363,6 +363,53 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it('should create a data stream with the azureMonitor connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const azureMonitorOption = 9
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(azureMonitorOption)).click()
+
+    cy.get(selectors.dataStream.azureMonitorConnector.logTypeInput).type('AzureMonitorTest')
+    cy.get(selectors.dataStream.azureMonitorConnector.sharedKeyInput).type(
+      'OiA9AdGr4As5Iujg5FAHsTWfawxOD4'
+    )
+    cy.get(selectors.dataStream.azureMonitorConnector.timeGeneratedFieldInput).type(
+      'myCustomTimeField'
+    )
+    cy.get(selectors.dataStream.azureMonitorConnector.workspaceIdInput).type(
+      'kik73154-0426-464c-aij3-eg6d24u87c50'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should(
+      'have.text',
+      'azure_monitor'
+    )
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -42,7 +42,7 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
-  it.only('should create a data stream with the kafka connector', () => {
+  it('should create a data stream with the kafka connector', () => {
     // Arrange
     cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
 
@@ -74,6 +74,51 @@ describe('Data Stream spec', () => {
       'Template teste'
     )
     cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'kafka')
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
+  it('should create a data stream with the s3 connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const s3Option = 2
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(s3Option)).click()
+
+    cy.get(selectors.dataStream.s3Connector.urlInput).type(
+      'https://myownhost.s3.us-east-1.myprovider.com'
+    )
+    cy.get(selectors.dataStream.s3Connector.bucketInput).type('mys3bucket')
+    cy.get(selectors.dataStream.s3Connector.regionInput).type('us-east-1')
+    cy.get(selectors.dataStream.s3Connector.accessKeyInput).type('ORIA5ZEH9MW4NL5OITY4')
+    cy.get(selectors.dataStream.s3Connector.secretKeyInput).type(
+      '+PLjkUWJyOLth3anuWXcLLVrMLeiiiThIokaPEiw'
+    )
+    cy.get(selectors.dataStream.s3Connector.objectKeyPrefixInput).type(
+      'waf_logs_1622575860091_37d66e78-c308-4006-9d4d-1c013ed89276'
+    )
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 's3')
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -328,6 +328,41 @@ describe('Data Stream spec', () => {
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 
+  it('should create a data stream with the ibmQRadar connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const ibmQRadarOption = 8
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(ibmQRadarOption)).click()
+
+    cy.get(selectors.dataStream.ibmQRadarConnector.urlInput).type('http://137.15.824.10:14440')
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'qradar')
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
   afterEach(() => {
     // Cleanup
     cy.deleteProduct(dataStreamName, '/data-stream').then(() => {

--- a/cypress/e2e/data-stream.cy.js
+++ b/cypress/e2e/data-stream.cy.js
@@ -50,6 +50,7 @@ describe('Data Stream spec', () => {
 
     cy.get(selectors.dataStream.createButton).click()
     cy.wait('@getTemplates')
+
     // Act
     cy.get(selectors.dataStream.nameInput).type(dataStreamName)
     cy.get(selectors.dataStream.connectorDropdown).click()
@@ -85,6 +86,7 @@ describe('Data Stream spec', () => {
 
     cy.get(selectors.dataStream.createButton).click()
     cy.wait('@getTemplates')
+
     // Act
     cy.get(selectors.dataStream.nameInput).type(dataStreamName)
     cy.get(selectors.dataStream.connectorDropdown).click()
@@ -119,6 +121,44 @@ describe('Data Stream spec', () => {
       'Template teste'
     )
     cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 's3')
+    cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
+  })
+
+  it('should create a data stream with the bigquery connector', () => {
+    // Arrange
+    cy.intercept('api/v3/data_streaming/templates').as('getTemplates')
+
+    const bigqueryOption = 3
+
+    cy.get(selectors.dataStream.createButton).click()
+    cy.wait('@getTemplates')
+
+    // Act
+    cy.get(selectors.dataStream.nameInput).type(dataStreamName)
+    cy.get(selectors.dataStream.connectorDropdown).click()
+    cy.get(selectors.dataStream.connectorOption(bigqueryOption)).click()
+
+    cy.get(selectors.dataStream.bigQueryConnector.projectIdInput).type('mycustomGBQproject01')
+    cy.get(selectors.dataStream.bigQueryConnector.datasetIdInput).type('myGBQdataset')
+    cy.get(selectors.dataStream.bigQueryConnector.tableIdInput).type('mypagaviewtable01')
+    cy.get(selectors.dataStream.bigQueryConnector.serviceAccountKeyInput).type('{}')
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your data stream has been created')
+
+    cy.get(selectors.list.searchInput).type(dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('name')).should('have.text', dataStreamName)
+    cy.get(selectors.dataStream.list.columnName('dataSource')).should(
+      'have.text',
+      'Edge Applications'
+    )
+    cy.get(selectors.dataStream.list.columnName('templateName')).should(
+      'have.text',
+      'Template teste'
+    )
+    cy.get(selectors.dataStream.list.columnName('endpointType')).should('have.text', 'big_query')
     cy.get(selectors.dataStream.list.columnName('active')).should('have.text', 'Active')
   })
 

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -255,6 +255,11 @@ const selectors = {
       secretKeyInput:
         '[data-testid="data-stream-form__destination__kinesis-secret-key-field__input"]'
     },
+    datadogConnector: {
+      urlInput: '[data-testid="data-stream-form__destination__datadog-url-field__input"]',
+      apiKeyTextarea:
+        '[data-testid="data-stream-form__destination__datadog-api-key-field__textarea"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -237,9 +237,14 @@ const selectors = {
       serviceAccountKeyInput:
         '[data-testid="data-stream-form__destination__service-account-key-field__input"]'
     },
-    elasticSearchConnector: {
+    elasticsearchConnector: {
       urlInput: '[data-testid="data-stream-form__destination__elasticsearch-url-field__input"]',
       apiKeyTextarea: '[data-testid="data-stream-form__destination__api-key-field__textarea"]'
+    },
+    splunkConnector: {
+      urlInput: '[data-testid="data-stream-form__destination__splunk-url-field__input"]',
+      apiKeyTextarea:
+        '[data-testid="data-stream-form__destination__splunk-api-key-field__textarea"]'
     },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -230,6 +230,13 @@ const selectors = {
       objectKeyPrefixInput:
         '[data-testid="data-stream-form__destination__object-key-prefix-field__input"]'
     },
+    bigQueryConnector: {
+      projectIdInput: '[data-testid="data-stream-form__destination__project-id-field__input"]',
+      datasetIdInput: '[data-testid="data-stream-form__destination__dataset-id-field__input"]',
+      tableIdInput: '[data-testid="data-stream-form__destination__table-id-field__input"]',
+      serviceAccountKeyInput:
+        '[data-testid="data-stream-form__destination__service-account-key-field__input"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -273,6 +273,14 @@ const selectors = {
       workspaceIdInput:
         '[data-testid="data-stream-form__destination__azure-monitor-workspace-id-field__input"]'
     },
+    azureBlobStorageConnector: {
+      storageAccountInput:
+        '[data-testid="data-stream-form__destination__azure-blob-storage-storage-account-field__input"]',
+      containerNameInput:
+        '[data-testid="data-stream-form__destination__azure-blob-storage-container-name-field__input"]',
+      blobSasTokenInput:
+        '[data-testid="data-stream-form__destination__azure-blob-storage-blob-token-field__input"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -260,6 +260,9 @@ const selectors = {
       apiKeyTextarea:
         '[data-testid="data-stream-form__destination__datadog-api-key-field__textarea"]'
     },
+    ibmQRadarConnector: {
+      urlInput: '[data-testid="data-stream-form__destination__qradar-url-field__input"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -237,6 +237,10 @@ const selectors = {
       serviceAccountKeyInput:
         '[data-testid="data-stream-form__destination__service-account-key-field__input"]'
     },
+    elasticSearchConnector: {
+      urlInput: '[data-testid="data-stream-form__destination__elasticsearch-url-field__input"]',
+      apiKeyTextarea: '[data-testid="data-stream-form__destination__api-key-field__textarea"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -246,6 +246,15 @@ const selectors = {
       apiKeyTextarea:
         '[data-testid="data-stream-form__destination__splunk-api-key-field__textarea"]'
     },
+    awsKinesisConnector: {
+      streamNameInput:
+        '[data-testid="data-stream-form__destination__kinesis-stream-name-field__input"]',
+      regionInput: '[data-testid="data-stream-form__destination__kinesis-region-field__input"]',
+      accessKeyInput:
+        '[data-testid="data-stream-form__destination__kinesis-access-key-field__input"]',
+      secretKeyInput:
+        '[data-testid="data-stream-form__destination__kinesis-secret-key-field__input"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -263,6 +263,16 @@ const selectors = {
     ibmQRadarConnector: {
       urlInput: '[data-testid="data-stream-form__destination__qradar-url-field__input"]'
     },
+    azureMonitorConnector: {
+      logTypeInput:
+        '[data-testid="data-stream-form__destination__azure-monitor-log-type-field__input"]',
+      sharedKeyInput:
+        '[data-testid="data-stream-form__destination__azure-monitor-shared-key-field__input"]',
+      timeGeneratedFieldInput:
+        '[data-testid="data-stream-form__destination__azure-monitor-generated-field__input"]',
+      workspaceIdInput:
+        '[data-testid="data-stream-form__destination__azure-monitor-workspace-id-field__input"]'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -202,7 +202,9 @@ const selectors = {
     sourceDropdown: '[data-testid="data-stream-form__data-settings__data-source-field__dropdown"]',
     templateDropdown: '[data-testid="data-stream-form__data-settings__template-field__dropdown"]',
     editorBody: '.view-lines',
-    connectorDropdown: '[data-testid="data-stream-form__destination__connector-field__dropdown"]',
+    connectorDropdown:
+      '[data-testid="data-stream-form__destination__connector-field__dropdown"] > .p-dropdown-trigger',
+    connectorOption: (optionIdx) => `#endpoint_${optionIdx}`,
     httpConnector: {
       urlInput: '[data-testid="data-stream-form__destination__url-field__input"]',
       headersInput: '[data-testid="data-stream-form__destination__headers-field-input"]',
@@ -212,12 +214,19 @@ const selectors = {
       maxSizeInput:
         '[data-testid="data-stream-form__destination__payload-max-size-field__input"] > .p-inputtext'
     },
+    kafkaConnector: {
+      serverTextarea:
+        '[data-testid="data-stream-form__destination__bootstrap-servers-field__textarea"]',
+      topicInput: '[data-testid="data-stream-form__destination__kafka-topic-field__input"]',
+      useTlsSlider:
+        '[data-testid="data-stream-form__destination__use-tls-field"] > .p-inputswitch-slider'
+    },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {
       columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`
     }
   },
-  edgeDns:{
+  edgeDns: {
     createButton: '[data-testid="create_Zone_button"] > .p-button-label',
     nameInput: '[data-testid="edge-dns-form__name__input"]',
     domainInput: '[data-testid="edge-dns-form__domain__input"]',
@@ -227,7 +236,7 @@ const selectors = {
     nameRow: '[data-testid="list-table-block__column__name__row"]',
     showMore: '.underline',
     domainRow: '.whitespace-pre',
-    statusRow: '[data-testid="list-table-block__column__status__row"] > .p-tag-value',
+    statusRow: '[data-testid="list-table-block__column__status__row"] > .p-tag-value'
   }
 }
 

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -207,7 +207,7 @@ const selectors = {
     connectorOption: (optionIdx) => `#endpoint_${optionIdx}`,
     httpConnector: {
       urlInput: '[data-testid="data-stream-form__destination__url-field__input"]',
-      headersInput: '[data-testid="data-stream-form__destination__headers-field-input"]',
+      headersInput: '[data-testid="data-stream-form__destination__headers-field__input"]',
       payloadInput: '[data-testid="data-stream-form__destination__payload-format-field__input"]',
       separatorInput:
         '[data-testid="data-stream-form__destination__payload-line-separator-field__input"]',
@@ -220,6 +220,15 @@ const selectors = {
       topicInput: '[data-testid="data-stream-form__destination__kafka-topic-field__input"]',
       useTlsSlider:
         '[data-testid="data-stream-form__destination__use-tls-field"] > .p-inputswitch-slider'
+    },
+    s3Connector: {
+      urlInput: '[data-testid="data-stream-form__destination__url-field__input"]',
+      bucketInput: '[data-testid="data-stream-form__destination__bucket-field__input"]',
+      regionInput: '[data-testid="data-stream-form__destination__region-field__input"]',
+      accessKeyInput: '[data-testid="data-stream-form__destination__access-key-field__input"]',
+      secretKeyInput: '[data-testid="data-stream-form__destination__secret-key-field__input"]',
+      objectKeyPrefixInput:
+        '[data-testid="data-stream-form__destination__object-key-prefix-field__input"]'
     },
     statusSlider: '[data-testid="data-stream-form__section__status"] input',
     list: {

--- a/src/services/data-stream-services/create-data-stream-service.js
+++ b/src/services/data-stream-services/create-data-stream-service.js
@@ -160,7 +160,7 @@ const parseHttpResponse = (httpResponse) => {
       }
     case 400: {
       const apiError = extractApiError(httpResponse)
-      throw new Error(apiError)
+      throw new Error(apiError).message
     }
     case 401:
       throw new Errors.InvalidApiTokenError().message

--- a/src/services/data-stream-services/edit-data-stream-service.js
+++ b/src/services/data-stream-services/edit-data-stream-service.js
@@ -157,7 +157,7 @@ const parseHttpResponse = (httpResponse) => {
       return 'Your data stream has been updated'
     case 400: {
       const apiError = extractApiError(httpResponse)
-      throw new Error(apiError)
+      throw new Error(apiError).message
     }
     case 401:
       throw new Errors.InvalidApiTokenError().message

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -823,7 +823,7 @@
             description="Specifies how long it’ll take for the log to be available after collection. Uses
             ingestion time if not specified."
             placeholder="myCustomTimeField"
-            data-testid="data-stream-form__destination__azure-monitor-generated-field__field"
+            data-testid="data-stream-form__destination__azure-monitor-generated-field"
           />
         </div>
 

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -853,6 +853,7 @@
             :value="storageAccount"
             description="Name of the storage account."
             placeholder="mystorageaccount"
+            data-testid="data-stream-form__destination__azure-blob-storage-storage-account-field"
           />
         </div>
 

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -101,7 +101,7 @@
         <LabelBlock
           for="domains"
           label="Domains"
-          data-testid="data-stream-form__domains__domains-field-label"
+          data-testid="data-stream-form__domains__domains-field__label"
           isRequired
         />
         <PickList
@@ -230,7 +230,7 @@
           <label
             for="customHeaders"
             class="text-color text-base font-medium"
-            data-testid="data-stream-form__destination__headers-field-label"
+            data-testid="data-stream-form__destination__headers-field__label"
             >Custom Headers</label
           >
           <div
@@ -243,7 +243,7 @@
               type="text"
               id="header-value"
               placeholder="header-name:value"
-              data-testid="data-stream-form__destination__headers-field-input"
+              data-testid="data-stream-form__destination__headers-field__input"
             />
             <ButtonPrimer
               icon="pi pi-trash"
@@ -251,7 +251,7 @@
               outlined
               v-if="header.deleted"
               @click="removeHeader(index)"
-              data-testid="data-stream-form__destination__headers-field-remove-button"
+              data-testid="data-stream-form__destination__headers-field__remove-button"
             />
           </div>
 
@@ -263,7 +263,7 @@
             size="small"
             class="w-fit"
             @click="addHeader()"
-            data-testid="data-stream-form__destination__headers-field-add-button"
+            data-testid="data-stream-form__destination__headers-field__add-button"
           />
         </div>
       </div>
@@ -310,12 +310,12 @@
             <label
               for="useTls"
               class="text-sm font-normal leading-tight"
-              data-testid="data-stream-form__destination__use-tls-field-label"
+              data-testid="data-stream-form__destination__use-tls-field__label"
               >Enable Transport Layer Security (TLS)</label
             >
             <small
               class="text-xs text-color-secondary font-normal leading-5"
-              data-testid="data-stream-form__destination__use-tls-field-description"
+              data-testid="data-stream-form__destination__use-tls-field__description"
             >
               Send encrypted data to secure communication. Make sure the receiving connector uses a
               trusted CA certificate.
@@ -369,7 +369,7 @@
           <LabelBlock
             for="accessKey"
             label="Access Key"
-            data-testid="data-stream-form__destination__access-key-field-label"
+            data-testid="data-stream-form__destination__access-key-field__label"
             isRequired
           />
           <PrimePassword
@@ -381,18 +381,18 @@
             :feedback="false"
             toggleMask
             placeholder="ORIA5ZEH9MW4NL5OITY4"
-            data-testid="data-stream-form__destination__access-key-field-input"
+            data-testid="data-stream-form__destination__access-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__access-key-field-description"
+            data-testid="data-stream-form__destination__access-key-field__description"
           >
             Public key to access the bucket.
           </small>
           <small
             id="access-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__access-key-field-error-message"
+            data-testid="data-stream-form__destination__access-key-field__error-message"
             >{{ accessKeyError }}</small
           >
         </div>
@@ -401,7 +401,7 @@
           <LabelBlock
             for="secretKey"
             label="Secret Key"
-            data-testid="data-stream-form__destination__secret-key-field-label"
+            data-testid="data-stream-form__destination__secret-key-field__label"
             isRequired
           />
           <PrimePassword
@@ -413,18 +413,18 @@
             :class="{ 'p-invalid': secretKeyError }"
             :feedback="false"
             toggleMask
-            data-testid="data-stream-form__destination__secret-key-field-input"
+            data-testid="data-stream-form__destination__secret-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__secret-key-field-description"
+            data-testid="data-stream-form__destination__secret-key-field__description"
           >
             Secret key to access the bucket.
           </small>
           <small
             id="secret-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__secret-key-field-error-message"
+            data-testid="data-stream-form__destination__secret-key-field__error-message"
             >{{ secretKeyError }}</small
           >
         </div>
@@ -433,7 +433,7 @@
           <label
             for="objectKeyPrefix"
             class="text-color text-base font-medium"
-            data-testid="data-stream-form__destination__object-key-prefix-field-label"
+            data-testid="data-stream-form__destination__object-key-prefix-field__label"
             >Object Key Prefix</label
           >
           <PrimePassword
@@ -445,11 +445,11 @@
             :class="{ 'p-invalid': objectKeyError }"
             :feedback="false"
             toggleMask
-            data-testid="data-stream-form__destination__object-key-prefix-field-input"
+            data-testid="data-stream-form__destination__object-key-prefix-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__object-key-prefix-field-description"
+            data-testid="data-stream-form__destination__object-key-prefix-field__description"
           >
             Prefix added to the name of the uploaded object to appear on the files that'll be sent.
             Composed of Prefix + Timestamp + UUID.
@@ -457,7 +457,7 @@
           <small
             id="object-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__object-key-prefix-field-error-message"
+            data-testid="data-stream-form__destination__object-key-prefix-field__error-message"
             >{{ objectKeyError }}</small
           >
         </div>
@@ -466,7 +466,7 @@
           <LabelBlock
             label="Content Type"
             isRequired
-            data-testid="data-stream-form__destination__content-type-field-label"
+            data-testid="data-stream-form__destination__content-type-field__label"
           />
           <div class="flex flex-col gap-3">
             <div
@@ -480,11 +480,11 @@
                 inputId="contentType"
                 :name="contentTypeItem.value"
                 :value="contentTypeItem.value"
-                data-testid="data-stream-form__destination__content-type-field-radio"
+                data-testid="data-stream-form__destination__content-type-field__radio"
               />
               <label
                 class="text-color text-sm font-normal leading-tight"
-                data-testid="data-stream-form__destination__content-type-field-label"
+                data-testid="data-stream-form__destination__content-type-field__label"
                 >{{ contentTypeItem.label }}</label
               >
             </div>
@@ -538,7 +538,7 @@
             for="serviceAccountKey"
             label="Service Account Key"
             isRequired
-            data-testid="data-stream-form__destination__service-account-key-field-label"
+            data-testid="data-stream-form__destination__service-account-key-field__label"
           />
           <vue-monaco-editor
             v-model:value="serviceAccountKey"
@@ -546,18 +546,18 @@
             :theme="theme"
             :options="serviceAccountMonacoOptions"
             class="min-h-[300px] surface-border border rounded-md overflow-hidden"
-            data-testid="data-stream-form__destination__service-account-key-field-input"
+            data-testid="data-stream-form__destination__service-account-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__service-account-key-field-description"
+            data-testid="data-stream-form__destination__service-account-key-field__description"
           >
             JSON file provided by Google Cloud used to authenticate with Google services.
           </small>
           <small
             id="service-account-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__service-account-key-field-error-message"
+            data-testid="data-stream-form__destination__service-account-key-field__error-message"
             >{{ serviceAccountKeyError }}</small
           >
         </div>
@@ -657,7 +657,7 @@
           <LabelBlock
             for="accessKey"
             label="Access Key"
-            data-testid="data-stream-form__destination__kinesis-access-key-field-label"
+            data-testid="data-stream-form__destination__kinesis-access-key-field__label"
             isRequired
           />
           <PrimePassword
@@ -669,18 +669,18 @@
             :class="{ 'p-invalid': awsAccessKeyError }"
             :feedback="false"
             toggleMask
-            data-testid="data-stream-form__destination__kinesis-access-key-field-input"
+            data-testid="data-stream-form__destination__kinesis-access-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__kinesis-access-key-field-description"
+            data-testid="data-stream-form__destination__kinesis-access-key-field__description"
           >
             Public key to access the Data Firehose given by AWS.
           </small>
           <small
             id="aws-access-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__kinesis-access-key-field-error"
+            data-testid="data-stream-form__destination__kinesis-access-key-field__error"
             >{{ awsAccessKeyError }}</small
           >
         </div>
@@ -689,7 +689,7 @@
           <LabelBlock
             for="accessKey"
             label="Secret Key"
-            data-testid="data-stream-form__destination__kinesis-secret-key-field-label"
+            data-testid="data-stream-form__destination__kinesis-secret-key-field__label"
             isRequired
           />
           <PrimePassword
@@ -701,18 +701,18 @@
             :class="{ 'p-invalid': awsSecretKeyError }"
             :feedback="false"
             toggleMask
-            data-testid="data-stream-form__destination__kinesis-secret-key-field-input"
+            data-testid="data-stream-form__destination__kinesis-secret-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__kinesis-secret-key-field-description"
+            data-testid="data-stream-form__destination__kinesis-secret-key-field__description"
           >
             Secret key to access the Data Firehose given by AWS.
           </small>
           <small
             id="aws-secret-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__kinesis-secret-key-field-error"
+            data-testid="data-stream-form__destination__kinesis-secret-key-field__error"
             >{{ awsSecretKeyError }}</small
           >
         </div>
@@ -787,7 +787,7 @@
           <LabelBlock
             for="sharedKey"
             label="Shared Key"
-            data-testid="data-stream-form__destination__azure-monitor-shared-key-field-label"
+            data-testid="data-stream-form__destination__azure-monitor-shared-key-field__label"
             isRequired
           />
           <PrimePassword
@@ -799,18 +799,18 @@
             :class="{ 'p-invalid': sharedKeyError }"
             :feedback="false"
             toggleMask
-            data-testid="data-stream-form__destination__azure-monitor-shared-key-field-input"
+            data-testid="data-stream-form__destination__azure-monitor-shared-key-field__input"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
-            data-testid="data-stream-form__destination__azure-monitor-shared-key-field-description"
+            data-testid="data-stream-form__destination__azure-monitor-shared-key-field__description"
           >
             Shared Key of the Workspace.
           </small>
           <small
             id="shared-key-help"
             class="p-error"
-            data-testid="data-stream-form__destination__azure-monitor-shared-key-field-error-message"
+            data-testid="data-stream-form__destination__azure-monitor-shared-key-field__error-message"
             >{{ sharedKeyError }}</small
           >
         </div>
@@ -823,7 +823,7 @@
             description="Specifies how long it’ll take for the log to be available after collection. Uses
             ingestion time if not specified."
             placeholder="myCustomTimeField"
-            data-testid="data-stream-form__destination__azure-monitor-generated-field-field"
+            data-testid="data-stream-form__destination__azure-monitor-generated-field__field"
           />
         </div>
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
*Fix*
- Resolve Error.message in create-data-stream service

*Test*
- Add data-testid and selectors related to data stream
- Add e2e test for kafka connector in data stream
- Add e2e test for s3 connector in data stream
- Add e2e test for bigquery connector in data stream
- Add e2e test for elasticsearch connector in data stream
- Add e2e test for splunk connector in data stream
- Add e2e test for kinesis connector in data stream
- Add e2e test for datadog connector in data stream
- Add e2e test for qradar connector in data stream
- Add e2e test for azure monitor connector in data stream
- Add e2e test for azure blob storage connector in data stream

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/57aafb59-c1b4-4a2e-a5fa-5ac8b0b3532d

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
