### PR TITLE
[UXE-5716] fix: send payload correctly when large file optimization is not enabled

### DIFF
--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -249,6 +249,9 @@
 
   watch(sliceConfigurationEnabled, (value) => {
     isSliceEdgeCachingEnabled.value = value
+    if (!value) {
+      isSliceL2CachingEnabled.value = false
+    }
   })
 </script>
 

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -248,7 +248,7 @@
   })
 
   watch(sliceConfigurationEnabled, (value) => {
-    isSliceEdgeCachingEnabled.value = Boolean(value)
+    isSliceEdgeCachingEnabled.value = value
   })
 </script>
 

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -248,7 +248,7 @@
   })
 
   watch(sliceConfigurationEnabled, (value) => {
-    isSliceEdgeCachingEnabled.value = value
+    isSliceEdgeCachingEnabled.value = Boolean(value)
   })
 </script>
 
@@ -405,9 +405,8 @@
         title="Active"
         data-testid="edge-application-cache-settings-form__slice-configuration-enabled-field"
       />
-
       <FieldGroupCheckbox
-        v-if="showSliceConfigurationRange"
+        :class="{ hidden: !sliceConfigurationEnabled }"
         label="Layer"
         :options="layerFileOptimizationRadioOptions"
         :isCard="false"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
When editing an a cache setting with large file optimization enabled, trying to disable it, the payload was being sent without the slice_edge_caching_enabled causing an error
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
