### PR TITLE
[UXE-5079] feat: retry counter and button to Compare With Azion

### DIFF
--- a/src/services/compare-with-azion/get-test-from-webpagetest.js
+++ b/src/services/compare-with-azion/get-test-from-webpagetest.js
@@ -3,13 +3,6 @@ import makeWebpagetestApi from '../axios/makeWebpagetestApi'
 // import { makeWebpagetestBaseUrlExternal } from './make-base-webpagetest-url'
 
 export const getResultFromWebpagetest = async (id) => {
-  if (!id) {
-    return {
-      status: 400,
-      error: `Invalid ID param.`
-    }
-  }
-
   let httpResponse = await AxiosHttpClientAdapter.request(
     {
       url: `/jsonResult.php?test=${id}`,

--- a/src/services/compare-with-azion/get-test-from-webpagetest.js
+++ b/src/services/compare-with-azion/get-test-from-webpagetest.js
@@ -1,6 +1,6 @@
 import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import makeWebpagetestApi from '../axios/makeWebpagetestApi'
-// import { makeWebpagetestBaseUrlExternal } from './make-base-webpagetest-url'
+
 
 export const getResultFromWebpagetest = async (id) => {
   let httpResponse = await AxiosHttpClientAdapter.request(

--- a/src/services/compare-with-azion/get-test-from-webpagetest.js
+++ b/src/services/compare-with-azion/get-test-from-webpagetest.js
@@ -1,7 +1,6 @@
 import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import makeWebpagetestApi from '../axios/makeWebpagetestApi'
 
-
 export const getResultFromWebpagetest = async (id) => {
   let httpResponse = await AxiosHttpClientAdapter.request(
     {

--- a/src/services/compare-with-azion/get-test.js
+++ b/src/services/compare-with-azion/get-test.js
@@ -2,14 +2,7 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import makeCompareWithAzionApi from '../axios/makeCompareWithAzionApi'
 import { makeWebpagetestBaseUrl } from './make-base-url'
 
-export const getTestById = async (id, clientId = undefined) => {
-  if (!id) {
-    return {
-      status: 400,
-      error: `Invalid testId param.`
-    }
-  }
-
+export const getTestById = async (id, clientId) => {
   let url = `${makeWebpagetestBaseUrl()}/db/test?id=${id}`
 
   if (clientId) {
@@ -28,13 +21,6 @@ export const getTestById = async (id, clientId = undefined) => {
 }
 
 export const getAllTestsByClientId = async (clientId) => {
-  if (!clientId) {
-    return {
-      status: 400,
-      error: `Invalid clientId param.`
-    }
-  }
-
   let httpResponse = await AxiosHttpClientAdapter.request(
     {
       url: `${makeWebpagetestBaseUrl()}/db/all-clientid-tests?clientId=${clientId}`,

--- a/src/views/CompareWithAzion/CompareView.vue
+++ b/src/views/CompareWithAzion/CompareView.vue
@@ -16,12 +16,7 @@
           <RetryMessage
             :timer="60"
             :data="generalError"
-            @onRetry="
-              () => {
-                resetGeneralMessage()
-                init()
-              }
-            "
+            @onRetry="retryGeneralMessage()"
           />
         </div>
         <div
@@ -36,13 +31,7 @@
               <RetryMessage
                 :timer="30"
                 :data="errorData"
-                @onRetry="
-                  async () => {
-                    resetTestMessage()
-                    const testById = await getTestById()
-                    loadTest(testById.body[0].id)
-                  }
-                "
+                @onRetry="retryTestMessage()"
               />
             </div>
             <div v-else>
@@ -63,13 +52,7 @@
               <RetryMessage
                 :timer="30"
                 :data="errorDataWithAzion"
-                @onRetry="
-                  async () => {
-                    resetTestWithAzionMessage()
-                    const testById = await getTestById()
-                    loadTestWithAzion(testById.body[0].id_azion)
-                  }
-                "
+                @onRetry="retryTestWithAzionMessage()"
               />
             </div>
             <div v-else>
@@ -204,6 +187,10 @@
       severity: general.severity
     })
   }
+  const retryGeneralMessage = () => {
+    resetGeneralMessage()
+    init()
+  }
 
   const hasTestMessage = () => Object.keys(errorData.value).length
   const resetTestMessage = () => (errorData.value = {})
@@ -214,11 +201,21 @@
       severity: test.severity
     })
   }
+  const retryTestMessage = async () => {
+    resetTestMessage()
+    const testById = await getTestById()
+    loadTest(testById.body[0].id)
+  }
 
   const hasTestWithAzionMessage = () => Object.keys(errorDataWithAzion.value).length
   const resetTestWithAzionMessage = () => (errorDataWithAzion.value = {})
   const setTestWithAzionMessage = (message) => {
     return (errorDataWithAzion.value = message)
+  }
+  const retryTestWithAzionMessage = async () => {
+    resetTestWithAzionMessage()
+    const testById = await getTestById()
+    loadTestWithAzion(testById.body[0].id_azion)
   }
 
   const loadTest = async (id) => {

--- a/src/views/CompareWithAzion/CompareView.vue
+++ b/src/views/CompareWithAzion/CompareView.vue
@@ -11,12 +11,12 @@
       <template #content>
         <div
           class="w-fit"
-          v-if="hasGeneralMessage()"
+          v-if="hasGeneralMessage"
         >
           <RetryMessage
             :timer="60"
             :data="generalError"
-            @onRetry="retryGeneralMessage()"
+            @onRetry="retryGeneralMessage"
           />
         </div>
         <div
@@ -25,13 +25,13 @@
         >
           <div>
             <div
-              v-if="hasTestMessage()"
+              v-if="hasTestMessage"
               class="w-fit"
             >
               <RetryMessage
                 :timer="30"
                 :data="errorData"
-                @onRetry="retryTestMessage()"
+                @onRetry="retryTestMessage"
               />
             </div>
             <div v-else>
@@ -46,13 +46,13 @@
 
           <div>
             <div
-              v-if="hasTestWithAzionMessage()"
+              v-if="hasTestWithAzionMessage"
               class="w-fit"
             >
               <RetryMessage
                 :timer="30"
                 :data="errorDataWithAzion"
-                @onRetry="retryTestWithAzionMessage()"
+                @onRetry="retryTestWithAzionMessage"
               />
             </div>
             <div v-else>
@@ -73,7 +73,7 @@
 </template>
 
 <script setup>
-  import { onMounted, onBeforeMount, ref } from 'vue'
+  import { computed, onMounted, onBeforeMount, ref } from 'vue'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import ContentBlock from '@/templates/content-block'
   import RetryMessage from './blocks/retry-message.vue'
@@ -178,7 +178,10 @@
     }
   }
 
-  const hasGeneralMessage = () => Object.keys(generalError.value).length
+  const hasGeneralMessage = computed(() => {
+    return Object.keys(generalError.value).length
+  })
+
   const resetGeneralMessage = () => (generalError.value = {})
   const setGeneralMessage = (general) => {
     return (generalError.value = {
@@ -192,7 +195,7 @@
     init()
   }
 
-  const hasTestMessage = () => Object.keys(errorData.value).length
+  const hasTestMessage = computed(() => Object.keys(errorData.value).length)
   const resetTestMessage = () => (errorData.value = {})
   const setTestMessage = (test) => {
     return (errorData.value = {
@@ -207,7 +210,7 @@
     loadTest(testById.body[0].id)
   }
 
-  const hasTestWithAzionMessage = () => Object.keys(errorDataWithAzion.value).length
+  const hasTestWithAzionMessage = computed(() => Object.keys(errorDataWithAzion.value).length)
   const resetTestWithAzionMessage = () => (errorDataWithAzion.value = {})
   const setTestWithAzionMessage = (message) => {
     return (errorDataWithAzion.value = message)

--- a/src/views/CompareWithAzion/CompareView.vue
+++ b/src/views/CompareWithAzion/CompareView.vue
@@ -1,81 +1,60 @@
 <template>
   <div class="px-4">
-    <ContentBlock data-testid="view-azion-compare">
+    <ContentBlock data-testid="view-compare-with-azion-test">
       <template #heading>
-        <PageHeadingBlock
-          pageTitle=""
-          data-testid="view-azion-compare-heading"
-        />
+        <PageHeadingBlock data-testid="view-compare-with-azion-test-heading" />
       </template>
 
       <template #content>
-        <Message
-          v-if="generalError"
-          severity="error"
-          :closable="false"
-        >
-          {{ generalError }}
-        </Message>
-
         <div
-          v-if="!generalError"
-          class="grid md:grid-cols-2 gap-10"
+          class="w-fit"
+          v-if="hasGeneralErrorMessage()"
         >
+          <RetryMessage
+            :timer="45"
+            :data="generalError"
+            @onRetry="() => {
+              resetGeneralErrorMessage()
+              init()
+            }"
+          />
+        </div>
+        <div v-else class="grid md:grid-cols-2 gap-10">
           <div>
-            <Message
-              v-if="errorData"
-              severity="error"
-              :closable="false"
-            >
-              {{ errorData }}
-            </Message>
-
-            <div v-if="!errorData">
-              <h2 class="text-3xl">Current Performance</h2>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">General</h3>
-                <ResumeBlock :data="resumeData" />
-              </div>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">Page Performance</h3>
-                <GradeBlock :items="gradeData" />
-              </div>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">Security</h3>
-                <SecurityBlock :securityHeaders="secureData" />
-              </div>
+            <div v-if="errorData">
+              <Message
+                severity="error"
+                :closable="false"
+              >
+                {{ errorData }}
+              </Message>
+            </div>
+            <div v-else>
+              <DataBlock
+                title="Current Performance"
+                :resumeData="resumeData"
+                :gradeData="gradeData"
+                :secureData="secureData"
+              />
             </div>
           </div>
 
           <div>
-            <Message
-              v-if="errorDataWithAzion"
-              severity="error"
-              :closable="false"
-            >
-              {{ errorDataWithAzion }}
-            </Message>
-
-            <div v-if="!errorDataWithAzion">
-              <h2 class="text-3xl">Performance <span style="color: #f3652b">with Azion</span></h2>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">General</h3>
-                <ResumeBlock :data="resumeDataWithAzion" />
-              </div>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">Page Performance</h3>
-                <GradeBlock :items="gradeDataWithAzion" />
-              </div>
-
-              <div class="mt-12">
-                <h3 class="text-xl mb-8">Security</h3>
-                <SecurityBlock :securityHeaders="secureDataWithAzion" />
-              </div>
+            <div v-if="errorDataWithAzion">
+              <Message
+                severity="error"
+                :closable="false"
+              >
+                {{ errorDataWithAzion }}
+              </Message>
+            </div>
+            <div v-else>
+              <DataBlock
+                title="Performance <span style='color: #f3652b'>with Azion</span>"
+                :resumeData="resumeDataWithAzion"
+                :gradeData="gradeDataWithAzion"
+                :secureData="secureDataWithAzion"
+              />
             </div>
           </div>
         </div>
@@ -87,25 +66,18 @@
 </template>
 
 <script setup>
-  import { onBeforeMount, ref } from 'vue'
+  import { onMounted, onBeforeMount, ref } from 'vue'
   import Message from 'primevue/message'
-
   import PageHeadingBlock from '@/templates/page-heading-block'
   import ContentBlock from '@/templates/content-block'
-
-  import GradeBlock from './blocks/grade-block.vue'
-  import SecurityBlock from './blocks/security-block.vue'
+  import RetryMessage from './blocks/retry-message.vue'
+  import DataBlock from './blocks/data-block.vue'
   import JourneyBlock from './blocks/journey-block.vue'
-  import ResumeBlock from './blocks/resume-block.vue'
-
   import { extract } from './utils/result-extract'
   import { convertMsToSeconds } from './utils/convert-ms-sec'
   import { formatBytesToKB } from './utils/format-bytes-to-kb'
   import { resultparse } from './utils/result-data-parse'
-
   import { useAccountStore } from '@/stores/account'
-  const accountStore = useAccountStore()
-  const { client_id } = accountStore.account
 
   const props = defineProps({
     testConsolidationService: {
@@ -130,7 +102,9 @@
     }
   })
 
-  const generalError = ref('')
+  const accountStore = useAccountStore()
+  const { client_id } = accountStore.account
+  const generalError = ref({})
   const errorData = ref('')
   const resumeData = ref({})
   const gradeData = ref([])
@@ -143,80 +117,100 @@
   const getResultFromWebpagetest = async (id) => await props.getResultFromWebpagetest(id)
   const getQueryString = (name) => new URLSearchParams(window.location.search).get(name)
 
-  const parseGradeData = (obj) => {
+  const parseGradeData = (metrics) => {
     return [
       {
         label: 'Time to First Byte',
         measure: 's',
-        value: convertMsToSeconds(obj.ttfb)
+        value: convertMsToSeconds(metrics.ttfb)
       },
       {
         label: 'Start Render',
         measure: 's',
-        value: convertMsToSeconds(obj.render)
+        value: convertMsToSeconds(metrics.render)
       },
       {
         label: 'First Contentful Pain',
         measure: 's',
-        value: convertMsToSeconds(obj.chromeUserTiming.firstContentfulPaint)
+        value: convertMsToSeconds(metrics.chromeUserTiming.firstContentfulPaint)
       },
       {
         label: 'Speed Index',
         measure: 's',
-        value: convertMsToSeconds(obj.speedIndex)
+        value: convertMsToSeconds(metrics.speedIndex)
       },
       {
         label: 'Largest Contentful Pain',
         measure: 's',
-        value: convertMsToSeconds(obj.chromeUserTiming.largestContentfulPaint)
+        value: convertMsToSeconds(metrics.chromeUserTiming.largestContentfulPaint)
       },
       {
         label: 'Cumulative Layout Shift',
         measure: 's',
-        value: convertMsToSeconds(obj.chromeUserTiming.cumulativeLayoutShift)
+        value: convertMsToSeconds(metrics.chromeUserTiming.cumulativeLayoutShift)
       },
       {
         label: 'Total Block Time',
         measure: 's',
-        value: convertMsToSeconds(obj.totalBlockingTime)
+        value: convertMsToSeconds(metrics.totalBlockingTime)
       },
       {
         label: 'Page Weight',
         measure: 'KB',
-        value: formatBytesToKB(obj.bytesIn)
+        value: formatBytesToKB(metrics.bytesIn)
       }
     ]
   }
 
-  const parseSecureData = (data) => {
+  const parseSecureData = (testResult) => {
     return {
-      protocol: data.requests[0].securityDetails.protocol,
-      tls_verion: data.requests[0].securityDetails.tls_version,
-      list: data.securityHeaders.securityHeadersList || [],
-      grade: data.securityHeaders.securityHeadersGrade || '',
-      score: data.securityHeaders.securityHeadersScore || ''
+      protocol: testResult.requests[0].securityDetails.protocol,
+      tls_verion: testResult.requests[0].securityDetails.tls_version,
+      list: testResult.securityHeaders.securityHeadersList || [],
+      grade: testResult.securityHeaders.securityHeadersGrade || '',
+      score: testResult.securityHeaders.securityHeadersScore || ''
     }
   }
 
-  onBeforeMount(async () => {
+  const resetGeneralErrorMessage = () => {
+    return generalError.value = {}
+  }
+
+  const setGeneralErrorMessage = (message, retry) => {
+    return generalError.value = {
+      message: message,
+      retry: retry
+    }
+  }
+
+  const hasGeneralErrorMessage = () => {
+    return Object.keys(generalError.value).length
+  } 
+
+  const setTestErrorMessage = (message) => {
+    return errorData.value = message
+  }
+
+  const setTestWithAzionErrorMessage = (message) => {
+    return errorDataWithAzion.value = message
+  }
+
+  const init = async () => {
     const testId = getQueryString('id')
-
-    await props.testConsolidationService({
-      testId: testId,
-      clientId: client_id
-    })
-
     const testById = await props.getTestById(testId, client_id)
-
+    
     if (!testById.body.length) {
-      generalError.value = 'Unavailable comparative tests.'
+      setGeneralErrorMessage(
+        'Unavailable comparative tests. 1. Propagating data; 2. Invalid id;',
+        true
+      )
       return
     }
 
     getResultFromWebpagetest(testById.body[0].id)
       .then((result) => {
         if (result.body.statusCode !== 200) {
-          errorData.value = `Test ${result.body.data.id} is ${result.body.statusText}`
+          setTestErrorMessage(`Test ${result.body.data.id} is ${result.body.statusText}`)
           return
         }
 
@@ -226,13 +220,13 @@
         secureData.value = parseSecureData(medianFirstView)
       })
       .catch(() => {
-        errorData.value = 'Not possible to load the Origin test.'
+        setTestErrorMessage('Not possible to load the Origin test.')
       })
 
     getResultFromWebpagetest(testById.body[0].id_azion)
       .then((resutWithAzion) => {
         if (resutWithAzion.body.statusCode !== 200) {
-          errorDataWithAzion.value = `Test ${resutWithAzion.body.data.id} is ${resutWithAzion.body.statusText}`
+          setTestWithAzionErrorMessage(`Test ${resutWithAzion.body.data.id} is ${resutWithAzion.body.statusText}`)
           return
         }
 
@@ -242,7 +236,31 @@
         secureDataWithAzion.value = parseSecureData(medianRepeatedViewWithAzion)
       })
       .catch(() => {
-        errorDataWithAzion.value = 'Not possible to load the test with Azion.'
+        setTestWithAzionErrorMessage('Not possible to load the test with Azion.')
       })
+  }
+
+  onMounted(() => {
+    if (!client_id) {
+      setGeneralErrorMessage(
+        'The logged-in account does not have a valid client ID.',
+        false
+      )
+      return
+    }
+  })
+
+  onBeforeMount(async () => {
+    if (!client_id) {
+      return
+    }
+
+    const testId = getQueryString('id')
+    await props.testConsolidationService({
+      testId: testId,
+      clientId: client_id
+    })
+
+    init()
   })
 </script>

--- a/src/views/CompareWithAzion/CompareView.vue
+++ b/src/views/CompareWithAzion/CompareView.vue
@@ -300,9 +300,7 @@
   })
 
   onBeforeMount(async () => {
-    if (!client_id) {
-      return
-    }
+    if (!client_id) return
 
     const testId = getQueryString('id')
     await props.testConsolidationService({

--- a/src/views/CompareWithAzion/blocks/data-block.vue
+++ b/src/views/CompareWithAzion/blocks/data-block.vue
@@ -1,5 +1,8 @@
 <template>
-  <h2 class="text-3xl" v-html="props.title" />
+  <h2
+    class="text-3xl"
+    v-html="props.title"
+  />
 
   <div class="mt-12">
     <h3 class="text-xl mb-8">General</h3>
@@ -39,6 +42,6 @@
     secureData: ref({
       type: Object,
       required: true
-    }),
+    })
   })
 </script>

--- a/src/views/CompareWithAzion/blocks/data-block.vue
+++ b/src/views/CompareWithAzion/blocks/data-block.vue
@@ -1,0 +1,44 @@
+<template>
+  <h2 class="text-3xl" v-html="props.title" />
+
+  <div class="mt-12">
+    <h3 class="text-xl mb-8">General</h3>
+    <ResumeBlock :data="resumeData" />
+  </div>
+
+  <div class="mt-12">
+    <h3 class="text-xl mb-8">Page Performance</h3>
+    <GradeBlock :items="gradeData" />
+  </div>
+
+  <div class="mt-12">
+    <h3 class="text-xl mb-8">Security</h3>
+    <SecurityBlock :securityHeaders="secureData" />
+  </div>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+  import ResumeBlock from './resume-block.vue'
+  import GradeBlock from './grade-block.vue'
+  import SecurityBlock from './security-block.vue'
+
+  const props = defineProps({
+    title: {
+      type: String,
+      required: true
+    },
+    resumeData: ref({
+      type: Object,
+      required: true
+    }),
+    gradeData: ref({
+      type: Array,
+      required: true
+    }),
+    secureData: ref({
+      type: Object,
+      required: true
+    }),
+  })
+</script>

--- a/src/views/CompareWithAzion/blocks/grade-block.vue
+++ b/src/views/CompareWithAzion/blocks/grade-block.vue
@@ -14,7 +14,7 @@
       <li
         v-for="item in props.items"
         :key="item.label"
-        class="p-4 surface-border border p-0 m-0"
+        class="p-4 surface-border border m-0"
       >
         <p>
           <small class="font-semibold">{{ item.label }}</small>

--- a/src/views/CompareWithAzion/blocks/retry-message.vue
+++ b/src/views/CompareWithAzion/blocks/retry-message.vue
@@ -42,6 +42,7 @@
   import Button from 'primevue/button'
 
   let interval
+  const RECONSULTATION_TIME_MS = 1000
   const emit = defineEmits(['onRetry'])
   const props = defineProps({
     data: ref({
@@ -50,12 +51,10 @@
     }),
     timer: {
       type: Number,
-      required: false,
       default: 30
     },
     severity: {
       type: String,
-      required: false,
       default: 'error'
     }
   })

--- a/src/views/CompareWithAzion/blocks/retry-message.vue
+++ b/src/views/CompareWithAzion/blocks/retry-message.vue
@@ -37,11 +37,10 @@
 </template>
 
 <script setup>
-  import { ref, onMounted } from 'vue'
+  import {  onMounted, ref } from 'vue'
   import Message from 'primevue/message'
   import Button from 'primevue/button'
-
-  const RECONSULTATION_TIME_MS = 1000
+  
   const emit = defineEmits(['onRetry'])
   const props = defineProps({
     data: ref({
@@ -57,25 +56,24 @@
       default: 'error'
     }
   })
+  
   const counter = ref(props.timer)
   const retryButton = ref({
     disabled: false,
     label: 'retry'
   })
+  const RECONSULTATION_TIME_MS = 1000
 
   const timerZero = () => {
     emit('onRetry')
 
     setCounter(0)
     clearInterval(interval)
-    setRetryButton(true, 'retrying')
-  }
 
-  const setRetryButton = (status, label) => {
-    return (retryButton.value = {
-      disabled: status,
-      label: label
-    })
+    retryButton.value = {
+      disabled: true,
+      label: 'retrying'
+    }
   }
 
   const setCounter = (number) => {

--- a/src/views/CompareWithAzion/blocks/retry-message.vue
+++ b/src/views/CompareWithAzion/blocks/retry-message.vue
@@ -1,6 +1,6 @@
 <template>
   <Message
-    :severity="props.severity"
+    :severity="props.data.severity"
     :closable="false"
   >
     <div class="flex gap-2 items-center">
@@ -17,10 +17,13 @@
         >
           {{ counter }} seconds
         </strong>
-        <span v-else class="ml-2">
+        <span
+          v-else
+          class="ml-2"
+        >
           <i class="pi pi-spin pi-spinner"></i>
         </span>
-  
+
         <Button
           link
           :label="retryButton.label"
@@ -30,7 +33,7 @@
         )
       </div>
     </div>
-  </Message> 
+  </Message>
 </template>
 
 <script setup>
@@ -38,7 +41,7 @@
   import Message from 'primevue/message'
   import Button from 'primevue/button'
 
-  let interval;
+  let interval
   const emit = defineEmits(['onRetry'])
   const props = defineProps({
     data: ref({
@@ -53,7 +56,7 @@
     severity: {
       type: String,
       required: false,
-      default: "error"
+      default: 'error'
     }
   })
   const counter = ref(props.timer)
@@ -71,29 +74,29 @@
   }
 
   const setRetryButton = (status, label) => {
-    return retryButton.value = {
+    return (retryButton.value = {
       disabled: status,
       label: label
-    }
+    })
   }
 
   const setCounter = (number) => {
-    return counter.value = number
+    return (counter.value = number)
   }
 
   const startCounter = () => {
     interval = setInterval(() => {
-      const decreasedCounter = (counter.value - 1)
+      const decreasedCounter = counter.value - 1
       setCounter(decreasedCounter)
 
-      if(!decreasedCounter) {
+      if (!decreasedCounter) {
         timerZero()
       }
     }, 1000)
   }
 
   onMounted(() => {
-    if(!props.data.retry) {
+    if (!props.data.retry) {
       return
     }
 

--- a/src/views/CompareWithAzion/blocks/retry-message.vue
+++ b/src/views/CompareWithAzion/blocks/retry-message.vue
@@ -7,12 +7,12 @@
       {{ props.data.message }}
 
       <div
-        v-if="props.data.retry"
+        v-if="props.data?.retry"
         class="flex items-center"
       >
         (&nbsp;&nbsp;
         <strong
-          v-if="props.data.retry && counter"
+          v-if="props.data?.retry && counter"
           class="flex items-center"
         >
           {{ counter }} seconds
@@ -41,7 +41,6 @@
   import Message from 'primevue/message'
   import Button from 'primevue/button'
 
-  let interval
   const RECONSULTATION_TIME_MS = 1000
   const emit = defineEmits(['onRetry'])
   const props = defineProps({
@@ -83,21 +82,18 @@
     return (counter.value = number)
   }
 
+  let interval
   const startCounter = () => {
     interval = setInterval(() => {
       const decreasedCounter = counter.value - 1
       setCounter(decreasedCounter)
 
-      if (!decreasedCounter) {
-        timerZero()
-      }
-    }, 1000)
+      if (!decreasedCounter) timerZero()
+    }, RECONSULTATION_TIME_MS)
   }
 
   onMounted(() => {
-    if (!props.data.retry) {
-      return
-    }
+    if (!props.data.retry) return
 
     setCounter(props.timer)
     startCounter()

--- a/src/views/CompareWithAzion/blocks/retry-message.vue
+++ b/src/views/CompareWithAzion/blocks/retry-message.vue
@@ -1,0 +1,103 @@
+<template>
+  <Message
+    :severity="props.severity"
+    :closable="false"
+  >
+    <div class="flex gap-2 items-center">
+      {{ props.data.message }}
+
+      <div
+        v-if="props.data.retry"
+        class="flex items-center"
+      >
+        (&nbsp;&nbsp;
+        <strong
+          v-if="props.data.retry && counter"
+          class="flex items-center"
+        >
+          {{ counter }} seconds
+        </strong>
+        <span v-else class="ml-2">
+          <i class="pi pi-spin pi-spinner"></i>
+        </span>
+  
+        <Button
+          link
+          :label="retryButton.label"
+          :disabled="retryButton.disabled"
+          @click="timerZero"
+        />
+        )
+      </div>
+    </div>
+  </Message> 
+</template>
+
+<script setup>
+  import { ref, onMounted } from 'vue'
+  import Message from 'primevue/message'
+  import Button from 'primevue/button'
+
+  let interval;
+  const emit = defineEmits(['onRetry'])
+  const props = defineProps({
+    data: ref({
+      type: Object,
+      required: true
+    }),
+    timer: {
+      type: Number,
+      required: false,
+      default: 30
+    },
+    severity: {
+      type: String,
+      required: false,
+      default: "error"
+    }
+  })
+  const counter = ref(props.timer)
+  const retryButton = ref({
+    disabled: false,
+    label: 'retry'
+  })
+
+  const timerZero = () => {
+    emit('onRetry')
+
+    setCounter(0)
+    clearInterval(interval)
+    setRetryButton(true, 'retrying')
+  }
+
+  const setRetryButton = (status, label) => {
+    return retryButton.value = {
+      disabled: status,
+      label: label
+    }
+  }
+
+  const setCounter = (number) => {
+    return counter.value = number
+  }
+
+  const startCounter = () => {
+    interval = setInterval(() => {
+      const decreasedCounter = (counter.value - 1)
+      setCounter(decreasedCounter)
+
+      if(!decreasedCounter) {
+        timerZero()
+      }
+    }, 1000)
+  }
+
+  onMounted(() => {
+    if(!props.data.retry) {
+      return
+    }
+
+    setCounter(props.timer)
+    startCounter()
+  })
+</script>

--- a/src/views/CompareWithAzion/blocks/security-block.vue
+++ b/src/views/CompareWithAzion/blocks/security-block.vue
@@ -30,7 +30,7 @@
       </li>
 
       <li
-        v-if="tls_version"
+        v-if="props.securityHeaders.tls_version"
         class="px-4 py-2 flex items-center"
       >
         {{ props.securityHeaders.tls_version }}

--- a/src/views/CompareWithAzion/utils/convert-ms-sec.js
+++ b/src/views/CompareWithAzion/utils/convert-ms-sec.js
@@ -1,4 +1,4 @@
 export function convertMsToSeconds(ms) {
-  let seconds = (ms / 1000).toFixed(3)
+  const seconds = (ms / 1000).toFixed(3)
   return seconds.startsWith('0') ? seconds.slice(1) : seconds
 }

--- a/src/views/CompareWithAzion/utils/result-data-parse.js
+++ b/src/views/CompareWithAzion/utils/result-data-parse.js
@@ -43,7 +43,8 @@ export const resultparse = {
     const grade = {}
     const secHeaders = test.data.median.firstView.securityHeaders
 
-    grade.security = secHeaders && secHeaders.securityHeadersGrade ? secHeaders.securityHeadersGrade : ''
+    grade.security =
+      secHeaders && secHeaders.securityHeadersGrade ? secHeaders.securityHeadersGrade : ''
     grade.ttfb = `${test.data.median.firstView.TTFB}ms`
     grade['score_keep-alive'] = gradeTranslate(test.data.median.firstView['score_keep-alive'])
     grade.score_gzip = gradeTranslate(test.data.median.firstView.score_gzip)

--- a/src/views/CompareWithAzion/utils/result-data-parse.js
+++ b/src/views/CompareWithAzion/utils/result-data-parse.js
@@ -25,125 +25,25 @@ export const resultparse = {
     return test.data.median.firstView.base_page_cdn || ''
   },
 
-  url: (test) => {
-    const requests = test.data.median.firstView.requests || []
-    let url = 'unknown url'
-
-    if (!requests.length) return
-
-    for (let index = 0; index < requests.length; index++) {
-      let request = requests[index]
-
-      if (request.contentType !== 'text/html') {
-        continue
-      }
-
-      url = request.documentURL
-      break
-    }
-
-    return url
-  },
-
-  bytesRequestType: (test) => {
-    let data = {
-      'html/requests': 0,
-      'html/bytes': 0,
-      'html/uncompressed': 0,
-
-      'css/requests': 0,
-      'css/bytes': 0,
-      'css/uncompressed': 0,
-
-      'javascript/requests': 0,
-      'javascript/bytes': 0,
-      'javascript/uncompressed': 0,
-
-      'image/requests': 0,
-      'image/bytes': 0,
-      'image/uncompressed': 0,
-
-      'video/requests': 0,
-      'video/bytes': 0,
-      'video/uncompressed': 0,
-
-      'font/requests': 0,
-      'font/bytes': 0,
-      'font/uncompressed': 0,
-
-      'json/requests': 0,
-      'json/bytes': 0,
-      'json/uncompressed': 0,
-
-      'others/requests': 0,
-      'others/bytes': 0,
-      'others/uncompressed': 0
-    }
-
-    const requests = test.data.median.firstView.requests || []
-    requests.forEach((request) => {
-      let type, mimetype
-
-      if (!request.contentType) return
-
-      type =
-        Array.isArray(request.contentType) && !request.contentType.length
-          ? 'other'
-          : request.contentType
-
-      if (!type.length) return
-
-      if (/(html)/i.test(type)) {
-        mimetype = 'html'
-      } else if (/(css)/i.test(type)) {
-        mimetype = 'css'
-      } else if (/(javascript)/i.test(type)) {
-        mimetype = 'javascript'
-      } else if (/(image)/i.test(type)) {
-        mimetype = 'image'
-      } else if (/(video)/i.test(type)) {
-        mimetype = 'video'
-      } else if (/(font)/i.test(type)) {
-        mimetype = 'font'
-      } else if (/(json)/i.test(type)) {
-        mimetype = 'json'
-      } else {
-        mimetype = 'others'
-      }
-
-      data[`${mimetype}/requests`] += 1
-      data[`${mimetype}/bytes`] += request.objectSize || 0
-      data[`${mimetype}/uncompressed`] = request.objectSizeUncompressed || 0
-    })
-
-    return data
-  },
-
   possibleSave: (test) => {
-    let possible = test.data.median.firstView.image_savings || 0
-    let total = test.data.median.firstView.image_total || 0
+    const possible = test.data.median.firstView.image_savings || 0
+    const total = test.data.median.firstView.image_total || 0
 
     return `${formatBytes(possible)} of ${formatBytes(total)}`
   },
 
   percentilImageSave: (test) => {
-    let possible = test.data.median.firstView.image_savings || 0
-    let total = test.data.median.firstView.image_total || 0
+    const possible = test.data.median.firstView.image_savings || 0
+    const total = test.data.median.firstView.image_total || 0
 
     return Number(((100 * possible) / total).toFixed(2))
   },
 
-  cart: (test) => {
-    let hasCart = test.data.median.firstView.detected['Ecommerce'] || undefined
-    return hasCart ? true : false
-  },
-
   grade: (test) => {
-    let grade = {}
-    let secHeaders = test.data.median.firstView.securityHeaders
+    const grade = {}
+    const secHeaders = test.data.median.firstView.securityHeaders
 
-    grade.security =
-      secHeaders && secHeaders.securityHeadersGrade ? secHeaders.securityHeadersGrade : ''
+    grade.security = secHeaders && secHeaders.securityHeadersGrade ? secHeaders.securityHeadersGrade : ''
     grade.ttfb = `${test.data.median.firstView.TTFB}ms`
     grade['score_keep-alive'] = gradeTranslate(test.data.median.firstView['score_keep-alive'])
     grade.score_gzip = gradeTranslate(test.data.median.firstView.score_gzip)


### PR DESCRIPTION
## Improvements

- Invalid Client Id Message
<img width="1680" alt="Screenshot 2024-09-25 at 12 14 55" src="https://github.com/user-attachments/assets/4ca4a585-da28-4280-b019-e32d107ece65">


- Message when it is propagating data in the Edge SQL, the consolidation information. But if the invalid ID too will maintain the same message because we cant know the difference until fix the propagation.

![Screenshot 2024-09-26 at 10 43 32](https://github.com/user-attachments/assets/5b5feebd-afae-44eb-bcb0-0a14f8b9a3de)

- Test Retry during Testing

![Screenshot 2024-09-26 at 10 52 24](https://github.com/user-attachments/assets/9699bc50-11ba-428f-b4f9-8897614de129)


## Refactor

- params renamed
- let to const
- computed
- removed unused functions prepared functions, can not mantain helpers for future
 
> TODO: in the next refactor we will adjust the services