### PR TITLE
[UXE-4942] feat: update Copilot tooltip message in AI Chat components

### DIFF
--- a/src/modules/azion-ai-chat/azion-ai-chat-header-block.vue
+++ b/src/modules/azion-ai-chat/azion-ai-chat-header-block.vue
@@ -5,10 +5,11 @@
     <h3 class="text-color text-lg font-medium">
       Copilot
       <PrimeTag
+        v-tooltip.bottom="
+          'Copilot is in preview mode and can give you some wrong answers. Please, always validate your answers.'
+        "
+        value="Preview"
         class="ml-2"
-        value="Experimental"
-        v-tooltip.bottom="experimentalMessageWarning"
-        severity="info"
       />
     </h3>
 
@@ -20,13 +21,8 @@
 
 <script setup>
   import PrimeTag from 'primevue/tag'
-  import { ref } from 'vue'
 
   defineOptions({
     name: 'azion-ai-chat-header'
   })
-
-  const experimentalMessageWarning = ref(
-    'Copilot is in the experimental stage and may generate inaccurate or misleading information. Always validate its answers.'
-  )
 </script>

--- a/src/modules/azion-ai-chat/azion-ai-chat-mobile.vue
+++ b/src/modules/azion-ai-chat/azion-ai-chat-mobile.vue
@@ -16,12 +16,11 @@
         <h2 class="flex items-center gap-2">
           Copilot
           <PrimeTag
-            class="ml-2"
-            value="Experimental"
             v-tooltip.bottom="
-              'Copilot is in experimental mode and can give you some wrong answers. Please, always validate your answers.'
+              'Copilot is in preview mode and can give you some wrong answers. Please, always validate your answers.'
             "
-            severity="info"
+            value="Preview"
+            class="ml-2"
           />
         </h2>
         <div class="gap-4 flex">


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request includes changes to the `azion-ai-chat` module to update the status message of the Copilot feature from "Experimental" to "Preview" and simplify the related code.

Updates to status message:

* [`src/modules/azion-ai-chat/azion-ai-chat-header-block.vue`](diffhunk://#diff-de62b9a090d9c598a1d43b8edf01f5f4984828d841631e4eb84a8b49bc3e2e20R8-L11): Changed the `PrimeTag` value from "Experimental" to "Preview" and updated the tooltip message to reflect the new status.
* [`src/modules/azion-ai-chat/azion-ai-chat-mobile.vue`](diffhunk://#diff-cde0ed04cbd814c5545964291d71f71e04d307ac85454f44f3e7757fdbde3172L19-R23): Updated the `PrimeTag` value and tooltip message to indicate that Copilot is now in "Preview" mode instead of "Experimental".

Code simplification:

* [`src/modules/azion-ai-chat/azion-ai-chat-header-block.vue`](diffhunk://#diff-de62b9a090d9c598a1d43b8edf01f5f4984828d841631e4eb84a8b49bc3e2e20L23-L31): Removed the `experimentalMessageWarning` reference and associated import, as it is no longer needed.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/user-attachments/assets/2789aa28-6adc-43fe-8190-58e6a854173d)

### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
