### PR TITLE
[UXE-2060][UXE-2063] feat: added clicked to create and edit track events in edge applications cache settings

### DIFF
--- a/src/views/EdgeApplicationsCacheSettings/ListView.vue
+++ b/src/views/EdgeApplicationsCacheSettings/ListView.vue
@@ -2,8 +2,11 @@
   import EmptyResultsBlock from '@/templates/empty-results-block'
   import ListTableBlock from '@/templates/list-table-block'
   import PrimeButton from 'primevue/button'
-  import { computed, ref } from 'vue'
+  import { computed, ref, inject } from 'vue'
   import Drawer from './Drawer'
+
+  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   const props = defineProps({
     edgeApplicationId: {
@@ -69,6 +72,7 @@
   ]
 
   const openCreateDrawer = () => {
+    handleTrackClickToCreate()
     drawerRef.value.openCreateDrawer()
   }
   const openEditDrawer = (item) => {
@@ -103,6 +107,22 @@
       }
     ]
   })
+
+  const handleTrackClickToCreate = () => {
+    tracker.product
+      .clickToCreate({
+        productName: 'Cache Settings'
+      })
+      .track()
+  }
+
+  const handleTrackClickToEdit = () => {
+    tracker.product
+      .clickToEdit({
+        productName: 'Cache Settings'
+      })
+      .track()
+  }
 </script>
 
 <template>
@@ -124,6 +144,7 @@
     :columns="getColumns"
     :editInDrawer="openEditDrawer"
     @on-load-data="handleLoadData"
+    @on-before-go-to-edit="handleTrackClickToEdit"
     emptyListMessage="No cache settings found."
     :actions="actions"
     isTabs

--- a/src/views/EdgeApplicationsDeviceGroups/ListView.vue
+++ b/src/views/EdgeApplicationsDeviceGroups/ListView.vue
@@ -92,7 +92,7 @@
   }
 
   const openCreateDeviceGroupDrawer = () => {
-    handleTrackEvent()
+    handleTrackClickToCreate()
     drawerDeviceGroups.value.openDrawerCreate()
   }
 
@@ -121,14 +121,14 @@
     }
   ]
 
-  const handleTrackEvent = () => {
+  const handleTrackClickToCreate = () => {
     tracker.product
       .clickToCreate({
         productName: 'Device Groups'
       })
       .track()
   }
-  const handleTrackEditEvent = () => {
+  const handleTrackClickToEdit = () => {
     tracker.product
       .clickToEdit({
         productName: 'Device Groups'
@@ -154,7 +154,7 @@
       :editInDrawer="openEditDeviceGroupDrawer"
       :columns="getColumns"
       @on-load-data="handleLoadData"
-      @on-before-go-to-edit="handleTrackEditEvent"
+      @on-before-go-to-edit="handleTrackClickToEdit"
       emptyListMessage="No device groups found."
       :actions="actions"
       isTabs


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
* click to create and edit track events in cache settings

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="593" alt="image" src="https://github.com/user-attachments/assets/ba5b0f1a-2d80-40a5-8d34-1639e5218abd">
<img width="593" alt="image" src="https://github.com/user-attachments/assets/c9b3f3fd-f1ce-4966-9e8f-20d4d981e69a">

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
