### PR TITLE
[UXE-3455] fix: remove the category query when the filter is all

### DIFF
--- a/src/views/Marketplace/MarketplaceHomeView.vue
+++ b/src/views/Marketplace/MarketplaceHomeView.vue
@@ -181,7 +181,8 @@
   const disabledOption = ({ code }) => code === selectedCategory.value?.code
 
   const changeCategory = async () => {
-    const category = selectedCategory.value.code
+    const { code } = selectedCategory.value
+    const category = code === 'all' ? undefined : code
 
     try {
       loading.value = true


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
remove the category query when the filter is all
### Does this PR introduce UI changes? Add a video or screenshots here.

![Captura de Tela 2024-07-31 às 11 57 24](https://github.com/user-attachments/assets/6765936b-d56b-413a-973d-63b32c033c71)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
