### PR TITLE
[UXE-5056] fix: resolve limit in gql

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/modules/real-time-metrics/constants/reports.js
+++ b/src/modules/real-time-metrics/constants/reports.js
@@ -970,7 +970,7 @@ const REPORTS = [
         variable: 'requests'
       }
     ],
-    limit: 5000,
+    limit: 10000,
     groupBy: ['classified'],
     orderDirection: 'ASC',
     dashboardId: '371360344901061482',

--- a/src/tests/modules/real-time-metrics/constants/reports.test.js
+++ b/src/tests/modules/real-time-metrics/constants/reports.test.js
@@ -947,7 +947,7 @@ describe('RealTimeMetricsModule', () => {
           id: '329891149133127508',
           isTopX: false,
           label: 'Bot Traffic',
-          limit: 5000,
+          limit: 10000,
           orderDirection: 'ASC',
           rotated: false,
           type: 'line',

--- a/src/tests/modules/real-time-metrics/reports/fixtures/gql-fixtures.js
+++ b/src/tests/modules/real-time-metrics/reports/fixtures/gql-fixtures.js
@@ -1158,7 +1158,7 @@ ts
     gqlQuery: {
       query: `query ($tsRange_begin:DateTime!, $tsRange_end:DateTime!) {
       botManagerMetrics (
-        limit: 5000
+        limit: 10000
         aggregate: {sum: requests 
 }
         groupBy: [ts, classified]


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Adjust bot traffic report query limit from 5000 to 10000. As the API returns an array of items, the chart displays the incorrect amount of points.

`24 hours * 60 min = 1440 ts points * 4 itens per point = 5760 items`

### Does this PR introduce UI changes? Add a video or screenshots here.
![Screenshot 2024-09-19 at 12 15 34](https://github.com/user-attachments/assets/f95a8ce8-e3db-4420-86ec-cb3f03527979)

![Screenshot 2024-09-19 at 12 15 03](https://github.com/user-attachments/assets/95c3bba1-683a-4771-8e7c-0f53dce14a81)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
