### PR TITLE
[UXE-4291] fix: convert the argument type from criteria to string on the edge firewall rules engine

### DIFF
--- a/src/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.js
@@ -12,6 +12,29 @@ export const loadEdgeFirewallRulesEngineService = async ({ id, edgeFirewallId })
 }
 
 /**
+ * Parse each criteria based on its type
+ * @param {Array} criterias
+ * @returns {Array}
+ */
+const parseCriterias = (criterias) => {
+  const parsedCriterias = criterias.map((criteriaGroup) => {
+    return criteriaGroup.map((criteria) => {
+      switch (criteria.variable) {
+        case 'network':
+          return {
+            ...criteria,
+            argument: criteria.argument.toString()
+          }
+        default:
+          return criteria
+      }
+    })
+  })
+
+  return parsedCriterias
+}
+
+/**
  * Parse each behavior based on its type
  * @param {Array} behaviors
  * @returns {Array}
@@ -63,7 +86,7 @@ const adapt = (httpResponse) => {
     name: ruleEngine.name,
     description: ruleEngine.description,
     active: ruleEngine.is_active,
-    criteria: ruleEngine.criteria,
+    criteria: parseCriterias(ruleEngine.criteria),
     behaviors: parseBehaviors(ruleEngine.behaviors)
   }
   return {

--- a/src/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.js
@@ -13,25 +13,25 @@ export const loadEdgeFirewallRulesEngineService = async ({ id, edgeFirewallId })
 
 /**
  * Parse each criteria based on its type
- * @param {Array} criterias
+ * @param {Array} criteria
  * @returns {Array}
  */
-const parseCriterias = (criterias) => {
-  const parsedCriterias = criterias.map((criteriaGroup) => {
-    return criteriaGroup.map((criteria) => {
-      switch (criteria.variable) {
+const parseCriteria = (criteria) => {
+  const parsedCriteria = criteria.map((criterionGroup) => {
+    return criterionGroup.map((criterion) => {
+      switch (criterion.variable) {
         case 'network':
           return {
-            ...criteria,
-            argument: criteria.argument.toString()
+            ...criterion,
+            argument: criterion.argument.toString()
           }
         default:
-          return criteria
+          return criterion
       }
     })
   })
 
-  return parsedCriterias
+  return parsedCriteria
 }
 
 /**
@@ -86,7 +86,7 @@ const adapt = (httpResponse) => {
     name: ruleEngine.name,
     description: ruleEngine.description,
     active: ruleEngine.is_active,
-    criteria: parseCriterias(ruleEngine.criteria),
+    criteria: parseCriteria(ruleEngine.criteria),
     behaviors: parseBehaviors(ruleEngine.behaviors)
   }
   return {

--- a/src/tests/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.test.js
@@ -1,0 +1,87 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { loadEdgeFirewallRulesEngineService } from '@/services/edge-firewall-rules-engine-services'
+import { describe, expect, it, vi } from 'vitest'
+
+// Constantes para reutilização
+const EDGE_FIREWALL_ID = '123'
+const RULES_ENGINE_ID = '456'
+
+const fixture = {
+  rulesEngine: {
+    id: 43873,
+    last_editor: 'test@azion.com',
+    last_modified: '2024-07-30T16:38:23.405703Z',
+    name: 'RT',
+    is_active: true,
+    description: '',
+    behaviors: [
+      {
+        name: 'deny'
+      }
+    ],
+    criteria: [
+      [
+        {
+          variable: 'network',
+          operator: 'is_in_list',
+          conditional: 'if',
+          argument: 66
+        }
+      ]
+    ],
+    order: 0
+  },
+  criteriaParsed: [
+    [
+      {
+        variable: 'network',
+        operator: 'is_in_list',
+        conditional: 'if',
+        argument: '66'
+      }
+    ]
+  ]
+}
+
+const makeSut = () => {
+  const sut = loadEdgeFirewallRulesEngineService
+  return { sut }
+}
+
+describe('EdgeFirewallRulesEngineServices', () => {
+  vi.restoreAllMocks()
+
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: fixture.rulesEngine }
+    })
+    const { sut } = makeSut()
+
+    await sut({ edgeFirewallId: EDGE_FIREWALL_ID, id: RULES_ENGINE_ID })
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `v3/edge_firewall/${EDGE_FIREWALL_ID}/rules_engine/${RULES_ENGINE_ID}`,
+      method: 'GET'
+    })
+  })
+
+  it('should correctly parse the returned edge firewall rules engine', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: fixture.rulesEngine }
+    })
+    const { sut } = makeSut()
+
+    const result = await sut({ edgeFirewallID: EDGE_FIREWALL_ID, id: RULES_ENGINE_ID })
+
+    expect(result).toEqual({
+      id: fixture.rulesEngine.id,
+      name: fixture.rulesEngine.name,
+      description: fixture.rulesEngine.description,
+      active: fixture.rulesEngine.is_active,
+      criteria: fixture.criteriaParsed,
+      behaviors: fixture.rulesEngine.behaviors
+    })
+  })
+})

--- a/src/tests/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/load-edge-firewall-rules-engine-service.test.js
@@ -2,7 +2,6 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import { loadEdgeFirewallRulesEngineService } from '@/services/edge-firewall-rules-engine-services'
 import { describe, expect, it, vi } from 'vitest'
 
-// Constantes para reutilização
 const EDGE_FIREWALL_ID = '123'
 const RULES_ENGINE_ID = '456'
 


### PR DESCRIPTION
## Bug fix
[UXE-4291] 

### Explain what was fixed and the correct behavior.
fix: convert the argument type from criteria to string

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/ad6dd26b-7f3a-43ac-b0df-ac7b12a9d8d6


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-4291]: https://aziontech.atlassian.net/browse/UXE-4291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ