### PR TITLE
[UXE-3698] refactor: load the default credit card when bill tab it is active

### DIFF
--- a/src/views/Billing/PaymentListView.vue
+++ b/src/views/Billing/PaymentListView.vue
@@ -53,7 +53,7 @@
   import { useToast } from 'primevue/usetoast'
 
   import { ref, inject } from 'vue'
-
+  const emit = defineEmits(['update-credit-event'])
   const hasContentToList = ref(true)
   const toast = useToast()
 
@@ -126,6 +126,7 @@
     try {
       const feedback = await props.setAsDefaultPaymentService(payment.id)
       showToast('success', feedback)
+      emit('update-credit-event')
       reloadList()
     } catch (error) {
       showToast('error', error)

--- a/src/views/Billing/TabsView.vue
+++ b/src/views/Billing/TabsView.vue
@@ -9,7 +9,7 @@
   import DrawerAddCredit from '@/views/Billing/Drawer/DrawerAddCredit'
   import DrawerPaymentMethod from '@/views/Billing/Drawer/DrawerPaymentMethod'
 
-  import { ref, computed, provide, onMounted } from 'vue'
+  import { ref, computed, provide, onMounted, watch } from 'vue'
 
   import { useRoute, useRouter } from 'vue-router'
   import { useAccountStore } from '@/stores/account'
@@ -71,7 +71,7 @@
       query
     })
   }
-
+  TABS_MAP.bills
   const isPaymentTabActive = computed(() => activeTab.value === TABS_MAP.payment)
   const isBillsTabActive = computed(() => activeTab.value === TABS_MAP.bills)
 
@@ -99,6 +99,12 @@
   const successAddCredit = async () => {
     await viewBillsRef.value?.reloadList()
   }
+
+  watch(isBillsTabActive, (newValue) => {
+    if (newValue) {
+      loadCardDefault()
+    }
+  })
 
   onMounted(() => {
     renderTabCurrentRouter()

--- a/src/views/Billing/TabsView.vue
+++ b/src/views/Billing/TabsView.vue
@@ -71,7 +71,7 @@
       query
     })
   }
-  TABS_MAP.bills
+  
   const isPaymentTabActive = computed(() => activeTab.value === TABS_MAP.payment)
   const isBillsTabActive = computed(() => activeTab.value === TABS_MAP.bills)
 

--- a/src/views/Billing/TabsView.vue
+++ b/src/views/Billing/TabsView.vue
@@ -9,7 +9,7 @@
   import DrawerAddCredit from '@/views/Billing/Drawer/DrawerAddCredit'
   import DrawerPaymentMethod from '@/views/Billing/Drawer/DrawerPaymentMethod'
 
-  import { ref, computed, provide, onMounted, watch } from 'vue'
+  import { ref, computed, provide, onMounted } from 'vue'
 
   import { useRoute, useRouter } from 'vue-router'
   import { useAccountStore } from '@/stores/account'
@@ -71,7 +71,7 @@
       query
     })
   }
-  
+
   const isPaymentTabActive = computed(() => activeTab.value === TABS_MAP.payment)
   const isBillsTabActive = computed(() => activeTab.value === TABS_MAP.bills)
 
@@ -99,12 +99,6 @@
   const successAddCredit = async () => {
     await viewBillsRef.value?.reloadList()
   }
-
-  watch(isBillsTabActive, (newValue) => {
-    if (newValue) {
-      loadCardDefault()
-    }
-  })
 
   onMounted(() => {
     renderTabCurrentRouter()
@@ -161,6 +155,7 @@
           <PaymentListView
             v-if="isPaymentTabActive"
             ref="listPaymentMethodsRef"
+            @update-credit-event="loadCardDefault"
             v-bind="props.paymentServices"
           />
         </TabPanel>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-3698] refactor: load the default credit card when bill tab it is active

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="Captura de Tela 2024-07-22 às 14 21 06" src="https://github.com/user-attachments/assets/fa0df023-0c0b-4921-98b4-5c081af23589">

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-3698]: https://aziontech.atlassian.net/browse/UXE-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ