### PR TITLE
[UXE-4355] fix: invoice details section not load values service and product charges

### DIFF
--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -199,9 +199,9 @@ const mapRegionMetrics = (metric, regionMetricsGrouped, currency, unit) => {
 const mapDescriptions = (product, metricsGrouped, regionMetricsGrouped) => {
   return metricsGrouped.reduce((list, metric) => {
     if (metric.productSlug === product.productSlug) {
-      const unit = METRIC_SLUGS[metric.metricSlug].unit
+      const unit = METRIC_SLUGS[metric.metricSlug]?.unit
       list.push({
-        service: METRIC_SLUGS[metric.metricSlug].title,
+        service: METRIC_SLUGS[metric.metricSlug]?.title,
         slug: metric.metricSlug,
         quantity: formatUnitValue(metric.accounted, unit),
         price: formatCurrencyString(product.currency, metric.value),


### PR DESCRIPTION
## Bug fix
invoice details section not load values service and product charges

### Explain what was fixed and the correct behavior.
should render the list with values service and product charges

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/user-attachments/assets/af9ffef6-0964-4d63-8411-99407606bbc6)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
