### PR TITLE
[UXE-5133] feat: add purge tracker events

### DIFF
--- a/src/plugins/analytics/trackers/ProductTracker.js
+++ b/src/plugins/analytics/trackers/ProductTracker.js
@@ -56,6 +56,21 @@ export class ProductTracker {
 
   /**
    * @param {Object} payload
+   * @param {String} productName
+   * @returns {AnalyticsTrackerAdapter}
+   */
+  clickedOnEvent(productName, payload) {
+    this.#trackerAdapter.addEvent({
+      eventName: `Clicked on ${productName}`,
+      props: {
+        ...payload
+      }
+    })
+    return this.#trackerAdapter
+  }
+
+  /**
+   * @param {Object} payload
    * @param {AzionProductsNames} payload.productName
    * @param {String} payload.createdFrom
    * @param {String} payload.from

--- a/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
@@ -590,4 +590,38 @@ describe('AnalyticsTrackerAdapter', () => {
       origin: originName
     })
   })
+
+  it('should be able to track a Clicked on event', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const productNameMock = 'Purge'
+    const purgeType = 'cache key'
+
+    sut.product.clickedOnEvent(productNameMock, {
+      purgeType
+    })
+
+    sut.track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith('Clicked on Purge', {
+      purgeType,
+      application: fixtures.application
+    })
+  })
+
+  it('should be able to track a realTimeMetrics', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const eventName = 'Clicked on More Options on Real-Time Metrics'
+    const payload = {
+      chart: 'map chart',
+      application: fixtures.application
+    }
+
+    sut.realTimeMetrics.clickedToRealTimeMetrics({ eventName, payload })
+
+    sut.track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith(eventName, payload)
+  })
+
+
 })

--- a/src/tests/services/data-stream-services/list-data-stream-domains-service.test.js
+++ b/src/tests/services/data-stream-services/list-data-stream-domains-service.test.js
@@ -1,0 +1,55 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { listDataStreamDomainsService } from '@/services/data-stream-services'
+import { describe, expect, it, vi } from 'vitest'
+
+const fixtures = {
+  domainsMock: {
+    domain_id: 1239875,
+    name: 'JS Edge Node',
+    selected: false
+  }
+}
+
+const makeSut = () => {
+  const sut = listDataStreamDomainsService
+
+  return {
+    sut
+  }
+}
+
+describe('DataStreamServices', () => {
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [] }
+    })
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut({})
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `${version}/data_streaming/domains?page_size=2000`,
+      method: 'GET'
+    })
+  })
+
+  it('should parsed correctly all returned domains', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [fixtures.domainsMock] }
+    })
+    const { sut } = makeSut()
+
+    const result = await sut({})
+
+    expect(result).toEqual([
+      {
+        id: fixtures.domainsMock.domain_id,
+        domainID: fixtures.domainsMock.domain_id,
+        name: fixtures.domainsMock.name,
+        selected: fixtures.domainsMock.selected
+      }
+    ])
+  })
+})

--- a/src/tests/services/data-stream-services/list-data-stream-template-service.test.js
+++ b/src/tests/services/data-stream-services/list-data-stream-template-service.test.js
@@ -1,0 +1,56 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { listDataStreamTemplateService } from '@/services/data-stream-services'
+import { describe, expect, it, vi } from 'vitest'
+
+const fixtures = {
+  templateMock: {
+    id: 1239875,
+    template_model: 'JS Edge Node',
+    name: 'test'
+  }
+}
+
+const makeSut = () => {
+  const sut = listDataStreamTemplateService
+
+  return {
+    sut
+  }
+}
+
+describe('DataStreamServices', () => {
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [] }
+    })
+    const { sut } = makeSut()
+    const version = 'v3'
+    await sut({})
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `${version}/data_streaming/templates`,
+      method: 'GET'
+    })
+  })
+
+  it('should parsed correctly all returned template', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [fixtures.templateMock] }
+    })
+    const { sut } = makeSut()
+    const customTemplate = { label: 'Custom Template', value: 'CUSTOM_TEMPLATE', template: '' }
+
+    const result = await sut({})
+
+    expect(result).toEqual([
+      {
+        value: fixtures.templateMock.id,
+        label: fixtures.templateMock.name,
+        template: fixtures.templateMock.template_model
+      },
+      customTemplate
+    ])
+  })
+})

--- a/src/tests/services/edge-application-functions-services/create-edge-application-functions-service.test.js
+++ b/src/tests/services/edge-application-functions-services/create-edge-application-functions-service.test.js
@@ -20,7 +20,7 @@ const makeSut = () => {
   }
 }
 
-describe('CreateFunctionService', () => {
+describe('EdgeFirewallFunctionsServices', () => {
   it('should call API with correct params and parse args as JSON', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValue({
       statusCode: 201,

--- a/src/tests/services/edge-firewall-rules-engine-services/delete-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/delete-edge-firewall-rules-engine-service.test.js
@@ -1,53 +1,46 @@
-import { describe, expect, it, vi } from 'vitest'
 import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
-import { resetPasswordService } from '@/services/auth-services'
 import * as Errors from '@/services/axios/errors'
+import { deleteEdgeFirewallRulesEngineService } from '@/services/edge-firewall-rules-engine-services'
+import { describe, expect, it, vi } from 'vitest'
 
-const fixtures = {
-  userData: {
-    password: 'Azn1234!',
-    uidb64: 'MjYyNw',
-    token: '6fm-c07c9d5f5d6f2e450555'
+const makeSut = () => {
+  const sut = deleteEdgeFirewallRulesEngineService
+
+  return {
+    sut
   }
 }
 
-const makeSut = () => {
-  const sut = resetPasswordService
-
-  return { sut }
-}
-
-describe('ResetPasswordService', () => {
-  it('should call API with correct params', async () => {
+describe('EdgeFirewallRulesEngineServices', () => {
+  it('should call Api with correct params', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 200
+      statusCode: 204
     })
-
+    const ruleEngineId = 12387555
+    const edgeFirewallId = 4245
     const { sut } = makeSut()
-
-    await sut(fixtures.userData)
+    await sut({ ruleEngineId, edgeFirewallId })
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `password/new`,
-      method: 'POST',
-      body: {
-        password: fixtures.userData.password,
-        uidb64: fixtures.userData.uidb64,
-        token: fixtures.userData.token
-      }
+      method: 'DELETE',
+      url: `v3/edge_firewall/${edgeFirewallId}/rules_engine/${ruleEngineId}`
     })
   })
 
-  it('should return a feedback message on successfully created', async () => {
+  it('should return a feedback message on successfully deleted', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-      statusCode: 200
+      statusCode: 204
     })
+    const ruleEngineId = 12387555
+    const edgeFirewallId = 4245
+
     const { sut } = makeSut()
 
-    const feedbackMessage = await sut(fixtures.userData)
+    const feedbackMessage = await sut({ ruleEngineId, edgeFirewallId })
 
-    expect(feedbackMessage).toBe('Password reset successfully')
+    expect(feedbackMessage).toBe('Rules Engine successfully deleted')
   })
+
   it.each([
     {
       statusCode: 401,
@@ -55,7 +48,7 @@ describe('ResetPasswordService', () => {
     },
     {
       statusCode: 403,
-      expectedError: new Errors.InvalidApiTokenError().message
+      expectedError: new Errors.PermissionError().message
     },
     {
       statusCode: 404,
@@ -77,7 +70,10 @@ describe('ResetPasswordService', () => {
       })
       const { sut } = makeSut()
 
-      const response = sut(fixtures.userData)
+      const ruleEngineId = 12387555
+      const edgeFirewallId = 4245
+
+      const response = sut({ ruleEngineId, edgeFirewallId })
 
       expect(response).rejects.toBe(expectedError)
     }

--- a/src/views/EdgeFunctions/ListView.vue
+++ b/src/views/EdgeFunctions/ListView.vue
@@ -23,6 +23,7 @@
         description="Click the button below to create your first function."
         createButtonLabel="Edge Function"
         createPagePath="edge-functions/create"
+        @click-to-create="handleCreateTrackEvent"
         :documentationService="documentationService"
       >
         <template #illustration>

--- a/src/views/NetworkLists/ListView.vue
+++ b/src/views/NetworkLists/ListView.vue
@@ -22,6 +22,7 @@
         title="No network lists have been added"
         description="Click the button below to add a network list based on ASNs, countries, or IP addresses."
         createButtonLabel="Network List"
+        @click-to-create="handleCreateTrackEvent"
         createPagePath="network-lists/create"
         :documentationService="documentationService"
       >

--- a/src/views/PersonalTokens/ListView.vue
+++ b/src/views/PersonalTokens/ListView.vue
@@ -22,6 +22,7 @@
         description="Click the button below to generate your first personal token."
         createButtonLabel="Personal Token"
         createPagePath="personal-tokens/create"
+        @click-to-create="handleTrackEvent"
         :documentationService="documentationService"
       >
         <template #illustration>

--- a/src/views/RealTimePurge/CreateView.vue
+++ b/src/views/RealTimePurge/CreateView.vue
@@ -7,6 +7,8 @@
       <CreateFormBlock
         :createService="props.createRealTimePurgeService"
         :schema="validationSchema"
+        @on-response="handleResponse"
+        @on-response-fail="handleTrackFailedCreation"
         :initialValues="initialValues"
       >
         <template #form>
@@ -39,7 +41,11 @@
   import FormFieldsCreateRealTimePurge from './FormFields/FormFieldsCreateRealTimePurge'
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import * as yup from 'yup'
-  import { ref } from 'vue'
+  import { ref, inject } from 'vue'
+  import { handleTrackerError } from '@/utils/errorHandlingTracker'
+
+  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   const props = defineProps({
     createRealTimePurgeService: {
@@ -51,6 +57,24 @@
       required: true
     }
   })
+
+  const handleResponse = () => {
+    tracker.product.productCreated({
+      productName: 'Purge'
+    })
+  }
+
+  const handleTrackFailedCreation = (error) => {
+    const { fieldName, message } = handleTrackerError(error)
+    tracker.product
+      .failedToCreate({
+        productName: 'Purge',
+        errorType: 'api',
+        fieldName: fieldName.trim(),
+        errorMessage: message
+      })
+      .track()
+  }
 
   const validationSchema = yup.object({
     layer: yup.string().required(),

--- a/src/views/RealTimePurge/ListView.vue
+++ b/src/views/RealTimePurge/ListView.vue
@@ -17,6 +17,7 @@
         addButtonLabel="Purge"
         createPagePath="real-time-purge/create"
         @on-load-data="handleLoadData"
+        @on-before-go-to-add-page="handleTrackEvent"
         :isGraphql="true"
         :enableEditClick="false"
         emptyListMessage="No purge found."
@@ -28,6 +29,7 @@
         title="No purges have been added"
         description="Click the button below to add your first purge."
         createButtonLabel="Purge"
+        @click-to-create="handleTrackEvent"
         createPagePath="real-time-purge/create"
         :documentationService="documentationService"
       >
@@ -47,9 +49,12 @@
   import PageHeadingBlock from '@/templates/page-heading-block'
   import InlineMessage from 'primevue/inlinemessage'
   import DialogPurge from './Dialog'
-  import { computed, ref } from 'vue'
+  import { computed, ref, inject } from 'vue'
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import { useToast } from 'primevue/usetoast'
+
+  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
 
   const props = defineProps({
     listRealTimePurgeService: { required: true, type: Function },
@@ -77,6 +82,16 @@
     showDialogPurge.value = false
   }
 
+  const handleTrackEvent = () => {
+    tracker.product.clickToCreate({
+      productName: 'Purge'
+    })
+  }
+
+  const handleClickedOnEvent = (purgeType) => {
+    tracker.product.clickedOnEvent('Purge', { purgeType })
+  }
+
   const showToast = (severity, detail) => {
     if (!detail) return
     const options = {
@@ -98,6 +113,7 @@
     try {
       const { feedback } = await props.createRealTimePurgeService(dataPurge)
       showToast('success', feedback)
+      handleClickedOnEvent(purgeToRepurge.type)
     } catch (error) {
       showToast('error', error)
     } finally {

--- a/src/views/TeamsPermissions/ListView.vue
+++ b/src/views/TeamsPermissions/ListView.vue
@@ -27,6 +27,7 @@
         title="No teams have been created"
         description="Click the button below to create your first team and add permissions."
         createButtonLabel="Team"
+        @click-to-create="handleTrackEventGoToCreate"
         createPagePath="teams-permission/create"
         :documentationService="documentationService"
       >

--- a/src/views/Users/ListView.vue
+++ b/src/views/Users/ListView.vue
@@ -136,6 +136,7 @@
         description=" Click the button below to create your first user."
         createButtonLabel="User"
         createPagePath="users/create"
+        @click-to-create="handleTrackEvent"
         :documentationService="documentationService"
         data-testid="users__list-view__empty-results-block"
       >

--- a/src/views/Variables/ListView.vue
+++ b/src/views/Variables/ListView.vue
@@ -24,6 +24,7 @@
         description="Click the button below to create your first variable."
         createButtonLabel="Variable"
         createPagePath="variables/create"
+        @click-to-create="handleTrackEvent"
         :documentationService="documentationService"
       >
         <template #illustration>

--- a/src/views/WafRules/ListView.vue
+++ b/src/views/WafRules/ListView.vue
@@ -21,6 +21,7 @@
         title="No WAF rules have been created"
         description="Click the button below to create your first WAF rule."
         createButtonLabel="WAF Rule"
+        @click-to-create="handleTrackClickToEdit"
         createPagePath="waf/create"
         :documentationService="documentationService"
       >


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-5133] feat: add purge tracker events

Foram adicionados eventos de tracker "Clicked to" em várias listagem nas quais não há itens, e o bloco "empty" é exibido nas seguintes telas:

- Edge Functions
- Network List
- Personal Token
- Teams Permissões
- Users
- Variables
- WAF

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-5133]: https://aziontech.atlassian.net/browse/UXE-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ