### PR TITLE
[UXE-3686] fix: change spaces in sign up page

### DIFF
--- a/src/views/Signup/SignupView.vue
+++ b/src/views/Signup/SignupView.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <section class="flex max-lg:flex-col">
+    <section class="flex flex-col md:flex-row p-3 md:p-6 2xl:p-10 gap-10 md:gap-20 2xl:gap-40 justify-center">
       <div
-        class="w-auto 2xl:w-full flex flex-col items-center justify-center p-6 lg:p-20 max-md:px-3 max-md:pt-4 max-md:pb-8"
+        class="flex flex-col items-center justify-center"
       >
         <form-signup-block v-bind="props" />
       </div>
       <div
-        class="w-full flex flex-col items-center justify-center p-20 lg:p-10 max-md:px-3 max-md:pt-4 max-md:pb-8"
+        class="flex flex-col items-center justify-center"
       >
         <div>
           <client-testimonials-block />


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Change spaces in sign up page to fit responsiveness in bigger screens
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="659" alt="image" src="https://github.com/user-attachments/assets/da09c684-a6b7-4527-982d-e557abe25d3c">


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
