### PR TITLE
[UXE-3946] test: add e2e teams permissions (view only)

### DIFF
--- a/cypress/e2e/teams-permissions.cy.js
+++ b/cypress/e2e/teams-permissions.cy.js
@@ -1,38 +1,33 @@
 import generateUniqueName from '../support/utils'
 import selectors from '../support/selectors'
 
-const teamsPermissionsName = generateUniqueName('TeamName')
+let teamsPermissionsName
 
 describe('Teams Permissions', () => {
   beforeEach(() => {
+    teamsPermissionsName = generateUniqueName('Team')
     cy.login()
     cy.openProduct('Teams Permissions')
+
+    cy.intercept('api/v4/iam/permissions*').as('loadPermissions')
   })
 
   it('should create a new team', () => {
     // Arrange
-    cy.get(selectors.list.searchField).type(teamsPermissionsName)
-    cy.get(selectors.list.filteredRow.empty)
-      .should('be.visible')
-      .and('have.text', 'No teams found.')
+    cy.get(selectors.teams.createTeamButton).click()
+    cy.get(selectors.teams.nameInput).clear()
 
-    cy.get(selectors.list.createTeamButton).click()
-
-    cy.get(selectors.form.teamName).type('A')
-    cy.get(selectors.form.teamName).clear()
-    cy.get(selectors.form.teamNameError)
-      .should('be.visible')
-      .and('have.text', 'Name is a required field')
-
-    // Act
+    // // Act
     // Test different permissions scenarios and verify whether form is enabled/disabled
-    cy.get(selectors.form.teamName).type(teamsPermissionsName)
+    cy.get(selectors.teams.nameInput).type(teamsPermissionsName)
 
-    cy.get(selectors.form.allPermissionsToTarget).click()
-    cy.get(selectors.form.allPermissionsToSource).click()
-    cy.get(selectors.form.viewContentDeliverySettingsPermission).click()
-    cy.get(selectors.form.singlePermissionToTarget).click()
-    cy.get(selectors.form.allPermissionsToTarget).click()
+    cy.wait('@loadPermissions')
+
+    cy.get(selectors.teams.allPermissionsToTarget).click()
+    cy.get(selectors.teams.allPermissionsToSource).click()
+    cy.get(selectors.teams.permission('View Content Delivery Settings')).click()
+    cy.get(selectors.teams.singlePermissionToTarget).click()
+    cy.get(selectors.teams.allPermissionsToTarget).click()
 
     cy.get(selectors.form.actionsSubmitButton).click()
 
@@ -42,12 +37,68 @@ describe('Teams Permissions', () => {
     cy.get(selectors.form.actionsCancelButton).click()
 
     cy.get(selectors.list.searchField).type(teamsPermissionsName)
-    cy.get(selectors.list.filteredRow.nameColumn()).should('have.text', teamsPermissionsName)
-    cy.get(selectors.list.filteredRow.permissionsColumn).should(
+    cy.get(selectors.teams.listRow('name')).should('have.text', teamsPermissionsName)
+    cy.get(selectors.teams.listRow('permissions')).should(
       'have.text',
       'View Content Delivery SettingsEdit Content Delivery SettingsShow more (46)'
     )
-    cy.get(selectors.list.filteredRow.statusColumn).should('have.text', 'Active')
+    cy.get(selectors.teams.listRow('status')).should('have.text', 'Active')
+  })
+
+  it('should create a new team with view permissions only', () => {
+    // Arrange
+    const viewPermissionsFixtures = [
+      'View Content Delivery Settings',
+      'View Real-Time Analytics',
+      'View Security Settings',
+      'View Subscriptions',
+      'View Payment Methods',
+      'View Bills',
+      'View Edge Applications',
+      'View Domains',
+      'View Real-Time Events',
+      'View Users',
+      'View Edge DNS',
+      'View Data Stream',
+      'View Network Lists',
+      'View Edge Firewall',
+      'View Edge Functions',
+      'View client list',
+      'View Storage Bucket',
+      'View Storage Object',
+      'View Storage Credentials',
+      'View VCS Integrations',
+      'View VCS Continuous Deployment'
+    ]
+
+    cy.get(selectors.teams.createTeamButton).click()
+    cy.get(selectors.teams.nameInput).clear()
+
+    // // Act
+    cy.get(selectors.teams.nameInput).type(teamsPermissionsName)
+
+    viewPermissionsFixtures.forEach((permission) => {
+      cy.get(selectors.teams.permission(permission)).dblclick()
+    })
+
+    cy.get(selectors.teams.sourceList).should('not.contain', 'View', {
+      matchCase: false
+    })
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your Team Permission has been created')
+
+    cy.get(selectors.form.actionsCancelButton).click()
+
+    cy.get(selectors.list.searchField).type(teamsPermissionsName)
+    cy.get(selectors.teams.listRow('name')).should('have.text', teamsPermissionsName)
+    cy.get(selectors.teams.listRow('permissions')).should(
+      'have.text',
+      'View Content Delivery SettingsView Real-Time AnalyticsShow more (19)'
+    )
+    cy.get(selectors.teams.listRow('status')).should('have.text', 'Active')
   })
 
   afterEach(() => {

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -2,14 +2,12 @@ const selectors = {
   list: {
     breadcumbReturnToList: ':nth-child(3) > .p-menuitem-link',
     createDigitalCertificateButton: '[data-testid="create_Digital Certificate_button"]',
-    createTeamButton: '[data-testid="create_Team_button"]',
     searchInput: '[data-testid="data-table-search-input"]',
     searchField: '[data-testid="data-table-search-input"]',
     filteredRow: {
       nameColumn: (columnName = 'name') =>
         `[data-testid="list-table-block__column__${columnName}__row"]`,
       statusColumn: '[data-testid="list-table-block__column__status__row"] > .p-tag-value',
-      permissionsColumn: '.p-selectable-row > :nth-child(2)',
       empty: 'tr.p-datatable-emptymessage > td',
       lastEditorColumn: '[data-testid="list-table-block__column__lastEditor__row"]',
       lastModifiedColumn: '[data-testid="list-table-block__column__lastModified__row"]'
@@ -31,14 +29,6 @@ const selectors = {
   },
   form: {
     digitalCertificateName: '[data-testid="digital-certificate__name-field__input"]',
-    teamName: '[data-testid="teams-permissions-form__name__field-text__input"]',
-    teamNameError: '[data-testid="teams-permissions-form__name__field-text__error-message"]',
-    teamStatus: '[data-testid="teams-permissions-form__form-fields__status"]',
-    allPermissionsToTarget: '[aria-label="Move All to Target"] > .p-icon',
-    allPermissionsToSource: '[aria-label="Move All to Source"] > .p-icon',
-    singlePermissionToTarget: 'button[aria-label="Move to Target"]',
-    viewContentDeliverySettingsPermission:
-      '[data-testid="teams-permissions-form__permissions-field__picklist__item-View Content Delivery Settings"]',
     actionsSubmitButton: '[data-testid="form-actions-submit-button"]',
     actionsCancelButton: '[data-testid="form-actions-cancel-button"]',
     submitButton: '[data-testid="form-actions-submit-button"]',
@@ -399,6 +389,19 @@ const selectors = {
     switchSocialLogin: '[data-testid="users-form__mfa-field__switch-isAccountOwner"]',
     switchMultiFactorAuth: '[data-testid="users-form__mfa-field__switch-twoFactorEnabled"]',
     listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`
+  },
+  teams: {
+    createTeamButton: '[data-testid="create_Team_button"]',
+    nameInput: '[data-testid="teams-permissions-form__name__field-text__input"]',
+    statusSwitch: '[data-testid="teams-permissions-form__form-fields__status"]',
+    sourceList: '.p-picklist-list.p-picklist-source-list',
+    targetList: '.p-picklist-list.p-picklist-target-list',
+    allPermissionsToTarget: '[aria-label="Move All to Target"] > .p-icon',
+    allPermissionsToSource: '[aria-label="Move All to Source"] > .p-icon',
+    singlePermissionToTarget: 'button[aria-label="Move to Target"]',
+    permission: (permissionName) =>
+      `[data-testid="teams-permissions-form__permissions-field__picklist__item-${permissionName}"]`,
+    listRow: (rowName) => `[data-testid="list-table-block__column__${rowName}__row"]`
   }
 }
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Add e2e teams permissions (view only)
- Update selectors

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/de4658ff-593b-41f5-906c-f98b8791d808

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
