### PR TITLE
[UXE-4473] fix: block users without permission of acessing team permissions edit page

### DIFF
--- a/cypress/e2mock/teams-permissions.cy.js
+++ b/cypress/e2mock/teams-permissions.cy.js
@@ -11,7 +11,7 @@ describe('Tams Permissions Spec', () => {
     cy.openProduct('Teams Permissions')
   })
 
-  it('should block users without acess of entering in the edit page', function () {
+  it('should block users without access of entering in the edit page', function () {
     //act
     cy.get(selectors.list.searchField).type('Default Team')
     cy.intercept('GET', '/api/v4/iam/teams/*', { statusCode: 403, body: fixtures.errorMessage }).as(

--- a/cypress/e2mock/teams-permissions.cy.js
+++ b/cypress/e2mock/teams-permissions.cy.js
@@ -1,0 +1,26 @@
+import selectors from '../support/selectors'
+
+const fixtures = {
+  errorMessage: {
+    detail: 'You do not have permission to perform this action (teams management).'
+  }
+}
+describe('Tams Permissions Spec', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.openProduct('Teams Permissions')
+  })
+
+  it('should block users without acess of entering in the edit page', function () {
+    //act
+    cy.get(selectors.list.searchField).type('Default Team')
+    cy.intercept('GET', '/api/v4/iam/teams/*', { statusCode: 403, body: fixtures.errorMessage }).as(
+      'teamsPermissions'
+    )
+    cy.get(selectors.teams.listRow('name')).click()
+
+    //assert
+    cy.verifyToast('error', `detail: ${fixtures.errorMessage.detail}`)
+    cy.location('pathname').should('eq', '/teams-permission')
+  })
+})

--- a/src/services/team-permission/load-team-permission-service.js
+++ b/src/services/team-permission/load-team-permission-service.js
@@ -1,4 +1,5 @@
-import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
+import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
+import * as Errors from '@/services/axios/errors'
 import { makeTeamPermissionBaseUrl } from './make-team-permission-base-url'
 
 export const loadTeamPermissionService = async ({ id }) => {
@@ -6,20 +7,54 @@ export const loadTeamPermissionService = async ({ id }) => {
     url: `${makeTeamPermissionBaseUrl()}/${id}`,
     method: 'GET'
   })
-
-  httpResponse = adapt(httpResponse)
-
   return parseHttpResponse(httpResponse)
 }
 
 const adapt = (httpResponse) => {
   return {
-    body: {
-      id: httpResponse.body.data.id,
-      name: httpResponse.body.data.name,
-      permissions: httpResponse.body.data.permissions,
-      isActive: httpResponse.body.data.is_active
-    },
-    statusCode: httpResponse.statusCode
+    id: httpResponse.body.data.id,
+    name: httpResponse.body.data.name,
+    permissions: httpResponse.body.data.permissions,
+    isActive: httpResponse.body.data.is_active
+  }
+}
+
+/**
+/**
+ * @param {Object} errorSchema - The error schema.
+ * @param {string} key - The error key of error schema.
+ * @returns {string} The result message based on the status code.
+ */
+const extractErrorKey = (errorSchema, key) => {
+  return `${errorSchema[key]}`
+}
+
+/**
+ * @param {Object} httpResponse - The HTTP response object.
+ * @param {Object} httpResponse.body - The response body.
+ * @returns {string} The result message based on the status code.
+ */
+const extractApiError = (httpResponse) => {
+  const apiKeyError = Object.keys(httpResponse.body)[0]
+  const apiValidationError = extractErrorKey(httpResponse.body, apiKeyError)
+
+  return `${apiKeyError}: ${apiValidationError}`
+}
+
+const parseHttpResponse = (httpResponse) => {
+  switch (httpResponse.statusCode) {
+    case 200:
+      return adapt(httpResponse)
+    case 401:
+      throw new Errors.InvalidApiTokenError().message
+    case 403:
+      const apiError = extractApiError(httpResponse)
+      throw new Error(apiError).message
+    case 404:
+      throw new Errors.NotFoundError().message
+    case 500:
+      throw new Errors.InternalServerError().message
+    default:
+      throw new Errors.UnexpectedError().message
   }
 }

--- a/src/templates/edit-form-block/index.vue
+++ b/src/templates/edit-form-block/index.vue
@@ -38,7 +38,7 @@
     }
   })
 
-  const emit = defineEmits(['on-edit-success', 'on-edit-fail'])
+  const emit = defineEmits(['on-edit-success', 'on-edit-fail', 'on-load-fail'])
 
   const { scrollToError } = useScrollToError()
   const router = useRouter()
@@ -101,6 +101,7 @@
       const initialValues = await props.loadService({ id })
       resetForm({ values: initialValues })
     } catch (error) {
+      emit('on-load-fail')
       showToast('error', error)
     }
   }

--- a/src/views/TeamsPermissions/EditView.vue
+++ b/src/views/TeamsPermissions/EditView.vue
@@ -8,6 +8,7 @@
     </template>
     <template #content>
       <EditFormBlock
+        @on-load-fail="handleLoadFail"
         :editService="props.editTeamPermissionService"
         :loadService="props.loadTeamPermissionService"
         :updatedRedirect="updatedRedirect"
@@ -32,6 +33,7 @@
   import EditFormBlock from '@/templates/edit-form-block'
   import ContentBlock from '@/templates/content-block'
   import PageHeadingBlock from '@/templates/page-heading-block'
+  import { useRouter } from 'vue-router'
   import FormFieldsTeamPermissions from './FormFields/FormFieldsTeamPermissions.vue'
   import ActionBarTemplate from '@/templates/action-bar-block/action-bar-with-teleport'
 
@@ -54,6 +56,13 @@
       required: true
     }
   })
+
+  const router = useRouter()
+
+  const handleLoadFail = () => {
+    router.push({ name: 'teams-permission' })
+  }
+
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field'),
     permissions: yup.array().required('Permission is a required field').min(1),


### PR DESCRIPTION

## Bug fix

### Explain what was fixed and the correct behavior.
Block users withous permission of acessing team permissions edit page
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/ee67cef1-c50d-4f4b-8924-b3880f7267ac

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
