### PR TITLE
[UXE-1907] [UXE-1910] feat: added clicked to create and edit track events in device groups

### DIFF
--- a/src/views/EdgeApplicationsDeviceGroups/ListView.vue
+++ b/src/views/EdgeApplicationsDeviceGroups/ListView.vue
@@ -122,14 +122,18 @@
   ]
 
   const handleTrackEvent = () => {
-    tracker.product.clickToCreate({
-      productName: 'Device Groups'
-    }).track()
+    tracker.product
+      .clickToCreate({
+        productName: 'Device Groups'
+      })
+      .track()
   }
   const handleTrackEditEvent = () => {
-    tracker.product.clickToEdit({
-      productName: 'Device Groups'
-    }).track()
+    tracker.product
+      .clickToEdit({
+        productName: 'Device Groups'
+      })
+      .track()
   }
 </script>
 

--- a/src/views/EdgeApplicationsDeviceGroups/ListView.vue
+++ b/src/views/EdgeApplicationsDeviceGroups/ListView.vue
@@ -5,8 +5,11 @@
   import ListTableBlock from '@/templates/list-table-block'
   import DrawerDeviceGroups from '@/views/EdgeApplicationsDeviceGroups/Drawer'
   import PrimeButton from 'primevue/button'
-  import { computed, ref } from 'vue'
+  import { computed, ref, inject } from 'vue'
   defineOptions({ name: 'list-edge-applications-device-groups-tab' })
+
+  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   const props = defineProps({
     edgeApplicationId: {
@@ -89,6 +92,7 @@
   }
 
   const openCreateDeviceGroupDrawer = () => {
+    handleTrackEvent()
     drawerDeviceGroups.value.openDrawerCreate()
   }
 
@@ -116,6 +120,17 @@
       service: deleteDeviceGroupsWithDecorator
     }
   ]
+
+  const handleTrackEvent = () => {
+    tracker.product.clickToCreate({
+      productName: 'Device Groups'
+    }).track()
+  }
+  const handleTrackEditEvent = () => {
+    tracker.product.clickToEdit({
+      productName: 'Device Groups'
+    }).track()
+  }
 </script>
 
 <template>
@@ -135,6 +150,7 @@
       :editInDrawer="openEditDeviceGroupDrawer"
       :columns="getColumns"
       @on-load-data="handleLoadData"
+      @on-before-go-to-edit="handleTrackEditEvent"
       emptyListMessage="No device groups found."
       :actions="actions"
       isTabs


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* added clicked to create and clicked to edit in edge app -> device groups list

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="525" alt="image" src="https://github.com/user-attachments/assets/234217ed-8759-4bf3-b63b-f4fa48aef00b">
<img width="525" alt="image" src="https://github.com/user-attachments/assets/5f77b5c1-58e0-4402-a4c0-a78e4403fd1e">

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari
