### PR TITLE
[UXE-4867] fix: enable the origin field only when the page path is filled

### DIFF
--- a/src/services/edge-application-error-responses-services/make-edge-application-error-responses-base-url.js
+++ b/src/services/edge-application-error-responses-services/make-edge-application-error-responses-base-url.js
@@ -1,4 +1,4 @@
 export const makeEdgeApplicationErrorResponsesBaseUrl = () => {
   const version = 'v4'
-  return `${version}/edge/applications`
+  return `${version}/edge_application/applications`
 }

--- a/src/tests/services/edge-application-error-responses/edit-error-responses-services.test.js
+++ b/src/tests/services/edge-application-error-responses/edit-error-responses-services.test.js
@@ -39,7 +39,7 @@ describe('EdgeApplicationErrorResponsesServices', () => {
     const errorResponse = fixtures.errorResponsePayload.errorResponses[0]
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `v4/edge/applications/${fixtures.errorResponsePayload.edgeApplicationId}/error_responses/${fixtures.errorResponsePayload.id}`,
+      url: `v4/edge_application/applications/${fixtures.errorResponsePayload.edgeApplicationId}/error_responses/${fixtures.errorResponsePayload.id}`,
       method: 'PATCH',
       body: {
         error_responses: [

--- a/src/tests/services/edge-application-error-responses/list-error-responses-service.test.js
+++ b/src/tests/services/edge-application-error-responses/list-error-responses-service.test.js
@@ -40,7 +40,7 @@ describe('EdgeApplicationErrorResponsesServices', () => {
     await sut({ edgeApplicationId: edgeApplicationId })
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `v4/edge/applications/${edgeApplicationId}/error_responses`,
+      url: `v4/edge_application/applications/${edgeApplicationId}/error_responses`,
       method: 'GET'
     })
   })

--- a/src/views/EdgeApplicationsErrorResponses/EditView.vue
+++ b/src/views/EdgeApplicationsErrorResponses/EditView.vue
@@ -66,15 +66,22 @@
   }
 
   const validationSchema = yup.object({
-    originId: yup.string().required().label('Origin'),
-    errorResponses: yup.array().of(
-      yup.object().shape({
-        code: yup.string().required(),
-        timeout: yup.number().required().label('Response TTL'),
-        uri: yup.string().nullable(true),
-        customStatusCode: yup.string().nullable(true)
-      })
-    )
+    errorResponses: yup
+      .array()
+      .of(
+        yup.object().shape({
+          code: yup.string().required(),
+          timeout: yup.number().required().label('Response TTL'),
+          uri: yup.string().nullable(true),
+          customStatusCode: yup.string().nullable(true)
+        })
+      )
+      .default([]),
+    originId: yup.string().when('errorResponses', {
+      is: (errorResponses) => errorResponses.length && errorResponses.some((data) => data.uri),
+      then: (schema) => schema.required().label('Origin'),
+      otherwise: (schema) => schema.nullable()
+    })
   })
 
   const router = useRouter()

--- a/src/views/EdgeApplicationsErrorResponses/FormFields/FormFieldsErrorResponses.vue
+++ b/src/views/EdgeApplicationsErrorResponses/FormFields/FormFieldsErrorResponses.vue
@@ -116,7 +116,7 @@
     }
   ]
   const showErrorResponsesInputs = computed(() => errorResponses.value.length > 0)
-  const disableOriginKey = computed(() => errorResponses.value.length < 2)
+  const disableOriginKey = computed(() => errorResponses.value.some((data) => data.value.uri))
 
   const { value: originId } = useField('originId')
   const {
@@ -280,7 +280,7 @@
       <div class="flex flex-col w-full sm:max-w-xs gap-2">
         <FieldDropdown
           label="Origin"
-          required
+          :required="disableOriginKey"
           :options="originOptions"
           optionLabel="name"
           data-testid="error-responses-form__origin"
@@ -289,7 +289,7 @@
           name="originId"
           :value="originId"
           scrollHeight="170px"
-          :disabled="disableOriginKey"
+          :disabled="!disableOriginKey"
         />
       </div>
     </template>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
enable the origin field only when the page path is filled

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/af34c383-bb41-4d8f-a0ec-cc1c2211dc8b

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
