### PR TITLE
[NO-ISSUE] chore: remove unused origin and rule from azion json for ai

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -68,11 +68,6 @@
       "origin-id": 153761,
       "origin-key": "f1f976fb-0558-4592-a930-dcad70ab2e7c",
       "name": "origin-console-feedback"
-    },
-    {
-      "origin-id": 157340,
-      "origin-key": "6c3fcf0c-f4b7-46d4-99fa-d61fa3860804",
-      "name": "origin-console-ai"
     }
   ],
   "rules-engine": {
@@ -156,11 +151,6 @@
       {
         "id": 296641,
         "name": "Route Send Feedback",
-        "phase": "request"
-      },
-      {
-        "id": 305832,
-        "name": "Route Send Message to Copilot",
         "phase": "request"
       }
     ]


### PR DESCRIPTION
This pull request includes changes to the `azion/stage/azion.json` file, focusing on cleaning up unused origins and rules. The most important changes involve the removal of specific origins and rules that are no longer necessary.

Cleanup of unused origins and rules:

* [`azion/stage/azion.json`](diffhunk://#diff-7d0327cdd86a77f061f2dea4f5dbe068a42499bfd8e8624d68329caa992611b2L71-L75): Removed the "origin-console-ai" origin entry.
* [`azion/stage/azion.json`](diffhunk://#diff-7d0327cdd86a77f061f2dea4f5dbe068a42499bfd8e8624d68329caa992611b2L160-L164): Removed the "Route Send Message to Copilot" rule entry.