### PR TITLE
[UXE-3918] fix: waf allowed rules data is not being loaded correctly into the table

### DIFF
--- a/src/services/waf-rules-services/list-waf-rules-allowed-service.js
+++ b/src/services/waf-rules-services/list-waf-rules-allowed-service.js
@@ -84,9 +84,9 @@ const adapt = (httpResponse) => {
           ),
           matchZones: parseMatchZone(waf.match_zones),
           path: waf.path,
-          reason: waf.reason,
+          description: waf.description,
           ruleId,
-          status: parseStatusData(waf.status),
+          status: parseStatusData(waf.active),
           useRegex: waf.use_regex
         }
 

--- a/src/tests/services/waf-rules-services/list-waf-rules-allowed-service.test.js
+++ b/src/tests/services/waf-rules-services/list-waf-rules-allowed-service.test.js
@@ -10,9 +10,9 @@ const fixtures = {
     last_modified: '2024-01-12T14:24:52.957488Z',
     match_zones: [{ zone: 'file_name', zone_input: null, matches_on: null }],
     path: '/test/te',
-    reason: 'hello, it is just a test',
+    description: 'hello, it is just a test',
     rule_id: 0,
-    status: true,
+    active: true,
     use_regex: false
   },
   wafRulesMockWithFalseStatus: {
@@ -21,9 +21,9 @@ const fixtures = {
     last_modified: '2024-01-12T14:24:52.957488Z',
     match_zones: [{ zone: 'file_name', zone_input: null, matches_on: null }],
     path: '/test/te',
-    reason: 'hello, it is just a test',
+    description: 'hello, it is just a test',
     rule_id: 0,
-    status: false,
+    active: false,
     use_regex: false
   }
 }
@@ -76,7 +76,7 @@ describe('WafRulesServices', () => {
         lastModified: 'Friday, January 12, 2024',
         matchZones: ['File Name (Multipart Body)'],
         path: fixtures.wafRulesMock.path,
-        reason: fixtures.wafRulesMock.reason,
+        description: fixtures.wafRulesMock.description,
         ruleId: '0 - All Rules',
         status: {
           content: 'Active',
@@ -90,7 +90,7 @@ describe('WafRulesServices', () => {
         lastModified: 'Friday, January 12, 2024',
         matchZones: ['File Name (Multipart Body)'],
         path: fixtures.wafRulesMock.path,
-        reason: fixtures.wafRulesMock.reason,
+        description: fixtures.wafRulesMock.description,
         ruleId: '0 - All Rules',
         status: {
           content: 'Inactive',

--- a/src/views/WafRules/ListWafRulesAllowed.vue
+++ b/src/views/WafRules/ListWafRulesAllowed.vue
@@ -164,7 +164,7 @@
         columnBuilder({ data: columnData, columnAppearance: 'expand-text-column' })
     },
     {
-      field: 'reason',
+      field: 'description',
       header: 'Description',
       type: 'component',
       component: (columnData) =>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

fix: waf allowed rules data is not being loaded correctly into the table

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/110847590/ec06c069-e313-4c8c-a589-663083570968


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
