### PR TITLE
fix: sync rules

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -63,6 +63,11 @@
       "origin-id": 139226,
       "origin-key": "90966025-1eac-436e-bac0-2bbd5bbc2654",
       "name": "origin-script-runner"
+    },
+    {
+      "origin-id": 139219,
+      "origin-key": "16a10030-5451-481c-85e9-d56f8e120679",
+      "name": "console_kit_stage_single"
     }
   ],
   "rules-engine": {
@@ -142,6 +147,11 @@
         "id": 263041,
         "name": "Secure Headers",
         "phase": "response"
+      },
+      {
+        "id": 267300,
+        "name": "Route GraphQL Billing Queries to Manager Origin",
+        "phase": ""
       }
     ]
   },


### PR DESCRIPTION
## How to fix the CICD

Ao criar uma nova regra no azion.config.cjs, se não houver a referencia do id dela local, o CLI vai sempre entender que é uma regra nova. Por isso o CICD estava quebrando, observem que todas as regras anteriores estava sendo atualizadas mas o cli falha ao criar a nova.
```
2024-07-19T12:08:18.461Z	DEBUG	Update Rules Engine
2024-07-19T12:08:21.476Z	DEBUG	Update Rules Engine
2024-07-19T12:08:24.454Z	DEBUG	Update Rules Engine
2024-07-19T12:08:31.882Z	DEBUG	Create Rules Engine
2024-07-19T12:08:32.175Z	DEBUG	Error while creating a Rules Engine	{"error": "400 Bad Request"}
...
Error: Failed to create the rule in Rules Engine: The name you've selected is already in use by another resource. Please choose a different name. Run 'azion list [resource]' to see all your resources
```

Isto ocorre pq ao rodar a primeira vez, o cli criou a regra mas o id dela não foi commitado de volta no projeto.
O que fiz para corrigir manualmente foi, após baixar a branch dev e autenticar o cli na conta 0001a rodar o seguinte comando:
```
$ azion sync --config-dir azion/stage
Adding out of sync rule 'Route GraphQL Billing Queries to Manager Origin' to your azion.json file
Adding out of sync origin 'console_kit_stage_single' to your azion.json file
Error: Failed to synchronize local resources with remote resources: open .edge/.env: no such file or directory
```
Pode ignrar o ultimo erro... o importante é o sink do arquivo `azion/stage/azion.json`.
```
$ git diff
diff --git a/azion/stage/azion.json b/azion/stage/azion.json
index 87356187..ac347cf1 100644
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -63,6 +63,11 @@
       "origin-id": 139226,
       "origin-key": "90966025-1eac-436e-bac0-2bbd5bbc2654",
       "name": "origin-script-runner"
+    },
+    {
+      "origin-id": 139219,
+      "origin-key": "16a10030-5451-481c-85e9-d56f8e120679",
+      "name": "console_kit_stage_single"
     }
   ],
   "rules-engine": {
@@ -142,6 +147,11 @@
         "id": 263041,
         "name": "Secure Headers",
         "phase": "response"
+      },
+      {
+        "id": 267300,
+        "name": "Route GraphQL Billing Queries to Manager Origin",
+        "phase": ""
       }
     ]
   },

```