### PR TITLE
[NO-ISSUE] fix: open accordion when there is error in fields inside it

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -567,7 +567,6 @@
               />
             </div>
           </AccordionTab>
-          teste
         </Accordion>
         <Divider
           v-if="isNotLastCriteria(criteriaIndex)"

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { useField, useFieldArray } from 'vee-validate'
-  import { computed, ref } from 'vue'
+  import { computed, ref, watch } from 'vue'
 
   import FieldAutoComplete from '@/templates/form-fields-inputs/fieldAutoComplete'
   import FieldDropdown from '@/templates/form-fields-inputs/fieldDropdown'
@@ -298,10 +298,6 @@
     activeAccordions.value[index] = invertedAccordionState
   }
 
-  const handleTabClose = (index) => {
-    console.log(index)
-    activeAccordions.value[index] = 0
-  }
   const addNewConditional = ({ index, operator }) => {
     criteria.value[index].value.push({ ...DEFAULT_OPERATOR, conditional: operator })
   }
@@ -383,6 +379,18 @@
     const MAXIMUM_ALLOWED = 5
     return criteria.value.length >= MAXIMUM_ALLOWED
   })
+
+  watch(
+    () => props.errors,
+    () => {
+      const errorsKeys = Object.keys(props.errors)
+      if (errorsKeys.length > 0) {
+        const match = errorsKeys[0].match(/criteria\[(\d+)\]/)
+        const index = match[1]
+        activeAccordions.value[index] = 0
+      }
+    }
+  )
 </script>
 
 <template>
@@ -454,18 +462,12 @@
     data-testid="rule-form-criteria"
   >
     <template #inputs>
-      {{ props.errors }}
-      <br />
-      {{ activeAccordions }}
       <div
         class="flex flex-col gap-8"
         v-for="(criteriaItem, criteriaIndex) in criteria"
         :key="criteriaIndex"
       >
-        <Accordion
-          v-model:activeIndex="activeAccordions[criteriaIndex]"
-          @update:activeIndex="handleTabClose(criteriaIndex)"
-        >
+        <Accordion v-model:activeIndex="activeAccordions[criteriaIndex]">
           <AccordionTab :header="`Criteria ${criteriaIndex + 1}`">
             <template #header>
               <div class="ml-auto flex justify-center items-center">
@@ -565,6 +567,7 @@
               />
             </div>
           </AccordionTab>
+          teste
         </Accordion>
         <Divider
           v-if="isNotLastCriteria(criteriaIndex)"

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -380,15 +380,19 @@
     return criteria.value.length >= MAXIMUM_ALLOWED
   })
 
+  const openAccordionWithFormErrors = () => {
+    const errorsKeys = Object.keys(props.errors)
+    if (errorsKeys.length > 0) {
+      const match = errorsKeys[0].match(/criteria\[(\d+)\]/)
+      const index = match[1]
+      activeAccordions.value[index] = 0
+    }
+  }
+
   watch(
     () => props.errors,
     () => {
-      const errorsKeys = Object.keys(props.errors)
-      if (errorsKeys.length > 0) {
-        const match = errorsKeys[0].match(/criteria\[(\d+)\]/)
-        const index = match[1]
-        activeAccordions.value[index] = 0
-      }
+      openAccordionWithFormErrors()
     }
   )
 </script>

--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -157,6 +157,8 @@
     }
   })
 
+  const activeAccordions = ref([0])
+
   const isEditDrawer = computed(() => !!props.selectedRulesEngineToEdit)
 
   const behaviorsLabelsTags = computed(() => {
@@ -289,11 +291,23 @@
     criteria.value[criteriaIndex].value.splice(conditionalIndex, 1)
   }
 
+  const removeCriteriaDecorator = (index) => {
+    activeAccordions.value.splice(index, 1)
+    removeCriteria(index)
+    const invertedAccordionState = activeAccordions.value[index] === null ? 0 : null
+    activeAccordions.value[index] = invertedAccordionState
+  }
+
+  const handleTabClose = (index) => {
+    console.log(index)
+    activeAccordions.value[index] = 0
+  }
   const addNewConditional = ({ index, operator }) => {
     criteria.value[index].value.push({ ...DEFAULT_OPERATOR, conditional: operator })
   }
 
   const addNewCriteria = () => {
+    activeAccordions.value.push(0)
     pushCriteria([DEFAULT_OPERATOR])
   }
 
@@ -440,12 +454,18 @@
     data-testid="rule-form-criteria"
   >
     <template #inputs>
+      {{ props.errors }}
+      <br />
+      {{ activeAccordions }}
       <div
         class="flex flex-col gap-8"
         v-for="(criteriaItem, criteriaIndex) in criteria"
         :key="criteriaIndex"
       >
-        <Accordion :activeIndex="0">
+        <Accordion
+          v-model:activeIndex="activeAccordions[criteriaIndex]"
+          @update:activeIndex="handleTabClose(criteriaIndex)"
+        >
           <AccordionTab :header="`Criteria ${criteriaIndex + 1}`">
             <template #header>
               <div class="ml-auto flex justify-center items-center">
@@ -454,7 +474,7 @@
                   icon="pi pi-trash"
                   size="small"
                   outlined
-                  @click="removeCriteria(criteriaIndex)"
+                  @click="removeCriteriaDecorator(criteriaIndex)"
                   :data-testid="`edge-application-rule-form__criteria-remove[${criteriaIndex}]__button`"
                 />
               </div>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Open accordions with field with errors inside to focus on it.
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

https://github.com/user-attachments/assets/6e810c04-d452-4202-8852-5297df785e73


### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
