### PR TITLE
[UXE-3366] fix: set cookie value to zone_input when the attack is a cookie

### DIFF
--- a/src/services/waf-rules-services/create-waf-rules-allowed-tuning-service.js
+++ b/src/services/waf-rules-services/create-waf-rules-allowed-tuning-service.js
@@ -17,7 +17,6 @@ export const createWafRulesAllowedTuningService = async ({ attackEvents, wafId, 
     const defaultZone = 'conditional_request_header'
     return MAP_MATCH_ZONES[zone] || defaultZone
   }
-
   const requestsAllowedRules = attackEvents.map(async (attack) => {
     let matchZones = {
       zone: checkAndReturnDefault(attack.matchZone),
@@ -25,11 +24,10 @@ export const createWafRulesAllowedTuningService = async ({ attackEvents, wafId, 
     }
 
     if (attack.matchValue) {
-      const isPathZone = matchZones.zone === 'path'
+      const isCookieZone = attack.matchZone === 'cookie'
 
-      matchZones.zone_input = attack.matchValue
-      matchZones.zone = checkAndReturnDefault(matchZones.zone)
-      matchZones.zone_input = isPathZone ? null : matchZones.zone_input
+      matchZones.zone_input = isCookieZone ? 'cookie' : attack.matchValue
+      matchZones.zone = checkAndReturnDefault(attack.matchZone)
     }
 
     const payload = {

--- a/src/tests/services/waf-rules-services/create-waf-rules-allowed-tuning-service.test.js
+++ b/src/tests/services/waf-rules-services/create-waf-rules-allowed-tuning-service.test.js
@@ -12,7 +12,7 @@ const fixtures = {
       id: 0,
       ruleId: 1010,
       ipCount: 1,
-      matchZone: 'query_string',
+      matchZone: 'cookie',
       pathCount: 1,
       topCountries: ['Brazil'],
       matchesOn: 'value',
@@ -65,7 +65,7 @@ describe('WafRulesServices', () => {
           {
             matches_on: 'value',
             zone: 'conditional_request_header',
-            zone_input: 'arg'
+            zone_input: 'cookie'
           }
         ]
       }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
fix: add the cookie value to zone_input when the attack is a cookie
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/c15186dc-7ddd-47fc-aaa2-f38665fafe72


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
