### PR TITLE
[UXE-3943] fix: change Cross-Origin-Opener-Policy to unsafe-none to avoid blockin Github pop-up

### DIFF
--- a/azion.config.cjs
+++ b/azion.config.cjs
@@ -352,7 +352,7 @@ const AzionConfig = {
             'Strict-Transport-Security: max-age=2592000; includeSubDomains',
             'Referrer-Policy: strict-origin-when-cross-origin',
             'X-XSS-Protection: 1; mode=block',
-            'Cross-Origin-Opener-Policy: same-origin-allow-popups'
+            'Cross-Origin-Opener-Policy: unsafe-none'
           ]
         }
       }


### PR DESCRIPTION
## Bug fix


### Explain what was fixed and the correct behavior.

Fix problem with github integration pop-up. Since the COOP policy was blocking the postMassage communication between Console and opened pop-up.


![image](https://github.com/aziontech/azion-console-kit/assets/101186721/b7c3c20c-5498-4140-9d19-639c5baf198c)

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [ ] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari