### PR TITLE
[UXE-4901] fix: reorder rules engine list table block

### DIFF
--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -298,6 +298,7 @@
   import { useDialog } from 'primevue/usedialog'
   import { useToast } from 'primevue/usetoast'
   import { getCsvCellContentFromRowData } from '@/helpers'
+  import { getArrayChangedIndexes } from '@/helpers/get-array-changed-indexes'
 
   defineOptions({ name: 'list-table-block-new' })
 
@@ -347,6 +348,9 @@
     },
     reorderableRows: {
       type: Boolean
+    },
+    onReorderService: {
+      type: Function
     },
     emptyListMessage: {
       type: String,
@@ -432,8 +436,25 @@
     columnSelectorPanel.value.toggle(event)
   }
 
-  const onRowReorder = (event) => {
-    data.value = event.value
+  const onRowReorder = async (event) => {
+    try {
+      const tableData = getArrayChangedIndexes(data.value, event.value)
+      data.value = event.value
+      await props.onReorderService(tableData)
+      reload()
+
+      toast.add({
+        closable: true,
+        severity: 'success',
+        summary: 'Reorder saved'
+      })
+    } catch (error) {
+      toast.add({
+        closable: true,
+        severity: 'error',
+        summary: error
+      })
+    }
   }
 
   const openDialog = (dialogComponent, body) => {


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
the sorting was not working the behavior is that when moving the rules the sorting works

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/d49236ba-3603-450f-882c-720031a024f3

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
