### PR TITLE
[UXE-3962] test: create e2e for edge dns records

### DIFF
--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -30,7 +30,7 @@ describe('Edge DNS spec', () => {
     cy.get(selectors.edgeDns.statusRow).should('have.text', 'Active')
   })
 
-  it.only('Create a record of type A', () => {
+  it('Create a record of type A', () => {
     // Arrange
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -35,7 +35,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'www',
+      name: generateUniqueName('record'),
       recordType: 'A',
       recordTypeOption: 0,
       ttl: 7,
@@ -111,7 +111,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'aaaa',
+      name: generateUniqueName('record'),
       recordType: 'AAAA',
       recordTypeOption: 1,
       ttl: 1,
@@ -180,7 +180,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'aname',
+      name: generateUniqueName('record'),
       recordType: 'ANAME',
       recordTypeOption: 2,
       ttl: 20,
@@ -248,7 +248,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'caa',
+      name: generateUniqueName('record'),
       recordType: 'CAA',
       recordTypeOption: 3,
       ttl: 10,
@@ -317,7 +317,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'cname',
+      name: generateUniqueName('record'),
       recordType: 'CNAME',
       recordTypeOption: 4,
       ttl: 100,
@@ -386,7 +386,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'ds',
+      name: generateUniqueName('record'),
       recordType: 'DS',
       recordTypeOption: 5,
       ttl: 3600,
@@ -455,7 +455,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'mail',
+      name: generateUniqueName('record'),
       recordType: 'MX',
       recordTypeOption: 6,
       ttl: 5,
@@ -524,7 +524,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'nsx',
+      name: generateUniqueName('record'),
       recordType: 'NS',
       recordTypeOption: 7,
       ttl: 20,
@@ -593,7 +593,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: '4.3.2.1.in-addr.arpa',
+      name: generateUniqueName('4.3.2.1.in-addr.arpa'),
       recordType: 'PTR',
       recordTypeOption: 8,
       ttl: 9090,
@@ -662,7 +662,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: '_sip._tcp',
+      name: generateUniqueName('_sip._tcp'),
       recordType: 'SRV',
       recordTypeOption: 9,
       ttl: 28,
@@ -731,7 +731,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'txt',
+      name: generateUniqueName('record'),
       recordType: 'TXT',
       recordTypeOption: 10,
       ttl: 2733,

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -10,25 +10,98 @@ describe('Edge DNS spec', () => {
     cy.openProductThroughSidebar('edge-dns')
   })
 
-  it('Create a Edge DNS ZOne', function() {
+  it('Create a Edge DNS Zone', function () {
     // Act
-    cy.get(selectors.edgeDns.createButton).click();
-    cy.get(selectors.edgeDns.nameInput).clear();
-    cy.get(selectors.edgeDns.nameInput).type(zoneName);
-    cy.get(selectors.edgeDns.domainInput).clear();
-    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`);
-    cy.get(selectors.edgeDns.saveButton).click();
-    cy.verifyToast('success','Your Edge DNS has been created');
-    cy.get(selectors.edgeDns.cancelButton).click();
-    
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).clear()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).clear()
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+
     // Assert
-    cy.get(selectors.edgeDns.searchInput).clear();
-    cy.get(selectors.edgeDns.searchInput).type(zoneName);
-    cy.get(selectors.edgeDns.nameRow).should('have.text', zoneName);
-    cy.get(selectors.edgeDns.showMore).click();
-    cy.get(selectors.edgeDns.domainRow).should('contain', zoneName.toLowerCase());
-    cy.get(selectors.edgeDns.statusRow).should('have.text', 'Active');
+    cy.get(selectors.edgeDns.searchInput).clear()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow).should('have.text', zoneName)
+    cy.get(selectors.edgeDns.showMore).click()
+    cy.get(selectors.edgeDns.domainRow).should('contain', zoneName.toLowerCase())
+    cy.get(selectors.edgeDns.statusRow).should('have.text', 'Active')
   })
+
+  it.only('Create a record of type A', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeA',
+      recordType: 'A',
+      recordTypeOption: 0,
+      ttl: 100,
+      value: '0.0.0.0',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('weight')).should('be.empty')
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
   afterEach(() => {
     cy.deleteProduct(zoneName, '/edge-dns').then(() => {
       cy.verifyToast('Your Edge DNS has been deleted')

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -38,8 +38,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeA',
       recordType: 'A',
       recordTypeOption: 0,
-      ttl: 100,
-      value: '0.0.0.0',
+      ttl: 7,
+      value: '10.0.0.1',
       policyType: 'weighted',
       policyTypeOption: 1,
       weight: 10,
@@ -117,8 +117,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeAAAA',
       recordType: 'AAAA',
       recordTypeOption: 1,
-      ttl: 100,
-      value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+      ttl: 1,
+      value: '2800:3f0:4001:805::200e',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -189,8 +189,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeANAME',
       recordType: 'ANAME',
       recordTypeOption: 2,
-      ttl: 100,
-      value: 'example.com',
+      ttl: 20,
+      value: '1234x.xx.azioncdn.net',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -217,7 +217,6 @@ describe('Edge DNS spec', () => {
     cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
     cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
     cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
-    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
     cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
     cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
@@ -261,7 +260,7 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeCAA',
       recordType: 'CAA',
       recordTypeOption: 3,
-      ttl: 100,
+      ttl: 10,
       value: '0 issue "letsencrypt.org"',
       policyType: 'simple',
       policyTypeOption: 0,
@@ -334,7 +333,7 @@ describe('Edge DNS spec', () => {
       recordType: 'CNAME',
       recordTypeOption: 4,
       ttl: 100,
-      value: 'example.com',
+      value: 'azion.net',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -405,8 +404,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeDS',
       recordType: 'DS',
       recordTypeOption: 5,
-      ttl: 100,
-      value: '12345 8 2 49FD46E6C4B45C55D4AC',
+      ttl: 3600,
+      value: '2371 13 2 72c48090c5b4b3e42f6b0170a156d1fda6aca0ba02cd8c2a0c35fc14d7c1bf93',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -477,8 +476,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeMX',
       recordType: 'MX',
       recordTypeOption: 6,
-      ttl: 100,
-      value: '10 mail.example.com',
+      ttl: 5,
+      value: '1 aspmx.l.google.com\n2 aspmx3.googlemail.com',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -549,8 +548,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeNS',
       recordType: 'NS',
       recordTypeOption: 7,
-      ttl: 100,
-      value: '10 mail.example.com',
+      ttl: 20,
+      value: 'ns4.aziondns.net\nns5.aziondns.com\nns6.aziondns.org',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -621,8 +620,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypePTR',
       recordType: 'PTR',
       recordTypeOption: 8,
-      ttl: 100,
-      value: 'example.com',
+      ttl: 9090,
+      value: 'ptrtesting.com',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -693,8 +692,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeSRV',
       recordType: 'SRV',
       recordTypeOption: 9,
-      ttl: 100,
-      value: '10 5 5060 sipserver.example.com',
+      ttl: 28,
+      value: '10 60 5060 bigbox.example.com',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -765,8 +764,8 @@ describe('Edge DNS spec', () => {
       name: 'recordTypeTXT',
       recordType: 'TXT',
       recordTypeOption: 10,
-      ttl: 100,
-      value: '"v=spf1 include:example.com ~all"',
+      ttl: 2733,
+      value: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -181,6 +181,654 @@ describe('Edge DNS spec', () => {
     })
   })
 
+  it('Create a record of type ANAME', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeANAME',
+      recordType: 'ANAME',
+      recordTypeOption: 2,
+      ttl: 100,
+      value: 'example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type CAA', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeCAA',
+      recordType: 'CAA',
+      recordTypeOption: 3,
+      ttl: 100,
+      value: '0 issue "letsencrypt.org"',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type CNAME', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeCNAME',
+      recordType: 'CNAME',
+      recordTypeOption: 4,
+      ttl: 100,
+      value: 'example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type DS', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeDS',
+      recordType: 'DS',
+      recordTypeOption: 5,
+      ttl: 100,
+      value: '12345 8 2 49FD46E6C4B45C55D4AC',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type MX', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeMX',
+      recordType: 'MX',
+      recordTypeOption: 6,
+      ttl: 100,
+      value: '10 mail.example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type NS', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeNS',
+      recordType: 'NS',
+      recordTypeOption: 7,
+      ttl: 100,
+      value: '10 mail.example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type PTR', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypePTR',
+      recordType: 'PTR',
+      recordTypeOption: 8,
+      ttl: 100,
+      value: 'example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type SRV', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeSRV',
+      recordType: 'SRV',
+      recordTypeOption: 9,
+      ttl: 100,
+      value: '10 5 5060 sipserver.example.com',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type TXT', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeTXT',
+      recordType: 'TXT',
+      recordTypeOption: 10,
+      ttl: 100,
+      value: '"v=spf1 include:example.com ~all"',
+      policyType: 'simple',
+      policyTypeOption: 0,
+      description: '-'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
   afterEach(() => {
     cy.deleteProduct({ entityName: zoneName, productName: 'Edge DNS' }).then(() => {
       cy.verifyToast('Your Edge DNS has been deleted')

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -477,7 +477,7 @@ describe('Edge DNS spec', () => {
       recordType: 'MX',
       recordTypeOption: 6,
       ttl: 5,
-      value: '1 aspmx.l.google.com\n2 aspmx3.googlemail.com',
+      value: '1 aspmx.l.google.com',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -523,10 +523,7 @@ describe('Edge DNS spec', () => {
       'have.text',
       recordTypeFixtures.recordType
     )
-    cy.get(selectors.edgeDns.list.columnName('value')).should(
-      'have.text',
-      recordTypeFixtures.value.replaceAll('\n', '')
-    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(
       'have.text',
@@ -552,7 +549,7 @@ describe('Edge DNS spec', () => {
       recordType: 'NS',
       recordTypeOption: 7,
       ttl: 20,
-      value: 'ns4.aziondns.net\nns5.aziondns.com\nns6.aziondns.org',
+      value: 'ns4.aziondns.net',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -598,10 +595,7 @@ describe('Edge DNS spec', () => {
       'have.text',
       recordTypeFixtures.recordType
     )
-    cy.get(selectors.edgeDns.list.columnName('value')).should(
-      'have.text',
-      recordTypeFixtures.value.replaceAll('\n', '')
-    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(
       'have.text',

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -523,7 +523,10 @@ describe('Edge DNS spec', () => {
       'have.text',
       recordTypeFixtures.recordType
     )
-    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('value')).should(
+      'have.text',
+      recordTypeFixtures.value.replaceAll('\n', ' ')
+    )
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(
       'have.text',
@@ -595,7 +598,10 @@ describe('Edge DNS spec', () => {
       'have.text',
       recordTypeFixtures.recordType
     )
-    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('value')).should(
+      'have.text',
+      recordTypeFixtures.value.replaceAll('\n', ' ')
+    )
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(
       'have.text',

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -40,6 +40,85 @@ describe('Edge DNS spec', () => {
       recordTypeOption: 0,
       ttl: 100,
       value: '0.0.0.0',
+      policyType: 'weighted',
+      policyTypeOption: 1,
+      weight: 10,
+      description: 'base description'
+    }
+
+    cy.get(selectors.edgeDns.createButton).click()
+    cy.get(selectors.edgeDns.nameInput).type(zoneName)
+    cy.get(selectors.edgeDns.domainInput).type(`${zoneName}.com.az`)
+    cy.get(selectors.edgeDns.saveButton).click()
+    cy.verifyToast('success', 'Your Edge DNS has been created')
+    cy.get(selectors.edgeDns.cancelButton).click()
+    cy.get(selectors.edgeDns.searchInput).type(zoneName)
+    cy.get(selectors.edgeDns.nameRow)
+      .should('contain', zoneName)
+      .then(() => {
+        cy.get(selectors.edgeDns.nameRow).click()
+      })
+
+    cy.wait('@loadZone')
+
+    // Act
+    cy.get(selectors.edgeDns.records.tab).click()
+    cy.get(selectors.edgeDns.records.createButton).click()
+    cy.get(selectors.edgeDns.records.nameInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.records.recordTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.recordTypeOption(recordTypeFixtures.recordTypeOption)).click()
+    cy.get(selectors.edgeDns.records.ttlInput).type(recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
+    cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+    cy.get(selectors.edgeDns.records.weightInput).type(recordTypeFixtures.weight)
+    cy.get(selectors.edgeDns.records.descriptionTextarea).type(recordTypeFixtures.description)
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Edge DNS Record has been created')
+
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
+    cy.get(selectors.edgeDns.list.columnName('name')).should(
+      'have.text',
+      recordTypeFixtures.name.toLocaleLowerCase()
+    )
+    cy.get(selectors.edgeDns.list.columnName('type')).should(
+      'have.text',
+      recordTypeFixtures.recordType
+    )
+    cy.get(selectors.edgeDns.list.columnName('value')).should('have.text', recordTypeFixtures.value)
+    cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
+    cy.get(selectors.edgeDns.list.columnName('policy')).should(
+      'have.text',
+      recordTypeFixtures.policyType
+    )
+    cy.get(selectors.edgeDns.list.columnName('weight')).should(
+      'have.text',
+      recordTypeFixtures.weight
+    )
+    cy.get(selectors.edgeDns.list.columnName('description')).should(
+      'have.text',
+      recordTypeFixtures.description
+    )
+
+    // Cleanup
+    cy.deleteEntityFromList().then(() => {
+      cy.verifyToast('Edge DNS Record successfully deleted')
+    })
+  })
+
+  it('Create a record of type AAAA', () => {
+    // Arrange
+    cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
+
+    const recordTypeFixtures = {
+      name: 'recordTypeAAAA',
+      recordType: 'AAAA',
+      recordTypeOption: 1,
+      ttl: 100,
+      value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
       policyType: 'simple',
       policyTypeOption: 0,
       description: '-'
@@ -70,6 +149,7 @@ describe('Edge DNS spec', () => {
     cy.get(selectors.edgeDns.records.valueTextarea).type(recordTypeFixtures.value)
     cy.get(selectors.edgeDns.records.policyTypeDropdown).click()
     cy.get(selectors.edgeDns.records.policyTypeOption(recordTypeFixtures.policyTypeOption)).click()
+
     cy.get(selectors.form.actionsSubmitButton).click()
 
     // Assert
@@ -90,7 +170,6 @@ describe('Edge DNS spec', () => {
       'have.text',
       recordTypeFixtures.policyType
     )
-    cy.get(selectors.edgeDns.list.columnName('weight')).should('be.empty')
     cy.get(selectors.edgeDns.list.columnName('description')).should(
       'have.text',
       recordTypeFixtures.description

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -35,7 +35,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeA',
+      name: 'www',
       recordType: 'A',
       recordTypeOption: 0,
       ttl: 7,
@@ -79,11 +79,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -114,7 +111,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeAAAA',
+      name: 'aaaa',
       recordType: 'AAAA',
       recordTypeOption: 1,
       ttl: 1,
@@ -155,11 +152,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -186,7 +180,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeANAME',
+      name: 'aname',
       recordType: 'ANAME',
       recordTypeOption: 2,
       ttl: 20,
@@ -226,11 +220,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -257,7 +248,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeCAA',
+      name: 'caa',
       recordType: 'CAA',
       recordTypeOption: 3,
       ttl: 10,
@@ -298,11 +289,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -329,7 +317,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeCNAME',
+      name: 'cname',
       recordType: 'CNAME',
       recordTypeOption: 4,
       ttl: 100,
@@ -370,11 +358,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -401,7 +386,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeDS',
+      name: 'ds',
       recordType: 'DS',
       recordTypeOption: 5,
       ttl: 3600,
@@ -442,11 +427,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -473,7 +455,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeMX',
+      name: 'mail',
       recordType: 'MX',
       recordTypeOption: 6,
       ttl: 5,
@@ -514,11 +496,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -545,7 +524,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeNS',
+      name: 'nsx',
       recordType: 'NS',
       recordTypeOption: 7,
       ttl: 20,
@@ -586,11 +565,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -617,7 +593,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypePTR',
+      name: '4.3.2.1.in-addr.arpa',
       recordType: 'PTR',
       recordTypeOption: 8,
       ttl: 9090,
@@ -658,11 +634,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -689,7 +662,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeSRV',
+      name: '_sip._tcp',
       recordType: 'SRV',
       recordTypeOption: 9,
       ttl: 28,
@@ -730,11 +703,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType
@@ -761,7 +731,7 @@ describe('Edge DNS spec', () => {
     cy.intercept('/api/v3/intelligent_dns/*').as('loadZone')
 
     const recordTypeFixtures = {
-      name: 'recordTypeTXT',
+      name: 'txt',
       recordType: 'TXT',
       recordTypeOption: 10,
       ttl: 2733,
@@ -802,11 +772,8 @@ describe('Edge DNS spec', () => {
     // Assert
     cy.verifyToast('success', 'Edge DNS Record has been created')
 
-    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name.toLocaleLowerCase())
-    cy.get(selectors.edgeDns.list.columnName('name')).should(
-      'have.text',
-      recordTypeFixtures.name.toLocaleLowerCase()
-    )
+    cy.get(selectors.list.searchInput).type(recordTypeFixtures.name)
+    cy.get(selectors.edgeDns.list.columnName('name')).should('have.text', recordTypeFixtures.name)
     cy.get(selectors.edgeDns.list.columnName('type')).should(
       'have.text',
       recordTypeFixtures.recordType

--- a/cypress/e2e/edge-dns.cy.js
+++ b/cypress/e2e/edge-dns.cy.js
@@ -525,7 +525,7 @@ describe('Edge DNS spec', () => {
     )
     cy.get(selectors.edgeDns.list.columnName('value')).should(
       'have.text',
-      recordTypeFixtures.value.replaceAll('\n', ' ')
+      recordTypeFixtures.value.replaceAll('\n', '')
     )
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(
@@ -600,7 +600,7 @@ describe('Edge DNS spec', () => {
     )
     cy.get(selectors.edgeDns.list.columnName('value')).should(
       'have.text',
-      recordTypeFixtures.value.replaceAll('\n', ' ')
+      recordTypeFixtures.value.replaceAll('\n', '')
     )
     cy.get(selectors.edgeDns.list.columnName('ttl')).should('have.text', recordTypeFixtures.ttl)
     cy.get(selectors.edgeDns.list.columnName('policy')).should(

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -74,45 +74,43 @@ Cypress.on('uncaught:exception', (err, runnable) => {
  * @throws Will throw an error if the email or password is not set for the specified environment.
  */
 Cypress.Commands.add('login', () => {
-  const environment = Cypress.env('environment') || 'dev';
-  const isCI = Cypress.env('isCI') === 'true';
+  const environment = Cypress.env('environment') || 'dev'
+  const isCI = Cypress.env('isCI') === 'true'
 
-  let email, password;
+  let email, password
 
   if (isCI) {
-    cy.log('Running in CI/CD environment');
-    email = Cypress.env('CYPRESS_EMAIL');
-    password = Cypress.env('CYPRESS_PASSWORD');
+    cy.log('Running in CI/CD environment')
+    email = Cypress.env('CYPRESS_EMAIL')
+    password = Cypress.env('CYPRESS_PASSWORD')
 
     if (!email || !password) {
-      throw new Error('Email or Password not set for CI/CD environment');
+      throw new Error('Email or Password not set for CI/CD environment')
     }
   } else {
     switch (environment) {
       case 'preview-prod':
-        email = Cypress.env('PREVIEW_PROD_CYPRESS_EMAIL');
-        password = Cypress.env('PREVIEW_PROD_CYPRESS_PASSWORD');
-        break;
+        email = Cypress.env('PREVIEW_PROD_CYPRESS_EMAIL')
+        password = Cypress.env('PREVIEW_PROD_CYPRESS_PASSWORD')
+        break
       case 'prod':
-        email = Cypress.env('PROD_CYPRESS_EMAIL');
-        password = Cypress.env('PROD_CYPRESS_PASSWORD');
-        break;
+        email = Cypress.env('PROD_CYPRESS_EMAIL')
+        password = Cypress.env('PROD_CYPRESS_PASSWORD')
+        break
       default:
-        email = Cypress.env('DEV_CYPRESS_EMAIL');
-        password = Cypress.env('DEV_CYPRESS_PASSWORD');
-        break;
+        email = Cypress.env('DEV_CYPRESS_EMAIL')
+        password = Cypress.env('DEV_CYPRESS_PASSWORD')
+        break
     }
   }
 
   if (!email || !password) {
-    throw new Error(`Email or Password not set for ${environment} environment`);
+    throw new Error(`Email or Password not set for ${environment} environment`)
   }
 
-  cy.log(`🔐 Authenticating | ${email}`);
-  login(email, password);
-});
-
-
+  cy.log(`🔐 Authenticating | ${email}`)
+  login(email, password)
+})
 
 /**
  * Opens a product through the sidebar menu.
@@ -203,21 +201,31 @@ Cypress.Commands.add('assertValueCopiedToClipboard', (expectedValue) => {
  * by combining the base URL with the relative path provided and then performs the visit action.
  *
  * TODO: remove this WORKAROUND for https://github.com/cypress-io/cypress/issues/20647,
- * 
+ *
  * @param {function} original - The original 'visit' function provided by Cypress.
  * @param {...any} args - The arguments passed to the 'visit' function, with the first being the relative path.
  * @throws Will throw an error if the base URL is not found in the environment variables.
  * @returns {Promise} - Resolves when the visit command completes.
  */
 Cypress.Commands.overwrite('visit', (original, ...args) => {
-  if (!Cypress.env("baseUrl")) {
-    throw new Error("Not found $.env.baseUrl but it is required");
+  if (!Cypress.env('baseUrl')) {
+    throw new Error('Not found $.env.baseUrl but it is required')
   }
 
-  const relative = args.shift();
-  const target = new URL(relative, new URL(Cypress.env("baseUrl")));
+  const relative = args.shift()
+  const target = new URL(relative, new URL(Cypress.env('baseUrl')))
 
   return new Promise((resolve) => {
-    resolve(original(target.toString(), ...args));
-  });
-});
+    resolve(original(target.toString(), ...args))
+  })
+})
+
+/**
+ * Deletes an entity from the loaded list.
+ **/
+Cypress.Commands.add('deleteEntityFromList', () => {
+  cy.get(selectors.list.actionsMenu.button).click()
+  cy.get(selectors.list.actionsMenu.deleteButton).click()
+  cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
+  cy.get(selectors.list.deleteDialog.deleteButton).click()
+})

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -334,7 +334,23 @@ const selectors = {
     nameRow: '[data-testid="list-table-block__column__name__row"]',
     showMore: '.underline',
     domainRow: '.whitespace-pre',
-    statusRow: '[data-testid="list-table-block__column__status__row"] > .p-tag-value'
+    statusRow: '[data-testid="list-table-block__column__status__row"] > .p-tag-value',
+    list: {
+      columnName: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`
+    },
+    records: {
+      tab: '[data-testid="edge-dns-edit-view__records__tab-panel"] > a',
+      createButton: '[data-testid="create_Record_button"]',
+      nameInput: '[data-testid="edge-dns-records-form__settings__name-field__input"]',
+      recordTypeDropdown:
+        '[data-testid="edge-dns-records-form__settings__record-type-field__dropdown"] > .p-dropdown-trigger',
+      recordTypeOption: (recordType) => `#selectedRecordType_${recordType}`,
+      ttlInput: '[data-testid="edge-dns-records-form__settings__ttl-field__input"]',
+      valueTextarea: '[data-testid="edge-dns-records-form__settings__value-field__textarea"]',
+      policyTypeDropdown:
+        '[data-testid="edge-dns-records-form__policy__policy-type-field__dropdown"] > .p-dropdown-trigger',
+      policyTypeOption: (policyType) => `#selectedPolicy_${policyType}`
+    }
   }
 }
 

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -349,7 +349,10 @@ const selectors = {
       valueTextarea: '[data-testid="edge-dns-records-form__settings__value-field__textarea"]',
       policyTypeDropdown:
         '[data-testid="edge-dns-records-form__policy__policy-type-field__dropdown"] > .p-dropdown-trigger',
-      policyTypeOption: (policyType) => `#selectedPolicy_${policyType}`
+      policyTypeOption: (policyType) => `#selectedPolicy_${policyType}`,
+      weightInput: '[data-testid="edge-dns-records-form__policy__weight-field__input"]',
+      descriptionTextarea:
+        '[data-testid="edge-dns-records-form__policy__description-field__textarea"]'
     }
   },
   domains: {

--- a/src/templates/list-table-block/no-header.vue
+++ b/src/templates/list-table-block/no-header.vue
@@ -47,7 +47,7 @@
                   icon="pi pi-plus"
                   :label="addButtonLabel"
                   v-if="addButtonLabel"
-                  data-testid="data-table-add-button"
+                  :data-testid="`create_${addButtonLabel}_button`"
                 />
               </slot>
             </div>

--- a/src/templates/list-table-block/no-header.vue
+++ b/src/templates/list-table-block/no-header.vue
@@ -89,11 +89,14 @@
             <template v-if="col.type !== 'component'">
               <div
                 v-html="rowData[col.field]"
-                data-testid="data-table-column-cell"
+                :data-testid="`list-table-block__column__${col.field}__row`"
               />
             </template>
             <template v-else>
-              <component :is="col.component(rowData[col.field])" />
+              <component
+                :is="col.component(rowData[col.field])"
+                :data-testid="`list-table-block__column__${col.field}__row`"
+              />
             </template>
           </template>
         </Column>
@@ -151,7 +154,7 @@
                 id="overlay_menu"
                 v-bind:model="actionOptions(rowData)"
                 :popup="true"
-                data-testid="data-table-actions-column-menu"
+                data-testid="data-table-actions-column-body-actions-menu"
               />
               <PrimeButton
                 v-tooltip.top="{ value: 'Actions', showDelay: 200 }"
@@ -160,7 +163,7 @@
                 outlined
                 @click="(event) => toggleActionsMenu(event, rowData)"
                 class="cursor-pointer table-button"
-                data-testid="data-table-actions-column-actions-button"
+                data-testid="data-table-actions-column-body-actions-menu-button"
               />
             </div>
           </template>

--- a/src/templates/list-table-block/with-lazy-and-dropdown-filter.vue
+++ b/src/templates/list-table-block/with-lazy-and-dropdown-filter.vue
@@ -69,10 +69,16 @@
         >
           <template #body="{ data: rowData }">
             <template v-if="col.type !== 'component'">
-              <div v-html="rowData[col.field]" />
+              <div
+                v-html="rowData[col.field]"
+                :data-testid="`list-table-block__column__${col.field}__row`"
+              />
             </template>
             <template v-else>
-              <component :is="col.component({ ...rowData[col.field], value: rowData })" />
+              <component
+                :is="col.component({ ...rowData[col.field], value: rowData })"
+                :data-testid="`list-table-block__column__${col.field}__row`"
+              />
             </template>
           </template>
         </Column>

--- a/src/views/EdgeDNS/EditView.vue
+++ b/src/views/EdgeDNS/EditView.vue
@@ -282,7 +282,14 @@
         @tab-click="changeRouteByClickingOnTab"
         class="w-full"
       >
-        <TabPanel header="Main Settings">
+        <TabPanel
+          header="Main Settings"
+          :pt="{
+            root: {
+              'data-testid': 'edge-dns-edit-view__main-settings__tab-panel'
+            }
+          }"
+        >
           <EditFormBlock
             :editService="editEdgeDNSService"
             :loadService="loadEdgeDNSService"
@@ -303,7 +310,14 @@
             </template>
           </EditFormBlock>
         </TabPanel>
-        <TabPanel header="Records">
+        <TabPanel
+          header="Records"
+          :pt="{
+            root: {
+              'data-testid': 'edge-dns-edit-view__records__tab-panel'
+            }
+          }"
+        >
           <div v-if="showRecords">
             <ListTableNoHeaderBlock
               ref="listEDNSResourcesRef"
@@ -322,6 +336,7 @@
                   icon="pi pi-plus"
                   label="Record"
                   @click="openCreateDrawerEDNSResource"
+                  data-testid="create-Record-button"
                 />
               </template>
             </ListTableNoHeaderBlock>
@@ -342,6 +357,7 @@
                   icon="pi pi-plus"
                   label="Record"
                   @click="openCreateDrawerEDNSResource"
+                  data-testid="create-Record-button"
                 />
               </template>
               <template #illustration>

--- a/src/views/EdgeDNS/EditView.vue
+++ b/src/views/EdgeDNS/EditView.vue
@@ -336,7 +336,7 @@
                   icon="pi pi-plus"
                   label="Record"
                   @click="openCreateDrawerEDNSResource"
-                  data-testid="create-Record-button"
+                  data-testid="create_Record_button"
                 />
               </template>
             </ListTableNoHeaderBlock>
@@ -357,7 +357,7 @@
                   icon="pi pi-plus"
                   label="Record"
                   @click="openCreateDrawerEDNSResource"
-                  data-testid="create-Record-button"
+                  data-testid="create_Record_button"
                 />
               </template>
               <template #illustration>

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -114,6 +114,7 @@
     :isDrawer="true"
     title="Settings"
     description="Add records to specify which IPs are associated with the domain and how Edge DNS should handle requests for the domain. The accepted value's format varies according to the chosen record type."
+    data-testid="edge-dns-records-form__section__settings"
   >
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
@@ -121,6 +122,7 @@
           for="name"
           label="Name"
           isRequired
+          data-testid="edge-dns-records-form__settings__name-field__label"
         />
         <div class="p-inputgroup">
           <InputText
@@ -130,14 +132,24 @@
             id="name"
             type="text"
             :class="{ 'p-invalid': errorName }"
+            data-testid="edge-dns-records-form__settings__name-field__input"
           />
-          <span class="p-inputgroup-addon"> .{{ edgeDNSStore.domain }} </span>
+          <span
+            class="p-inputgroup-addon"
+            data-testid="edge-dns-records-form__settings__name-field__suffix"
+          >
+            .{{ edgeDNSStore.domain }}
+          </span>
         </div>
-        <small class="text-xs text-color-secondary font-normal leading-5">
-          Use @ to create a record for the root domain.
+        <small
+          class="text-xs text-color-secondary font-normal leading-5"
+          data-testid="edge-dns-records-form__settings__name-field__description"
+        >
+          > Use @ to create a record for the root domain.
         </small>
         <small
           v-if="errorName"
+          data-testid="edge-dns-records-form__settings__name-field__error-message"
           class="p-error text-xs font-normal leading-tight"
         >
           {{ errorName }}
@@ -156,6 +168,7 @@
             optionValue="value"
             :value="selectedRecordType"
             placeholder="Select a Record Type"
+            data-testid="edge-dns-records-form__settings__record-type-field"
           >
             <template #description>
               <PrimeButton
@@ -163,6 +176,7 @@
                 link
                 class="text-xs p-0 leading-5 text-start"
                 @click="documentationGuideProducts.edgeDnsRecordTypes"
+                data-testid="edge-dns-records-form__settings__record-type-field__read-more-btn"
               />
             </template>
           </FieldDropdown>
@@ -180,6 +194,7 @@
             showButtons
             :disabled="!enableTTLField"
             :step="1"
+            data-testid="edge-dns-records-form__settings__ttl-field"
           />
         </div>
       </div>
@@ -191,6 +206,7 @@
           name="value"
           :placeholder="selectedRecordTypeInfo?.valuePlaceholder"
           :description="selectedRecordTypeInfo?.valueTip"
+          data-testid="edge-dns-records-form__settings__value-field"
         />
       </div>
     </template>
@@ -199,6 +215,7 @@
     :isDrawer="true"
     title="Policy"
     description="Choose the policy type to specify how Edge DNS should deal with requests answered by this record."
+    data-testid="edge-dns-records-form__section__policy"
   >
     <template #inputs>
       <div class="flex gap-6 flex-wrap">
@@ -213,6 +230,7 @@
             optionValue="value"
             :value="selectedPolicy"
             placeholder="Select a Record Type"
+            data-testid="edge-dns-records-form__policy__policy-type-field"
           >
             <template #description>
               Choose <code>Simple</code> to use the standard DNS functionality or
@@ -235,6 +253,7 @@
             :min="0"
             :max="255"
             :step="1"
+            data-testid="edge-dns-records-form__policy__weight-field"
           />
         </div>
       </div>
@@ -249,6 +268,7 @@
           name="description"
           placeholder="add the description"
           description="Differentiate records with the same Name and Type by adding a description that identifies each one. Accepts up to 45 characters."
+          data-testid="edge-dns-records-form__policy__description-field"
         />
       </div>
     </template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

- Add data-testid selectors related to edge dns test flow
- Create cypress command to delete entity from loaded table
- Create e2e for `record type A`
- Create e2e for `record type AAAA`
- Create e2e for `record type ANAME`
- Create e2e for `record type CAA`
- Create e2e for `record type CNAME`
- Create e2e for `record type DS`
- Create e2e for `record type MX`
- Create e2e for `record type NS`
- Create e2e for `record type PTR`
- Create e2e for `record type SRV`
- Create e2e for `record type TXT`

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/19f39938-a1f6-43bb-8162-172ea80acfab

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
