### PR TITLE
[UXE-4805] fix: drawer add button redirecting to home when table is not loaded

### DIFF
--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -255,14 +255,19 @@
                 data-testid="data-table-skeleton-search-input"
               />
             </span>
-            <PrimeButton
-              class="max-sm:w-full"
-              @click="navigateToAddPage"
-              icon="pi pi-plus"
-              :label="addButtonLabel"
-              v-if="addButtonLabel"
-              data-testid="data-table-skeleton-add-button"
-            />
+            <slot
+              name="addButton"
+              data-testid="data-table-add-button"
+            >
+              <PrimeButton
+                class="max-sm:w-full"
+                @click="navigateToAddPage"
+                icon="pi pi-plus"
+                :label="addButtonLabel"
+                v-if="addButtonLabel"
+                data-testid="data-table-skeleton-add-button"
+              />
+            </slot>
           </div>
         </slot>
       </template>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
drawer add button redirecting to home when table is not loaded

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/646985bb-b6ad-4c5f-a726-e9921529c680
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
