### PR TITLE
[UXE-4039] fix: Unable edit to secret variables

### DIFF
--- a/src/views/Variables/FormFields/FormFieldsVariables.vue
+++ b/src/views/Variables/FormFields/FormFieldsVariables.vue
@@ -2,6 +2,7 @@
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
   import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
   import FieldText from '@/templates/form-fields-inputs/fieldText'
+  import InlineMessage from 'primevue/inlinemessage'
 
   import { useField } from 'vee-validate'
   defineOptions({ name: 'form-fields-variables' })
@@ -40,15 +41,23 @@
           data-testid="variables-form__value-field"
         />
       </div>
-      <div class="flex gap-3 items-center">
-        <FieldSwitchBlock
-          nameField="secret"
-          name="secret"
-          auto
-          :isCard="false"
-          title="Secret"
-          data-testid="variables-form__secret-field"
-        />
+      <div class="flex flex-col sm:max-w-lg w-full gap-2">
+        <div class="flex items-center">
+          <FieldSwitchBlock
+            nameField="secret"
+            name="secret"
+            auto
+            :isCard="false"
+            title="Secret"
+            data-testid="variables-form__secret-field"
+          />
+        </div>
+        <InlineMessage
+          severity="info"
+          class="w-fit"
+        >
+          Sensitive data is handled by a PCI-compliant payment partner.
+        </InlineMessage>
       </div>
     </template>
   </FormHorizontal>

--- a/src/views/Variables/ListView.vue
+++ b/src/views/Variables/ListView.vue
@@ -6,11 +6,13 @@
     <template #content>
       <ListTableBlock
         v-if="hasContentToList"
+        @on-before-go-to-edit="checkIfIsEditable"
         :listService="listVariablesService"
         :columns="getColumns"
         addButtonLabel="Variable"
         createPagePath="variables/create"
         editPagePath="variables/edit"
+        ref="refListTable"
         @on-load-data="handleLoadData"
         emptyListMessage="No variables found."
         :actions="actions"
@@ -33,6 +35,7 @@
 
 <script setup>
   import Illustration from '@/assets/svg/illustration-layers.vue'
+  import { onBeforeRouteLeave } from 'vue-router'
   import ContentBlock from '@/templates/content-block'
   import EmptyResultsBlock from '@/templates/empty-results-block'
   import ListTableBlock from '@/templates/list-table-block'
@@ -61,6 +64,8 @@
     }
   })
 
+  const enableRedirect = ref(true)
+  const refListTable = ref()
   const hasContentToList = ref(true)
   const actions = [
     {
@@ -110,5 +115,17 @@
         header: 'Last Update'
       }
     ]
+  })
+
+  const checkIfIsEditable = (item) => {
+    enableRedirect.value = item.value.isSecret ? false : true
+  }
+
+  onBeforeRouteLeave((to, from, next) => {
+    if (enableRedirect.value) {
+      return next()
+    }
+    enableRedirect.value = true
+    return next(false)
   })
 </script>

--- a/src/views/Variables/ListView.vue
+++ b/src/views/Variables/ListView.vue
@@ -118,7 +118,7 @@
   })
 
   const checkIfIsEditable = (item) => {
-    enableRedirect.value = item.value.isSecret ? false : true
+    enableRedirect.value = !item.value.isSecret
   }
 
   onBeforeRouteLeave((to, from, next) => {


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Block edit redirection when a variable is a secret and add a message to the form informing that secrets are not editable
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/aa1bd302-f28e-4eb1-9860-e4851d6cd9ce


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
