### PR TITLE
[UXE-4335] fix: update rules engine list response phase after success creation

### DIFF
--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -185,17 +185,19 @@
         </template>
       </Column>
       <template #empty>
-        <div
+        <slot
+          name="noRecordsFound"
           data-testid="data-table-empty-content"
-          class="my-4 flex flex-col gap-3 justify-center items-start"
         >
-          <p
-            class="text-md font-normal text-secondary"
-            data-testid="list-table-block__empty-message__text"
-          >
-            {{ emptyListMessage }}
-          </p>
-        </div>
+          <div class="my-4 flex flex-col gap-3 justify-center items-start">
+            <p
+              class="text-md font-normal text-secondary"
+              data-testid="list-table-block__empty-message__text"
+            >
+              {{ emptyListMessage }}
+            </p>
+          </div>
+        </slot>
       </template>
     </DataTable>
 

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -185,19 +185,17 @@
         </template>
       </Column>
       <template #empty>
-        <slot
-          name="noRecordsFound"
+        <div
           data-testid="data-table-empty-content"
+          class="my-4 flex flex-col gap-3 justify-center items-start"
         >
-          <div class="my-4 flex flex-col gap-3 justify-center items-start">
-            <p
-              class="text-md font-normal text-secondary"
-              data-testid="list-table-block__empty-message__text"
-            >
-              {{ emptyListMessage }}
-            </p>
-          </div>
-        </slot>
+          <p
+            class="text-md font-normal text-secondary"
+            data-testid="list-table-block__empty-message__text"
+          >
+            {{ emptyListMessage }}
+          </p>
+        </div>
       </template>
     </DataTable>
 

--- a/src/tests/services/billing-services/load-your-service-plan-service.test.js
+++ b/src/tests/services/billing-services/load-your-service-plan-service.test.js
@@ -1,23 +1,7 @@
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import { loadYourServicePlanService } from '@/services/billing-services'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import graphQLApi from '@/services/axios/makeGraphQl'
-import { formatDateToUSBilling } from '@/helpers/convert-date'
-
-const getFirstDayCurrentDate = () => {
-  const currentDate = new Date()
-  const firstDayOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
-  const lastDayOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0)
-
-  const formatDate = (date) => {
-    return date.toISOString().split('T')[0]
-  }
-
-  return {
-    firstDayOfMonth: formatDate(firstDayOfMonth),
-    lastDayOfMonth: formatDate(lastDayOfMonth)
-  }
-}
 
 const fixtures = {
   paymentMock: {
@@ -27,7 +11,7 @@ const fixtures = {
     currency: 'USD',
     paymentDate: '2024-07-01'
   },
-  disclaimerTwentyThree:
+  disclaimerWithCustomAmount:
     "Welcome to the Free Trial period. The credit of USD 23.40 is available for use over the next 71 days. To use Azion with no service interruptions at the end of the trial, add a <a href='/billing-subscriptions/payment-methods/add' target='_top'>payment method</a>.",
   disclaimerZero:
     "Welcome to the Free Trial period. The credit of USD is available for use over the next 71 days. To use Azion with no service interruptions at the end of the trial, add a <a href='/billing-subscriptions/payment-methods/add' target='_top'>payment method</a>.",
@@ -41,7 +25,15 @@ const makeSut = () => {
   return { sut }
 }
 describe('BillingService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
   it('should call api with correct params', async () => {
+    const januaryFirst2024Mock = new Date(2024, 0, 1)
+    vi.setSystemTime(januaryFirst2024Mock)
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
       body: {
@@ -54,7 +46,6 @@ describe('BillingService', () => {
     const { sut } = makeSut()
 
     await sut(fixtures.disclaimerDefault)
-    const { lastDayOfMonth, firstDayOfMonth } = getFirstDayCurrentDate()
 
     const payload = {
       query: `query getBillDetail {
@@ -62,7 +53,7 @@ describe('BillingService', () => {
               limit: 1,
               filter: {
                   paymentDateRange: {
-                      begin: "${firstDayOfMonth}", end: "${lastDayOfMonth}"
+                      begin: "2024-01-01", end: "2024-01-31"
                   },
             },
           orderBy: [paymentDate_ASC]
@@ -84,26 +75,24 @@ describe('BillingService', () => {
       graphQLApi
     )
   })
-  it('should return 23.40 value in the disclaimer ', async () => {
-    const { firstDayOfMonth } = getFirstDayCurrentDate()
-
+  it('should return correct credit amount in the disclaimer message', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
       body: { data: { payments: [fixtures.paymentMock] } }
     })
 
     const { sut } = makeSut()
-    const result = await sut(fixtures.disclaimerTwentyThree)
+    const result = await sut(fixtures.disclaimerWithCustomAmount)
 
     expect(result).toEqual({
       amount: 0,
       creditBalance: '23.40',
       currency: 'USD',
-      paymentDate: formatDateToUSBilling(firstDayOfMonth)
+      paymentDate: '07/01/2024'
     })
   })
 
-  it('should replace with correct placeholder on empty payment data', async () => {
+  it('should return correct response when no payments are found', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
       body: { data: { payments: [] } }

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -75,16 +75,14 @@
   })
 
   const PHASE_OPTIONS = ['Request phase', 'Response phase']
-  const drawerRulesEngineRef = ref('')
-  const hasContentToList = ref(true)
-  const listRulesEngineRef = ref(null)
-
-  const selectedPhase = ref('Request phase')
-  const parsePhase = {
+  const PARSE_PHASE = {
     'Request phase': 'request',
     'Response phase': 'response'
   }
-
+  const drawerRulesEngineRef = ref('')
+  const hasContentToList = ref(true)
+  const listRulesEngineRef = ref(null)
+  const selectedPhase = ref('Request phase')
   const getColumns = computed(() => {
     return [
       {
@@ -130,7 +128,7 @@
   const listRulesEngineWithDecorator = async () => {
     return props.listRulesEngineService({
       id: props.edgeApplicationId,
-      phase: parsePhase[selectedPhase.value]
+      phase: PARSE_PHASE[selectedPhase.value]
     })
   }
 
@@ -154,8 +152,8 @@
   }
 
   const openCreateRulesEngineDrawerByPhase = () => {
-    parsePhase[selectedPhase.value]
-    drawerRulesEngineRef.value.openDrawerCreate(parsePhase[selectedPhase.value])
+    PARSE_PHASE[selectedPhase.value]
+    drawerRulesEngineRef.value.openDrawerCreate(PARSE_PHASE[selectedPhase.value])
   }
 
   const openEditRulesEngineDrawer = (item) => {

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -150,11 +150,7 @@
   }
 
   const reloadList = () => {
-    if (hasContentToList.value) {
-      listRulesEngineRef.value.reload()
-      return
-    }
-    hasContentToList.value = true
+    listRulesEngineRef.value.reload()
   }
 
   const openCreateRulesEngineDrawerByPhase = () => {
@@ -183,10 +179,6 @@
       service: deleteRulesEngineWithDecorator
     }
   ]
-
-  const reloadListOnPhaseChange = () => {
-    listRulesEngineRef.value.reload()
-  }
 </script>
 
 <template>
@@ -209,7 +201,6 @@
     data-testid="rules-engine-drawer"
   />
   <ListTableBlock
-    v-if="hasContentToList"
     ref="listRulesEngineRef"
     :reorderableRows="true"
     :columns="getColumns"
@@ -233,7 +224,7 @@
       >
         <SelectButton
           v-model="selectedPhase"
-          @change="reloadListOnPhaseChange"
+          @change="reloadList"
           :options="PHASE_OPTIONS"
           :unselectable="true"
           data-testid="rules-engine-select-phase"
@@ -246,26 +237,29 @@
         />
       </div>
     </template>
-  </ListTableBlock>
-  <EmptyResultsBlock
-    v-else
-    :title="titleEmptyState"
-    :description="descriptionEmptyState"
-    :createButtonLabel="selectedPhase"
-    :documentationService="documentationService"
-    :inTabs="true"
-    :noBorder="true"
-    data-testid="rules-engine-empty-results"
-  >
-    <template #default>
-      <PrimeButton
-        class="max-md:w-full w-fit"
-        @click="openCreateRulesEngineDrawerByPhase"
-        severity="secondary"
-        icon="pi pi-plus"
-        label="Rule"
-        data-testid="rules-engine-empty-results-create-button"
-      />
+
+    <template #noRecordsFound>
+      <EmptyResultsBlock
+        v-if="!hasContentToList"
+        :title="titleEmptyState"
+        :description="descriptionEmptyState"
+        :createButtonLabel="selectedPhase"
+        :documentationService="documentationService"
+        :inTabs="true"
+        :noBorder="true"
+        data-testid="rules-engine-empty-results"
+      >
+        <template #default>
+          <PrimeButton
+            class="max-md:w-full w-fit"
+            @click="openCreateRulesEngineDrawerByPhase"
+            severity="secondary"
+            icon="pi pi-plus"
+            label="Rule"
+            data-testid="rules-engine-empty-results-create-button"
+          />
+        </template>
+      </EmptyResultsBlock>
     </template>
-  </EmptyResultsBlock>
+  </ListTableBlock>
 </template>

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -5,7 +5,7 @@
   import ListTableBlock from '@/templates/list-table-block'
   import PrimeButton from 'primevue/button'
   import SelectButton from 'primevue/selectbutton'
-  import { computed, ref, watch } from 'vue'
+  import { computed, ref } from 'vue'
 
   defineOptions({ name: 'list-edge-applications-device-groups-tab' })
 
@@ -74,11 +74,11 @@
     }
   })
 
+  const PHASE_OPTIONS = ['Request phase', 'Response phase']
   const drawerRulesEngineRef = ref('')
   const hasContentToList = ref(true)
   const listRulesEngineRef = ref(null)
 
-  const phaseOptions = ref(['Request phase', 'Response phase'])
   const selectedPhase = ref('Request phase')
   const parsePhase = {
     'Request phase': 'request',
@@ -184,9 +184,9 @@
     }
   ]
 
-  watch(selectedPhase, () => {
+  const reloadListOnPhaseChange = () => {
     listRulesEngineRef.value.reload()
-  })
+  }
 </script>
 
 <template>
@@ -233,7 +233,8 @@
       >
         <SelectButton
           v-model="selectedPhase"
-          :options="phaseOptions"
+          @change="reloadListOnPhaseChange"
+          :options="PHASE_OPTIONS"
           :unselectable="true"
           data-testid="rules-engine-select-phase"
         />

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -1,5 +1,4 @@
 <script setup>
-  import Illustration from '@/assets/svg/illustration-layers'
   import EmptyResultsBlock from '@/templates/empty-results-block'
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import DrawerRulesEngine from '@/views/EdgeApplicationsRulesEngine/Drawer'
@@ -75,7 +74,16 @@
     }
   })
 
+  const drawerRulesEngineRef = ref('')
   const hasContentToList = ref(true)
+  const listRulesEngineRef = ref(null)
+
+  const phaseOptions = ref(['Request phase', 'Response phase'])
+  const selectedPhase = ref('Request phase')
+  const parsePhase = {
+    'Request phase': 'request',
+    'Response phase': 'response'
+  }
 
   const getColumns = computed(() => {
     return [
@@ -119,12 +127,6 @@
     hasContentToList.value = event
   }
 
-  const phaseOptions = ref(['Request phase', 'Response phase'])
-  const selectedPhase = ref('Request phase')
-  const parsePhase = {
-    'Request phase': 'request',
-    'Response phase': 'response'
-  }
   const listRulesEngineWithDecorator = async () => {
     return props.listRulesEngineService({
       id: props.edgeApplicationId,
@@ -147,11 +149,6 @@
     return props.reorderRulesEngine(tableData, props.edgeApplicationId)
   }
 
-  const listRulesEngineRef = ref(null)
-  watch(selectedPhase, () => {
-    listRulesEngineRef.value.reload()
-  })
-
   const reloadList = () => {
     if (hasContentToList.value) {
       listRulesEngineRef.value.reload()
@@ -159,8 +156,6 @@
     }
     hasContentToList.value = true
   }
-
-  const drawerRulesEngineRef = ref('')
 
   const openCreateRulesEngineDrawerByPhase = () => {
     parsePhase[selectedPhase.value]
@@ -188,6 +183,10 @@
       service: deleteRulesEngineWithDecorator
     }
   ]
+
+  watch(selectedPhase, () => {
+    listRulesEngineRef.value.reload()
+  })
 </script>
 
 <template>
@@ -210,6 +209,7 @@
     data-testid="rules-engine-drawer"
   />
   <ListTableBlock
+    v-if="hasContentToList"
     ref="listRulesEngineRef"
     :reorderableRows="true"
     :columns="getColumns"
@@ -220,7 +220,7 @@
     :pt="{
       thead: { class: !hasContentToList && 'hidden' }
     }"
-    emptyListMessage="No rules have been created."
+    emptyListMessage="No rules found."
     :isReorderAllEnabled="removeReorderForRequestPhaseFirstItem"
     data-testid="rules-engine-list"
     :actions="actions"
@@ -245,31 +245,26 @@
         />
       </div>
     </template>
-
-    <template #noRecordsFound>
-      <EmptyResultsBlock
-        :title="titleEmptyState"
-        :description="descriptionEmptyState"
-        :createButtonLabel="selectedPhase"
-        :documentationService="documentationService"
-        :inTabs="true"
-        :noBorder="true"
-        data-testid="rules-engine-empty-results"
-      >
-        <template #default>
-          <PrimeButton
-            class="max-md:w-full w-fit"
-            @click="openCreateRulesEngineDrawerByPhase"
-            severity="secondary"
-            icon="pi pi-plus"
-            label="Rule"
-            data-testid="rules-engine-empty-results-create-button"
-          />
-        </template>
-        <template #illustration>
-          <Illustration />
-        </template>
-      </EmptyResultsBlock>
-    </template>
   </ListTableBlock>
+  <EmptyResultsBlock
+    v-else
+    :title="titleEmptyState"
+    :description="descriptionEmptyState"
+    :createButtonLabel="selectedPhase"
+    :documentationService="documentationService"
+    :inTabs="true"
+    :noBorder="true"
+    data-testid="rules-engine-empty-results"
+  >
+    <template #default>
+      <PrimeButton
+        class="max-md:w-full w-fit"
+        @click="openCreateRulesEngineDrawerByPhase"
+        severity="secondary"
+        icon="pi pi-plus"
+        label="Rule"
+        data-testid="rules-engine-empty-results-create-button"
+      />
+    </template>
+  </EmptyResultsBlock>
 </template>

--- a/src/views/EdgeFirewallRulesEngine/ListView.vue
+++ b/src/views/EdgeFirewallRulesEngine/ListView.vue
@@ -165,7 +165,7 @@
     :editInDrawer="openEditDrawer"
     :isReorderAllEnabled="true"
     @on-load-data="handleLoadData"
-    emptyListMessage="No rules have been created."
+    emptyListMessage="No rules found."
     addButtonLabel="Rules Engine"
     :actions="actions"
     isTabs


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Ensure that  the Edge application - Rules Engine - Response phase list is updated after a successfully creation .
- Fix empty search results message
- fix flaky test implementation of load-your-service-plan-service, by using vitest fake timers instead of the production code using JS Date Class.
- remove dead code inside list-template-block by removing unused slot 


### Does this PR introduce UI changes? Add a video or screenshots here.
Yes



https://github.com/user-attachments/assets/af87bba6-74d2-428f-ac05-5c4e1b6376c8




<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [x] Safari
