### PR TITLE
[UXE-4013] fix: disable phase change when editing rules engine in edge application

### DIFF
--- a/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-csr-service.js
@@ -31,8 +31,7 @@ const extractApiError = (body) => {
         apiError = errorValue.message[0]
         break
       }
-    }
-    else {
+    } else {
       apiError = body[keyError]
       break
     }

--- a/src/services/digital-certificates-services/create-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/create-digital-certificates-service.js
@@ -31,8 +31,7 @@ const extractApiError = (body) => {
         apiError = errorValue.message[0]
         break
       }
-    }
-    else {
+    } else {
       apiError = body[keyError]
       break
     }

--- a/src/services/digital-certificates-services/edit-digital-certificates-service.js
+++ b/src/services/digital-certificates-services/edit-digital-certificates-service.js
@@ -32,8 +32,7 @@ const extractApiError = (body) => {
         apiError = errorValue.message[0]
         break
       }
-    }
-    else {
+    } else {
       apiError = body[keyError]
       break
     }

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-csr-service.test.js
@@ -34,7 +34,8 @@ const fixture = {
     sans: ['SAN1', 'SAN2', 'SAN3']
   },
   nameErrorMock: {
-    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+    detail:
+      'The field name needs to be unique. There is already another certificate with this name in your account.'
   },
   errorMock: {
     error: ['Error Message']

--- a/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/create-digital-certificates-service.test.js
@@ -52,7 +52,8 @@ const fixture = {
     certificate_type: 'SSL/TLS'
   },
   nameErrorMock: {
-    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+    detail:
+      'The field name needs to be unique. There is already another certificate with this name in your account.'
   },
   errorMock: {
     error: ['Error Message']

--- a/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
+++ b/src/tests/services/digital-certificates-services/edit-digital-certificates-service.test.js
@@ -13,7 +13,8 @@ const fixture = {
       '-----BEGIN PRIVATE KEY-----\nMIIE... (private key content) ...\n-----END PRIVATE KEY-----'
   },
   nameErrorMock: {
-    detail: 'The field name needs to be unique. There is already another certificate with this name in your account.'
+    detail:
+      'The field name needs to be unique. There is already another certificate with this name in your account.'
   },
   errorMock: {
     error: ['Error Message']

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -709,6 +709,7 @@
         isCard
         :options="phasesRadioOptions"
         data-testid="rule-form-phase-radio"
+        :disabled="isEditDrawer"
       />
     </template>
   </FormHorizontal>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
- Disable "Phase" radio group when in edit mode of rules engine in edge application
- Update e2e test to verify this change
- Run linter for code formatting

### Does this PR introduce UI changes? Add a video or screenshots here.

![Screenshot 2024-07-29 at 09 11 54](https://github.com/user-attachments/assets/ae4d2976-092b-48e9-902c-2a19670aeeba)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
