### PR TITLE
[NO-ISSUE] chore: remove unnecessary import of define props at text-full-width-clipboard column

### DIFF
--- a/src/templates/list-table-block/columns/text-full-with-clipboard-column.vue
+++ b/src/templates/list-table-block/columns/text-full-with-clipboard-column.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-  import { defineProps } from 'vue'
   import PrimeButton from 'primevue/button'
   defineOptions({ name: 'text-full-with-clipboard-column' })
 


### PR DESCRIPTION

## Bug fix

### Explain what was fixed and the correct behavior.
Removed define props since it is global and generate a console warning in local environments

### Does this PR introduce UI changes? Add a video or screenshots here.
Not necessary
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] Safari
