### PR TITLE
[NO-ISSUE] chore: remove unused dependencie

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "primeflex": "^3.3.1",
     "primeicons": "^7.0.0",
     "primevue": "^3.35.0",
-    "primevue-sass-theme": "git+https://github.com/primefaces/primevue-sass-theme.git#3.39.0",
     "qrcode.vue": "^3.4.1",
     "recaptcha-v3": "^1.10.0",
     "vee-validate": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,10 +6346,6 @@ primeicons@^7.0.0:
   resolved "https://registry.yarnpkg.com/primeicons/-/primeicons-7.0.0.tgz#6b25c3fdcb29bb745a3035bdc1ed5902f4a419cf"
   integrity sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==
 
-"primevue-sass-theme@git+https://github.com/primefaces/primevue-sass-theme.git#3.39.0":
-  version "3.39.0"
-  resolved "git+https://github.com/primefaces/primevue-sass-theme.git#f30329513d57d5cbe93927c437ed4caeb6ca8d20"
-
 primevue@^3.35.0:
   version "3.35.0"
   resolved "https://registry.npmjs.org/primevue/-/primevue-3.35.0.tgz"


### PR DESCRIPTION
The dependencie below it is not more used.
``` json
{
"primevue-sass-theme": "git+https://github.com/primefaces/primevue-sass-theme.git#3.39.0",
}
```

We stop the use with the [azion-theme](https://github.com/aziontech/azion-theme) migration.
