### PR TITLE
[UXE-3318] fix: rename edge node drawer title to Bind Service

### DIFF
--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -918,8 +918,8 @@
         <FieldNumber
           label="Payload Max Size"
           name="maxSize"
-          :min="1000000"
-          :max="2147483647"
+          :min="MIN_PAYLOAD_SIZE_IN_BYTES"
+          :max="MAX_PAYLOAD_SIZE_IN_BYTES"
           :value="maxSize"
           description="Customizable maximum size of data packets in bytes. Accepts values starting from 1000000."
           placeholder="1000000"
@@ -987,6 +987,9 @@
   })
 
   const route = useRoute()
+
+  const MAX_PAYLOAD_SIZE_IN_BYTES = ref(2147483647)
+  const MIN_PAYLOAD_SIZE_IN_BYTES = ref(1000000)
 
   // Variables
   const listDataSources = ref([
@@ -1194,7 +1197,7 @@
         // standard
         endpointUrl: '',
         headers: [{ value: '', deleted: false }],
-        maxSize: 1000000,
+        maxSize: MIN_PAYLOAD_SIZE_IN_BYTES.value,
         lineSeparator: '\\n',
         payloadFormat: '$dataset',
 
@@ -1271,7 +1274,7 @@
   const setDefaultValuesWhenChangeTheEndpointInEdit = (isFirstRender) => {
     if (route.name === 'edit-data-stream' && !isFirstRender) {
       if (endpoint.value === 'standard') {
-        maxSize.value = 1000000
+        maxSize.value = MIN_PAYLOAD_SIZE_IN_BYTES.value
         lineSeparator.value = '\\n'
         payloadFormat.value = '$dataset'
         headers.value = [{ value: '', deleted: false }]

--- a/src/views/EdgeNode/Drawer/index.vue
+++ b/src/views/EdgeNode/Drawer/index.vue
@@ -113,7 +113,7 @@
     :schema="validationSchema"
     :initialValues="initialValues"
     @onSuccess="emit('onSuccess')"
-    title="Create Service"
+    title="Bind Service"
   >
     <template #formFields="{ disabledFields }">
       <FormFieldsDrawerService


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
1) Rename drawer title to correct text. 

2) Add max and min values to Data streaming payload size field to improve UX by avoiding to use numbers outside of the valid range of payload size.

### Does this PR introduce UI changes? Add a video or screenshots here.
yes, in Data Streaming only:

Data Streaming :

https://github.com/user-attachments/assets/dfa5a5f5-8897-4722-9303-b45606bef906


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
