### PR TITLE
[UXE-3804] fix: format correctly digital certificates error messages

### DIFF
--- a/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
@@ -32,6 +32,10 @@ const extractApiError = (body) => {
         break
       }
     }
+    else {
+      apiError = body[keyError]
+      break
+    }
   }
 
   return apiError

--- a/src/services/digital-certificates-services/create-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-service.js
@@ -32,6 +32,10 @@ const extractApiError = (body) => {
         break
       }
     }
+    else {
+      apiError = body[keyError]
+      break
+    }
   }
 
   return apiError

--- a/src/services/digital-certificates-services/edit-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/edit-digital-certificates-service.js
@@ -33,6 +33,10 @@ const extractApiError = (body) => {
         break
       }
     }
+    else {
+      apiError = body[keyError]
+      break
+    }
   }
 
   return apiError

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
@@ -33,6 +33,9 @@ const fixture = {
     private_key_type: 'rsa_2048',
     sans: ['SAN1', 'SAN2', 'SAN3']
   },
+  nameErrorMock: {
+    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+  },
   errorMock: {
     error: ['Error Message']
   }
@@ -66,6 +69,18 @@ describe('DigitalCertificatesServices', () => {
       url: `${version}/digital_certificates/csr`,
       body: fixture.requestBodyMock
     })
+  })
+
+  it('should parse correctly the feedback message when the error is a string inside an object', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: fixture.nameErrorMock
+    })
+    const { sut } = makeSut()
+
+    const response = sut(fixture.csrCertificateMock)
+
+    expect(response).rejects.toThrow(fixture.nameErrorMock.detail)
   })
 
   it.each([

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
@@ -51,6 +51,9 @@ const fixture = {
     name: 'MyWebsiteCertificate',
     certificate_type: 'SSL/TLS'
   },
+  nameErrorMock: {
+    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+  },
   errorMock: {
     error: ['Error Message']
   }
@@ -152,6 +155,18 @@ describe('DigitalCertificatesServices', () => {
       url: `${version}/digital_certificates`,
       body: fixture.requestBodyMockWithoutPrivateKey
     })
+  })
+
+  it('should parse correctly the feedback message when the error is a string inside an object', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: fixture.nameErrorMock
+    })
+    const { sut } = makeSut()
+
+    const response = sut(fixture.payloadMock)
+
+    expect(response).rejects.toThrow(fixture.nameErrorMock.detail)
   })
 
   it.each([

--- a/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
@@ -12,6 +12,9 @@ const fixture = {
     privateKey:
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
   },
+  nameErrorMock: {
+    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+  },
   errorMock: {
     error: ['Error Message']
   }
@@ -54,6 +57,18 @@ describe('DigitalCertificatesServices', () => {
     const feedbackMessage = sut(fixture.payloadMock)
 
     expect(feedbackMessage).resolves.toBe('Your digital certificate has been updated!')
+  })
+
+  it('should parse correctly the feedback message when the error is a string inside an object', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: fixture.nameErrorMock
+    })
+    const { sut } = makeSut()
+
+    const response = sut(fixture.payloadMock)
+
+    expect(response).rejects.toThrow(fixture.nameErrorMock.detail)
   })
 
   it.each([


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Parse correctly digital certificate error message

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/59046892-16c8-480b-ad40-c2f380ea9dde">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
