### PR TITLE
[UXE-3948] test: create e2e for waf rule with some threat types

### DIFF
--- a/cypress/e2e/waf.cy.js
+++ b/cypress/e2e/waf.cy.js
@@ -1,31 +1,37 @@
 import generateUniqueName from '../support/utils'
 import selectors from '../support/selectors'
 
-const wafName = generateUniqueName('WAF')
+let wafName
+const breadcrumbToListIndex = 2
 
 describe('WAF spec', () => {
   beforeEach(() => {
     cy.login()
     cy.openProduct('WAF Rules')
+
+    wafName = generateUniqueName('WAF')
   })
 
-  it('Create a WAF ', function () {
-    // Act
+  it('should create a WAF ', function () {
+    // Arrange
     cy.get(selectors.wafs.createButton).click()
-    cy.get(selectors.wafs.nameInput).clear('')
+
+    cy.get(selectors.wafs.nameInput).clear()
+
+    // Act
     cy.get(selectors.wafs.nameInput).type(wafName)
 
-    cy.get(selectors.wafs.saveButton).click()
+    cy.get(selectors.form.actionsSubmitButton).click()
     cy.verifyToast('success', 'Your waf rule has been created')
-    cy.get(selectors.wafs.cancelButton).click()
-    cy.get(selectors.wafs.cancelButton).click()
-    cy.get(selectors.wafs.cancelButton).click()
+
+    cy.get(selectors.wafs.breadcumb(breadcrumbToListIndex)).click()
+
+    cy.get(selectors.list.searchInput).clear()
+    cy.get(selectors.list.searchInput).type(wafName)
 
     // Assert
-    cy.get(selectors.wafs.searchInput).clear()
-    cy.get(selectors.wafs.searchInput).type(`${wafName}{enter}`)
-    cy.get(selectors.wafs.nameRow).should('have.text', wafName)
-    cy.get(selectors.wafs.threatTypesRow).should('have.text', 'File upload')
+    cy.get(selectors.wafs.listRow('name')).should('have.text', wafName)
+    cy.get(selectors.wafs.listRow('threatTypes')).should('have.text', 'File upload')
   })
 
   afterEach(() => {

--- a/cypress/e2e/waf.cy.js
+++ b/cypress/e2e/waf.cy.js
@@ -2,12 +2,13 @@ import generateUniqueName from '../support/utils'
 import selectors from '../support/selectors'
 
 let wafName
-const breadcrumbToListIndex = 2
 
 describe('WAF spec', () => {
   beforeEach(() => {
     cy.login()
     cy.openProduct('WAF Rules')
+
+    cy.intercept('/api/v3/waf/rulesets/*').as('saveRuleset')
 
     wafName = generateUniqueName('WAF')
   })
@@ -24,14 +25,85 @@ describe('WAF spec', () => {
     cy.get(selectors.form.actionsSubmitButton).click()
     cy.verifyToast('success', 'Your waf rule has been created')
 
-    cy.get(selectors.wafs.breadcumb(breadcrumbToListIndex)).click()
+    cy.wait('@saveRuleset')
+    cy.get(selectors.wafs.breadcumbToList).click()
 
     cy.get(selectors.list.searchInput).clear()
     cy.get(selectors.list.searchInput).type(wafName)
 
     // Assert
     cy.get(selectors.wafs.listRow('name')).should('have.text', wafName)
-    cy.get(selectors.wafs.listRow('threatTypes')).should('have.text', 'File upload')
+    cy.get(selectors.wafs.listRow('threatTypes')).should(
+      'have.text',
+      'File uploadEvading TricksShow more (6)'
+    )
+  })
+
+  it('should edit a waf with some threat types enabled', () => {
+    // Creation flow
+    // Arrange
+    cy.get(selectors.wafs.createButton).click()
+
+    // Act
+    cy.get(selectors.wafs.nameInput).type(wafName)
+
+    //disable
+    cy.get(selectors.wafs.threatTypeSwitch('sqlInjection')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('directoryTraversal')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('fileUpload')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('unwantedAccess')).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    cy.verifyToast('success', 'Your waf rule has been created')
+
+    cy.wait('@saveRuleset')
+    cy.get(selectors.wafs.breadcumbToList).click()
+
+    // Assert
+    cy.get(selectors.list.searchInput).type(wafName)
+
+    cy.get(selectors.wafs.listRow('name')).should('have.text', wafName)
+    cy.get(selectors.wafs.seeMore('threatTypes')).click()
+    cy.get(selectors.wafs.listRow('threatTypes')).should(
+      'have.text',
+      'Evading TricksIdentified AttackCross-Site Scripting (XSS)Remote File Inclusions (RFI)Show less'
+    )
+    cy.get(selectors.wafs.listRow('active')).should('have.text', 'Active')
+
+    // Edit flow
+    // Arrange
+    cy.get(selectors.wafs.listRow('name')).click()
+
+    // Act
+    //enable
+    cy.get(selectors.wafs.threatTypeSwitch('sqlInjection')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('directoryTraversal')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('fileUpload')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('unwantedAccess')).click()
+    //disable
+    cy.get(selectors.wafs.threatTypeSwitch('remoteFileInclusion')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('crossSiteScripting')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('evadingTricks')).click()
+    cy.get(selectors.wafs.threatTypeSwitch('identifiedAttack')).click()
+
+    cy.get(selectors.form.actionsSubmitButton).click()
+
+    cy.verifyToast('success', 'Your waf rule has been updated')
+
+    cy.wait('@saveRuleset')
+    cy.get(selectors.wafs.breadcumbToList).click()
+
+    // Assert
+    cy.get(selectors.list.searchInput).type(wafName)
+
+    cy.get(selectors.wafs.listRow('name')).should('have.text', wafName)
+    cy.get(selectors.wafs.seeMore('threatTypes')).click()
+    cy.get(selectors.wafs.listRow('threatTypes')).should(
+      'have.text',
+      'File uploadUnwanted AccessDirectory TraversalSQL InjectionShow less'
+    )
+    cy.get(selectors.wafs.listRow('active')).should('have.text', 'Active')
   })
 
   afterEach(() => {

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -138,16 +138,10 @@ const selectors = {
   wafs: {
     createButton: '[data-testid="create_WAF Rule_button"] > .p-button-label',
     nameInput: '[data-testid="waf-rules-form__name-field__input"]',
-    saveButton: '[data-testid="form-actions-submit-button"]',
-    cancelButton: '[data-testid="form-actions-cancel-button"]',
-    searchInput: '[data-testid="data-table-search-input"]',
-    nameRow: '[data-testid="list-table-block__column__name__row"]',
-    threatTypesRow: '[data-testid="list-table-block__column__threatTypes__row"] > :nth-child(1)',
-    actionButton:
-      '[data-testid="data-table-actions-column-body-actions-menu-button"] > .p-button-icon',
-    deleteButton: '.p-menuitem-content > .p-menuitem-link > .p-menuitem-text',
-    deleteInput: '[data-testid="delete-dialog-confirmation-input-field"]',
-    confirmDeleteButton: '[data-testid="delete-dialog-footer-delete-button"] > .p-button-label'
+    breadcumb: (position) => `.p-breadcrumb li.menuitem:nth-child(${position})`,
+    listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`,
+    seeMore: (columnName) =>
+      `[data-testid="list-table-block__column__${columnName}__row"] .underline`
   },
   functions: {
     createButton: '[data-testid="create_Edge Function_button"] > .p-button-label',

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -138,7 +138,12 @@ const selectors = {
   wafs: {
     createButton: '[data-testid="create_WAF Rule_button"] > .p-button-label',
     nameInput: '[data-testid="waf-rules-form__name-field__input"]',
-    breadcumb: (position) => `.p-breadcrumb li.menuitem:nth-child(${position})`,
+    threatTypeSwitch: (name) =>
+      `[data-testid="field-group-switch__switch-${name}__switch"] > .p-inputswitch-slider`,
+    dropdownTrigger: (name) =>
+      `[data-testid="waf-rules-form__${name}-field__dropdown"] .p-dropdown-trigger`,
+    dropdownOptions: (name, position) => `#${name}_${position}`,
+    breadcumbToList: '.p-breadcrumb-list li.p-menuitem:nth-child(3) .p-menuitem-link',
     listRow: (columnName) => `[data-testid="list-table-block__column__${columnName}__row"]`,
     seeMore: (columnName) =>
       `[data-testid="list-table-block__column__${columnName}__row"] .underline`

--- a/src/views/WafRules/FormFields/FormFieldsWafRules.vue
+++ b/src/views/WafRules/FormFields/FormFieldsWafRules.vue
@@ -148,6 +148,7 @@
                 inputClass=""
                 :name="item.dropdown.value"
                 :value="item.dropdown.initialValue"
+                :data-testid="`waf-rules-form__${item.dropdown.value}-field`"
               />
             </div>
           </template>
@@ -165,6 +166,7 @@
           :isCard="false"
           title="Active"
           :disabled="props.disabledActive"
+          data-testid="waf-rules-form__active-field"
         />
       </div>
     </template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- Refactor base waf test to receive more scenarios
- Create e2e for waf rules with some threat types enabled

[Manual workflow execution](https://github.com/aziontech/azion-console-kit/actions/runs/9894154294)

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Add a video or screenshots here.
https://github.com/aziontech/azion-console-kit/assets/95643165/f722046e-c189-4d4a-88de-8f53c53ee905

### Does it have a link on Figma?
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
