### PR TITLE
[UXE-4538] fix: select created app when drawer close

### DIFF
--- a/cypress/e2e/domains/create-domain-edge-application.cy.js
+++ b/cypress/e2e/domains/create-domain-edge-application.cy.js
@@ -32,9 +32,6 @@ describe('Domains spec', { tags: ['@dev3', '@xfail'] }, () => {
     cy.get(selectors.domains.edgeApplicationField).click()
     cy.get(selectors.domains.createEdgeApplicationButton).click()
     createEdgeApplicationCase()
-    cy.get(selectors.domains.edgeApplicationField).click()
-    cy.get(selectors.domains.edgeApplicationDropdownFilter).type(edgeAppName)
-    cy.get(selectors.domains.edgeApplicationOption).click()
     cy.get(selectors.domains.cnamesField).type(`${domainName}.edge.app`)
 
     // Act

--- a/src/services/edge-application-services/create-edge-application-service.js
+++ b/src/services/edge-application-services/create-edge-application-service.js
@@ -74,7 +74,8 @@ const parseHttpResponse = (httpResponse) => {
     case 201:
       return {
         feedback: 'Your edge application has been created',
-        urlToEditView: `/edge-applications/edit/${httpResponse.body.results.id}`
+        urlToEditView: `/edge-applications/edit/${httpResponse.body.results.id}`,
+        applicationId: httpResponse.body.results.id
       }
     case 400:
       const apiError = extractApiError(httpResponse)

--- a/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
@@ -48,7 +48,8 @@
     drawerRef.value.openCreateDrawer()
   }
 
-  const handleEdgeApplicationCreated = () => {
+  const handleEdgeApplicationCreated = (id) => {
+    edgeApplication.value = id
     emit('edgeApplicationCreated')
   }
 

--- a/src/views/Domains/FormFields/FormFieldsEditDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsEditDomains.vue
@@ -104,7 +104,8 @@
     drawerRef.value.openCreateDrawer()
   }
 
-  const handleEdgeApplicationCreated = () => {
+  const handleEdgeApplicationCreated = (id) => {
+    edgeApplication.value = id
     emit('edgeApplicationCreated')
   }
 

--- a/src/views/EdgeApplications/Drawer/index.vue
+++ b/src/views/EdgeApplications/Drawer/index.vue
@@ -90,10 +90,10 @@
   const openCreateDrawer = () => {
     showCreateEdgeApplicationsDrawer.value = true
   }
-  const handleCreateWithSuccess = () => {
+  const handleCreateWithSuccess = (response) => {
     handleTrackCreation()
     emit('onSuccess')
-    emit('onEdgeApplicationCreated')
+    emit('onEdgeApplicationCreated', response.applicationId)
     closeCreateDrawer()
   }
   defineExpose({


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Select Created app when the drawer is closed
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
