### PR TITLE
[UXE-4857] fix: update styles for big-number and tab-panel-block components

### DIFF
--- a/src/templates/info-drawer-block/info-labels/big-number.vue
+++ b/src/templates/info-drawer-block/info-labels/big-number.vue
@@ -47,7 +47,7 @@
       />
     </label>
     <div class="flex gap-1 items-center">
-      <span class="text-2xl font-bold">
+      <span class="text-2xl font-medium">
         <slot></slot>
       </span>
       <span class="text-sm text-color">{{ props.sufix }}</span>

--- a/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
+++ b/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
@@ -97,9 +97,7 @@
     />
     <div class="flex flex-col gap-8 my-4">
       <div class="flex gap-1">
-        <p class="text-xs text-color font-medium leading-4">
-          Specification
-        </p>
+        <p class="text-xs text-color font-medium leading-4">Specification</p>
         <p class="text-xs text-color-secondary font-normal leading-4">
           {{ props.tabSelected.description }}
         </p>

--- a/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
+++ b/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
@@ -97,12 +97,15 @@
     />
     <div class="flex flex-col gap-8 my-4">
       <div class="flex gap-1">
-        <p class="text-xs font-medium leading-4">
+        <p class="text-xs text-color font-medium leading-4">
+          Specification
+        </p>
+        <p class="text-xs text-color-secondary font-normal leading-4">
           {{ props.tabSelected.description }}
         </p>
       </div>
     </div>
-    <div class="border-1 border-bottom-none border-round-top-xl p-3.5 surface-border">
+    <div class="border-1 border-bottom-none border-round-top-xl p-3.5 surface-border rounded-md">
       <ContentFilterBlock
         v-model:filterData="filterData"
         :fieldsInFilter="props.filterFields"

--- a/src/views/RealTimeEvents/Drawer/httpRequests.vue
+++ b/src/views/RealTimeEvents/Drawer/httpRequests.vue
@@ -132,22 +132,25 @@
                 label="Request Time"
                 sufix="ms"
                 :tooltipMessage="requestTimeTooltip"
-                >{{ details.requestTime }}
+              >
+                {{ details.requestTime }}
               </BigNumber>
 
               <BigNumber
                 label="Bytes Sent"
                 sufix="bytes"
                 :tooltipMessage="bytesSentTooltip"
-                >{{ details.bytesSent }}
+              >
+                {{ details.bytesSent }}
               </BigNumber>
 
               <BigNumber
                 label="Request Length"
                 sufix="bytes"
                 :tooltipMessage="requestLengthTooltip"
-                >{{ details.requestLength }}</BigNumber
               >
+                {{ details.requestLength }}
+              </BigNumber>
             </div>
 
             <Divider />


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- update styles for big-number and tab-panel-block components

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/user-attachments/assets/85b13469-017c-4486-90be-6e015796b62c)
![image](https://github.com/user-attachments/assets/574d4403-79a5-418d-8502-ee11710179ef)

### Does it have a link on Figma?
https://www.figma.com/design/0TY2pcUTBsndMlrs0ZUvQf/Console-UI?node-id=7976-158788&node-type=FRAME&t=yPO1vEFPTKQfKkBB-0
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
