### PR TITLE
[NO-ISSUE] feat: add credentials option to DEEP_CHAT_CONFIG_REQUEST

### DIFF
--- a/src/modules/azion-ai-chat/azion-ai-chat-block.vue
+++ b/src/modules/azion-ai-chat/azion-ai-chat-block.vue
@@ -83,7 +83,8 @@
   const DEEP_CHAT_CONFIG_REQUEST = {
     url: `https://${
       environment === 'production' ? '' : 'stage-'
-    }ai.azion.com/copilot/chat/completions`
+    }ai.azion.com/copilot/chat/completions`,
+    credentials: 'include'
   }
   const aiAskAzionSessionId = ref('')
   const promptOrigin = ref(null)


### PR DESCRIPTION
This pull request includes a small but important change to the `src/modules/azion-ai-chat/azion-ai-chat-block.vue` file. The change ensures that credentials are included in the request to the AI chat service.

* [`src/modules/azion-ai-chat/azion-ai-chat-block.vue`](diffhunk://#diff-32bfa2b2e4460fc0b3c1e942acb6259c3c89b7c6a5b4343f4241fa0fbdc6397aL86-R87): Added `credentials: 'include'` to the `DEEP_CHAT_CONFIG_REQUEST` to ensure that credentials are sent with the request.