### PR TITLE
[UXE-3943] fix: change Secure Headers Cross Origin Opener Policy from same-origin to same-origin-allow-popups

### DIFF
--- a/azion.config.cjs
+++ b/azion.config.cjs
@@ -352,7 +352,7 @@ const AzionConfig = {
             'Strict-Transport-Security: max-age=2592000; includeSubDomains',
             'Referrer-Policy: strict-origin-when-cross-origin',
             'X-XSS-Protection: 1; mode=block',
-            'Cross-Origin-Opener-Policy: same-origin'
+            'Cross-Origin-Opener-Policy: same-origin-allow-popups'
           ]
         }
       }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

### Does this PR introduce UI changes? Add a video or screenshots here.

This PR changes the edge application configuration to use Security header that enable the use of window.opener() method, that is only defined in window object if the COOP is not set as 'same-orgin'.

<q>If a cross-origin document with COOP is opened in a new window, the opening document will not have a reference to it, and the [window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener) property of the new window will be null. This allows you to have more control over references to a window than [rel=noopener](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener), which only affects outgoing navigations.</q>

Documentation about COOP:
[COOP Header , read here](
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
