### PR TITLE
[UXE-3625] refactor: add h-[2.323rem] in px(37) in the advanced filter component

### DIFF
--- a/src/templates/advanced-filter/dialog-filter.vue
+++ b/src/templates/advanced-filter/dialog-filter.vue
@@ -177,7 +177,7 @@
     icon="pi pi-plus"
     label="Filter"
     type="button"
-    class="flex justify-center items-center md:rounded-[6px_0px_0px_6px] min-w-max md:h-12"
+    class="flex justify-center items-center md:rounded-[6px_0px_0px_6px] min-w-max md:h-[2.313rem]"
     severity="secondary"
     badgeClass="!text-xl"
     :disabled="disabled"

--- a/src/templates/advanced-filter/dialog-filter.vue
+++ b/src/templates/advanced-filter/dialog-filter.vue
@@ -177,9 +177,10 @@
     icon="pi pi-plus"
     label="Filter"
     type="button"
-    class="flex justify-center items-center md:rounded-[6px_0px_0px_6px] min-w-max md:h-[2.313rem]"
+    class="flex justify-center items-center md:rounded-[6px_0px_0px_6px] md:h-[2.313rem]"
     severity="secondary"
     badgeClass="!text-xl"
+    size="small"
     :disabled="disabled"
     outlined
     v-bind="counterFilter"

--- a/src/templates/advanced-filter/index.vue
+++ b/src/templates/advanced-filter/index.vue
@@ -255,7 +255,7 @@
     />
 
     <div
-      class="md:-ml-2 md:border-b md:border-left-none md:border-r border-solid border-t flex items-center p-inputtext md:rounded-[0px_6px_6px_0px] w-full overflow-x-auto overflow-y-hidden h-[37px] md:h-12"
+      class="md:-ml-2 md:border-b md:border-left-none md:border-r border-solid border-t flex items-center p-inputtext md:rounded-[0px_6px_6px_0px] w-full overflow-x-auto overflow-y-hidden h-[2.313rem]"
       data-testid="search-filter-chips-container"
     >
       <ul
@@ -314,7 +314,7 @@
     </div>
 
     <PrimeButton
-      class="h-auto min-w-max max-sm:bg-red"
+      class="min-w-max max-sm:bg-red"
       size="small"
       :disabled="disabledSearch"
       @click="searchFilter"

--- a/src/views/RealTimeMetrics/blocks/content-filter-block.vue
+++ b/src/views/RealTimeMetrics/blocks/content-filter-block.vue
@@ -212,7 +212,7 @@
 </script>
 
 <template>
-  <div class="flex w-full flex-column gap-6 md:gap-2 md:flex-row">
+  <div class="flex w-full flex-column gap-6 md:gap-2 md:flex-row h-[2.313rem]">
     <advancedFilter
       :disabled="disabledFilter"
       :fieldsInFilter="optionsFields"

--- a/src/views/RealTimeMetrics/blocks/content-filter-block.vue
+++ b/src/views/RealTimeMetrics/blocks/content-filter-block.vue
@@ -212,7 +212,7 @@
 </script>
 
 <template>
-  <div class="flex w-full flex-column gap-6 md:gap-2 md:flex-row h-[2.313rem]">
+  <div class="flex w-full flex-column gap-6 md:gap-2 md:flex-row">
     <advancedFilter
       :disabled="disabledFilter"
       :fieldsInFilter="optionsFields"

--- a/src/views/RealTimeMetrics/blocks/interval-filter-block.vue
+++ b/src/views/RealTimeMetrics/blocks/interval-filter-block.vue
@@ -169,7 +169,7 @@
 </script>
 
 <template>
-  <div class="flex flex-column gap-6 md:flex-row md:gap-6 w-full">
+  <div class="flex flex-column gap-6 md:flex-row md:gap-3 w-full">
     <div class="w-full lg:max-w-xs max-w-full">
       <Dropdown
         appendTo="self"


### PR DESCRIPTION
## Pull Request
[UXE-3625]
### What is the new behavior introduced by this PR?

add h-[2.323rem] in px(37) in the advanced filter component

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="Captura de Tela 2024-08-06 às 16 13 11" src="https://github.com/user-attachments/assets/120977f4-0e5d-4421-bbe0-9c33f35e8f44">

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-3625]: https://aziontech.atlassian.net/browse/UXE-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ