### PR TITLE
[UXE-3592] fix: limit custom header in 5 items

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -260,6 +260,7 @@
           <ButtonPrimer
             outlined
             icon="pi pi-plus-circle"
+            v-if="headers.length < 5"
             iconPos="left"
             label="Header"
             size="small"

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -260,7 +260,7 @@
           <ButtonPrimer
             outlined
             icon="pi pi-plus-circle"
-            v-if="headers.length < 5"
+            v-if="hasLessThanFive"
             iconPos="left"
             label="Header"
             size="small"
@@ -1128,6 +1128,11 @@
 
   // Using the store
   const store = useAccountStore()
+
+  const MAX_HEADER_COUNT = 5
+  const hasLessThanFive = computed(() => {
+    return headers.value.length < MAX_HEADER_COUNT
+  })
 
   const placeholderLineSeparator = computed(() => {
     const text = '"\\n"'


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Remove add button when there is already 5 custom headers (api doesnt accept more than 5)
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d5e6e106-d187-4124-88cc-f420065acf35">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
