### PR TITLE
[UXE-3957] test: e2e for variable edition with secrets

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import { defineConfig } from 'cypress'
 import codeCoverageTask from '@cypress/code-coverage/task'
-import registerCypressGrep from '@cypress/grep/src/plugin';
+import registerCypressGrep from '@cypress/grep/src/plugin'
 import fs from 'fs'
 
 export default defineConfig({
@@ -13,7 +13,7 @@ export default defineConfig({
     experimentalStudio: true,
     experimentalRunAllSpecs: true,
     setupNodeEvents(on, config) {
-      registerCypressGrep(config);
+      registerCypressGrep(config)
       codeCoverageTask(on, config)
       on('after:spec', (spec, results) => {
         if (results?.video && results?.stats?.failures === 0) {

--- a/cypress/e2e/variables.cy.js
+++ b/cypress/e2e/variables.cy.js
@@ -25,8 +25,55 @@ describe('Variables spec', () => {
     cy.get(selectors.form.actionsCancelButton).click()
 
     // Assert
-    cy.get(selectors.list.searchInput).type(`${variableKey}`)
+    cy.get(selectors.list.searchInput).type(variableKey)
     cy.get(selectors.variables.listRow('key')).should('have.text', variableKey)
+  })
+
+  it('should edit a variable', function () {
+    // Creation Flow
+    // Arrange
+    const secretValue = '********'
+    cy.get(selectors.variables.createButton).click()
+
+    // Act
+    cy.get(selectors.variables.keyInput).type(variableKey)
+    cy.get(selectors.variables.valueInput).type(variableValue)
+    cy.get(selectors.variables.secretToggle).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your variable has been created')
+
+    cy.get(selectors.variables.valueInput).should('have.value', secretValue)
+    cy.get(selectors.form.actionsCancelButton).click()
+
+    cy.get(selectors.list.searchInput).type(variableKey)
+    cy.get(selectors.variables.listRow('key')).should('have.text', variableKey)
+    cy.get(selectors.variables.listRow('value')).should('have.text', secretValue)
+
+    // Edit Flow
+    // Arrange
+    cy.intercept('GET', '/api/v3/variables/*').as('variablesApi')
+
+    cy.get(selectors.variables.listRow('key')).click()
+
+    cy.wait('@variablesApi')
+    cy.get(selectors.variables.secretToggle).click()
+
+    // Act
+    cy.get(selectors.variables.valueInput).clear()
+    cy.get(selectors.variables.valueInput).type(variableValue)
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    // Assert
+    cy.verifyToast('success', 'Your variable has been updated')
+
+    cy.get(selectors.list.searchInput).type(variableKey)
+    cy.get(selectors.variables.listRow('key')).should('have.text', variableKey)
+    cy.get(selectors.variables.showMore).click()
+    cy.get(selectors.variables.listRow('value')).should('contain.text', variableValue)
   })
 
   afterEach(() => {

--- a/cypress/e2e/variables.cy.js
+++ b/cypress/e2e/variables.cy.js
@@ -1,27 +1,32 @@
 import generateUniqueName from '../support/utils'
 import selectors from '../support/selectors'
 
-const variableKey = generateUniqueName('KEY')
-const variableValue = generateUniqueName('value')
+let variableKey
+let variableValue
 
 describe('Variables spec', () => {
   beforeEach(() => {
     cy.login()
     cy.openProduct('Variables')
+
+    variableKey = generateUniqueName('KEY')
+    variableValue = generateUniqueName('value')
   })
 
-  it('Create a variable', function () {
-    // Act
+  it('should create a variable', function () {
+    // Arrange
     cy.get(selectors.variables.createButton).click()
+
+    // Act
     cy.get(selectors.variables.keyInput).type(variableKey)
     cy.get(selectors.variables.valueInput).type(variableValue)
-    cy.get(selectors.variables.saveButton).click()
+    cy.get(selectors.form.actionsSubmitButton).click()
     cy.verifyToast('success', 'Your variable has been created')
-    cy.get(selectors.variables.cancelButton).click()
+    cy.get(selectors.form.actionsCancelButton).click()
 
     // Assert
-    cy.get(selectors.variables.searchInput).type(`${variableKey}`)
-    cy.get(selectors.variables.keyRow).should('have.text', variableKey)
+    cy.get(selectors.list.searchInput).type(`${variableKey}`)
+    cy.get(selectors.variables.listRow('key')).should('have.text', variableKey)
   })
 
   afterEach(() => {

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -132,9 +132,9 @@ const selectors = {
     createButton: '[data-testid="create_Variable_button"]',
     keyInput: '[data-testid="variables-form__key-field__input"]',
     valueInput: '[data-testid="variables-form__value-field__input"]',
-    secretToggle:
-      '[data-testid="data-testid="variables-form__secret-field__switch""] > .p-inputswitch-slider',
-    listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`
+    secretToggle: '[data-testid="variables-form__secret-field__switch"] > .p-inputswitch-slider',
+    listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`,
+    showMore: '[data-testid="list-table-block__column__value__row"] .underline'
   },
   wafs: {
     createButton: '[data-testid="create_WAF Rule_button"] > .p-button-label',

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -129,19 +129,12 @@ const selectors = {
     confirmDeleteButton: '[data-testid="delete-dialog-footer-delete-button"] > .p-button-label'
   },
   variables: {
-    createButton: '[data-testid="create_Variable_button"] > .p-button-label',
+    createButton: '[data-testid="create_Variable_button"]',
     keyInput: '[data-testid="variables-form__key-field__input"]',
     valueInput: '[data-testid="variables-form__value-field__input"]',
-    saveButton: '[data-testid="form-actions-submit-button"]',
-    cancelButton: '[data-testid="form-actions-cancel-button"]',
-    searchInput: '[data-testid="data-table-search-input"]',
-    keyRow: '[data-testid="list-table-block__column__key__row"]',
-    valueRow: '.whitespace-pre',
-    actionButton:
-      '[data-testid="data-table-actions-column-body-actions-menu-button"] > .p-button-icon',
-    deleteButton: '.p-menuitem-content > .p-menuitem-link > .p-menuitem-text',
-    deleteInput: '[data-testid="delete-dialog-confirmation-input-field"]',
-    confirmDeleteButton: '[data-testid="delete-dialog-footer-delete-button"] > .p-button-label'
+    secretToggle:
+      '[data-testid="data-testid="variables-form__secret-field__switch""] > .p-inputswitch-slider',
+    listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`
   },
   wafs: {
     createButton: '[data-testid="create_WAF Rule_button"] > .p-button-label',

--- a/src/views/Variables/FormFields/FormFieldsVariables.vue
+++ b/src/views/Variables/FormFields/FormFieldsVariables.vue
@@ -47,6 +47,7 @@
           auto
           :isCard="false"
           title="Secret"
+          data-testid="variables-form__secret-field"
         />
       </div>
     </template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Create e2e for editing variable flow

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Add a video or screenshots here.

https://github.com/aziontech/azion-console-kit/assets/95643165/3a9d50de-3ddc-4afd-a5b8-98266244f9bb

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
