### PR TITLE
[NO-ISSUE] refactor: move preview message to its own block

### DIFF
--- a/src/templates/content-block/banner.vue
+++ b/src/templates/content-block/banner.vue
@@ -2,31 +2,7 @@
   <section class="w-full min-h-[calc(100vh-120px)] relative">
     <div class="surface-ground w-full">
       <div class="mx-auto">
-        <Message
-          severity="warn"
-          :closable="false"
-          :pt="{
-            root: { class: 'mx-3 mt-4 md:mx-8' },
-            wrapper: { class: 'py-3 px-3 items-start sm:items-center' }
-          }"
-        >
-          <template #messageicon>
-            <Avatar
-              icon="pi pi-exclamation-triangle"
-              class="bg-yellow-600 bg-opacity-20 text-yellow-600 mr-2 min-w-[2rem]"
-            />
-          </template>
-          <p class="text-color-secondary">
-            <b class="text-color">Preview Stage:</b>
-            The new Azion Console is in preview. You may encounter minor issues during this time.
-            <PrimeButton
-              label="Switch to the classic interface"
-              link
-              class="p-0"
-              @click="goToClassicInterface()"
-            />
-          </p>
-        </Message>
+        <ProjectStageMessageBlock />
       </div>
     </div>
     <div class="w-full mx-auto"></div>
@@ -38,10 +14,5 @@
 </template>
 <script setup>
   defineOptions({ name: 'BannerContentBlock' })
-
-  import Message from 'primevue/message'
-  import Avatar from 'primevue/avatar'
-  import PrimeButton from 'primevue/button'
-
-  import { goToClassicInterface } from '@/helpers/go-to-classic-interface'
+  import ProjectStageMessageBlock from './project-stage-message-block.vue'
 </script>

--- a/src/templates/content-block/index.vue
+++ b/src/templates/content-block/index.vue
@@ -1,31 +1,7 @@
 <template>
   <section class="w-full min-h-[calc(100vh-120px)] relative">
     <section class="w-full h-full flex flex-col mx-auto">
-      <Message
-        severity="warn"
-        :closable="false"
-        :pt="{
-          root: { class: 'mx-3 mt-4 md:mx-8' },
-          wrapper: { class: 'py-3 px-3 items-start sm:items-center' }
-        }"
-      >
-        <template #messageicon>
-          <Avatar
-            icon="pi pi-exclamation-triangle"
-            class="bg-yellow-600 bg-opacity-20 text-yellow-600 mr-2 min-w-[2rem]"
-          />
-        </template>
-        <p class="text-color-secondary">
-          <b class="text-color">Preview Stage:</b>
-          The new Azion Console is in preview. You may encounter minor issues during this time.
-          <PrimeButton
-            label="Switch to the classic interface"
-            link
-            class="p-0"
-            @click="goToClassicInterface()"
-          />
-        </p>
-      </Message>
+      <ProjectStageMessageBlock />
       <div
         class="mx-3 md:mx-8 mt-4"
         v-if="hasHeadingSlot"
@@ -48,11 +24,7 @@
 <script setup>
   defineOptions({ name: 'ContentBlock' })
 
-  import Message from 'primevue/message'
-  import Avatar from 'primevue/avatar'
-  import PrimeButton from 'primevue/button'
-
-  import { goToClassicInterface } from '@/helpers/go-to-classic-interface'
+  import ProjectStageMessageBlock from './project-stage-message-block.vue'
   import { computed, useSlots } from 'vue'
   const slots = useSlots()
   const hasHeadingSlot = computed(() => !!slots.heading)

--- a/src/templates/content-block/project-stage-message-block.vue
+++ b/src/templates/content-block/project-stage-message-block.vue
@@ -1,0 +1,37 @@
+<template>
+  <Message
+    severity="warn"
+    :closable="false"
+    :pt="{
+      root: { class: 'mx-3 mt-4 md:mx-8' },
+      wrapper: { class: 'py-3 px-3 items-start sm:items-center' }
+    }"
+  >
+    <template #messageicon>
+      <Avatar
+        icon="pi pi-exclamation-triangle"
+        class="bg-yellow-600 bg-opacity-20 text-yellow-600 mr-2 min-w-[2rem]"
+      />
+    </template>
+    <p class="text-color-secondary">
+      <b class="text-color">Preview Stage:</b>
+      The new Azion Console is in preview. You may encounter minor issues during this time.
+      <PrimeButton
+        label="Switch to the classic interface"
+        link
+        class="p-0"
+        @click="goToClassicInterface()"
+      />
+    </p>
+  </Message>
+</template>
+
+<script setup>
+  defineOptions({ name: 'ProjectStageMessageBlock' })
+
+  import Message from 'primevue/message'
+  import Avatar from 'primevue/avatar'
+  import PrimeButton from 'primevue/button'
+
+  import { goToClassicInterface } from '@/helpers/go-to-classic-interface'
+</script>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
move project access stage message to its own block to avoid DRY between Content block and Banner Block ( only used in Marketplace)

![image](https://github.com/user-attachments/assets/981a18e5-3ce4-415f-aa0e-d8fb55833ff9)


### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
No.

https://github.com/user-attachments/assets/7a4bc57f-4c18-4d17-bcd6-71123258c4d4



### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
