### PR TITLE
[UXE-1908] feat: added create and edit track events in edge applications device groups

### DIFF
--- a/src/helpers/metrics-playground-opener.js
+++ b/src/helpers/metrics-playground-opener.js
@@ -1,6 +1,6 @@
 import { getStaticUrlsByEnvironment } from './get-static-urls-by-environment'
 
 export const metricsPlaygroundOpener = () => {
-  const playgroundUrl = getStaticUrlsByEnvironment('playground')
+  const playgroundUrl = getStaticUrlsByEnvironment('playgroundMetrics')
   window.open(playgroundUrl, '_blank')
 }

--- a/src/services/edge-application-device-groups-services/create-device-group-service.js
+++ b/src/services/edge-application-device-groups-services/create-device-group-service.js
@@ -4,7 +4,7 @@ import * as Errors from '@/services/axios/errors'
 
 export const createDeviceGroupService = async (payload) => {
   const { edgeApplicationId } = payload
-  let httpResponse = await AxiosHttpClientAdapter.request({
+  const httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeEdgeApplicationBaseUrl()}/${edgeApplicationId}/device_groups`,
     method: 'POST',
     body: adapt(payload)

--- a/src/services/edge-application-device-groups-services/edit-device-group-service.js
+++ b/src/services/edge-application-device-groups-services/edit-device-group-service.js
@@ -3,7 +3,7 @@ import { makeEdgeApplicationBaseUrl } from '../edge-application-services/make-ed
 import * as Errors from '@/services/axios/errors'
 
 export const editDeviceGroupService = async (payload) => {
-  let httpResponse = await AxiosHttpClientAdapter.request({
+  const httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeEdgeApplicationBaseUrl()}/${payload.edgeApplicationId}/device_groups/${payload.id}`,
     method: 'PATCH',
     body: adapt(payload)


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* create and edit track event - Edge Application -> Device Groups
* failed to create and edit track event - Edge Application -> Device Groups
* fix playground metrics url
* [UXE-2204](https://aziontech.atlassian.net/browse/UXE-2204)

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/user-attachments/assets/f2ddc6ca-1dfa-4159-9b98-ec1c21f8c1f0)
![image](https://github.com/user-attachments/assets/291ff98f-59c3-424c-8d15-ec16b29f0847)

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-2204]: https://aziontech.atlassian.net/browse/UXE-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ