### PR TITLE
[UXE-4165] fix: double / from prefix field in Edge App Edge Storage Origins

### DIFF
--- a/src/services/edge-application-origins-services/create-origin-service.js
+++ b/src/services/edge-application-origins-services/create-origin-service.js
@@ -19,7 +19,7 @@ const adapt = (payload) => {
       name: payload.name,
       origin_type: payload.originType,
       bucket: payload.bucketName,
-      prefix: `/${payload.prefix}`.trim()
+      prefix: payload.prefix.trim() === '' ? '/' : payload.prefix
     }
   }
 

--- a/src/services/edge-application-origins-services/create-origin-service.js
+++ b/src/services/edge-application-origins-services/create-origin-service.js
@@ -19,7 +19,7 @@ const adapt = (payload) => {
       name: payload.name,
       origin_type: payload.originType,
       bucket: payload.bucketName,
-      prefix: payload.prefix.trim() === '' ? '/' : payload.prefix
+      prefix: payload.prefix.trim() || '/'
     }
   }
 

--- a/src/services/edge-application-origins-services/edit-origin-service.js
+++ b/src/services/edge-application-origins-services/edit-origin-service.js
@@ -19,7 +19,7 @@ const adapt = (payload) => {
       name: payload.name,
       origin_type: payload.originType,
       bucket: payload.bucketName,
-      prefix: `/${payload.prefix}`.trim()
+      prefix: payload.prefix.trim() === '' ? '/' : payload.prefix
     }
   }
 

--- a/src/services/edge-application-origins-services/edit-origin-service.js
+++ b/src/services/edge-application-origins-services/edit-origin-service.js
@@ -19,7 +19,7 @@ const adapt = (payload) => {
       name: payload.name,
       origin_type: payload.originType,
       bucket: payload.bucketName,
-      prefix: payload.prefix.trim() === '' ? '/' : payload.prefix
+      prefix: payload.prefix.trim() || '/'
     }
   }
 

--- a/src/tests/services/edge-application-origins-services/create-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/create-origin-service.test.js
@@ -84,7 +84,7 @@ const scenarios = [
       ...fixtures.requestPayloadMock,
       originType: 'object_storage',
       bucketName: 'my-bucket',
-      prefix: 'test'
+      prefix: '/test'
     },
     adaptedPayload: {
       name: 'New Origin',

--- a/src/tests/services/edge-application-origins-services/create-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/create-origin-service.test.js
@@ -92,6 +92,21 @@ const scenarios = [
       bucket: 'my-bucket',
       prefix: '/test'
     }
+  },
+  {
+    label: 'should adapt prefix to / when the field is empty',
+    payload: {
+      ...fixtures.requestPayloadMock,
+      originType: 'object_storage',
+      bucketName: 'my-bucket',
+      prefix: ''
+    },
+    adaptedPayload: {
+      name: 'New Origin',
+      origin_type: 'object_storage',
+      bucket: 'my-bucket',
+      prefix: '/'
+    }
   }
 ]
 

--- a/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
@@ -39,6 +39,15 @@ const fixtures = {
     bucketName: 'my-bucket',
     prefix: '/test'
   },
+  emptyPrefixOrigin: {
+    id: '0000000-00000000-00a0a00s0as0-000000',
+    edgeApplicationId: 123,
+    name: 'New Origin',
+    originProtocolPolicy: 'http',
+    originType: 'object_storage',
+    bucketName: 'my-bucket',
+    prefix: ''
+  },
   addressesMock: [
     {
       address: 'httpbin.org',
@@ -108,6 +117,27 @@ describe('EdgeApplicationOriginsServices', () => {
         name: fixtures.originTypeObjectStorage.name,
         bucket: fixtures.originTypeObjectStorage.bucketName,
         prefix: fixtures.originTypeObjectStorage.prefix
+      }
+    })
+  })
+  it('should adapt prefix to / when the field is empty', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200
+    })
+
+    const { sut } = makeSut()
+    const version = 'v3'
+
+    await sut(fixtures.emptyPrefixOrigin)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `${version}/edge_applications/${fixtures.emptyPrefixOrigin.edgeApplicationId}/origins/${fixtures.emptyPrefixOrigin.id}`,
+      method: 'PATCH',
+      body: {
+        origin_type: fixtures.emptyPrefixOrigin.originType,
+        name: fixtures.emptyPrefixOrigin.name,
+        bucket: fixtures.emptyPrefixOrigin.bucketName,
+        prefix: '/'
       }
     })
   })

--- a/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
@@ -30,6 +30,15 @@ const fixtures = {
     connectionTimeout: 60,
     timeoutBetweenBytes: 35
   },
+  originTypeObjectStorage: {
+    id: '0000000-00000000-00a0a00s0as0-000000',
+    edgeApplicationId: 123,
+    name: 'New Origin',
+    originProtocolPolicy: 'http',
+    originType: 'object_storage',
+    bucketName: 'my-bucket',
+    prefix: '/test'
+  },
   addressesMock: [
     {
       address: 'httpbin.org',
@@ -77,6 +86,28 @@ describe('EdgeApplicationOriginsServices', () => {
         hmac_secret_key: fixtures.originMock.hmacSecretKey,
         connection_timeout: fixtures.originMock.connectionTimeout,
         timeout_between_bytes: fixtures.originMock.timeoutBetweenBytes
+      }
+    })
+  })
+
+  it('should call API with correct params when origin type is object storage', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200
+    })
+
+    const { sut } = makeSut()
+    const version = 'v3'
+
+    await sut(fixtures.originTypeObjectStorage)
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `${version}/edge_applications/${fixtures.originTypeObjectStorage.edgeApplicationId}/origins/${fixtures.originTypeObjectStorage.id}`,
+      method: 'PATCH',
+      body: {
+        origin_type: fixtures.originTypeObjectStorage.originType,
+        name: fixtures.originTypeObjectStorage.name,
+        bucket: fixtures.originTypeObjectStorage.bucketName,
+        prefix: fixtures.originTypeObjectStorage.prefix
       }
     })
   })

--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -94,7 +94,7 @@
     hmacAccessKey: '',
     hmacSecretKey: '',
     bucketName: null,
-    prefix: null
+    prefix: ''
   })
 
   const createFormDrawer = ref('')


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Remove / from prefix field in edge application origins forms
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/13a050e6-965d-4f5f-8301-903cbda0347d">

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [ ] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
