### PR TITLE
[NO-ISSUE] fix: resolve pagination issue when sorting columns

### DIFF
--- a/cypress/e2mock/edge-application/list-edge-applications.cy.js
+++ b/cypress/e2mock/edge-application/list-edge-applications.cy.js
@@ -50,6 +50,8 @@ describe('Edge Application List Spec', { tags: ['@dev2'] }, () => {
   })
 
   it('should ordering edge applications list', function () {
+    cy.get(selectors.list.pageNumber.option('5')).click()    
+
     cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
       if (req.url.includes('ordering=name')) {
         req.reply({
@@ -57,12 +59,16 @@ describe('Edge Application List Spec', { tags: ['@dev2'] }, () => {
         })
       }
     }).as('filteredEdgeApplicationsListApi')
-
+  
+    
     cy.get(selectors.list.orderingHeader.firstColumn).click()
 
     cy.wait('@filteredEdgeApplicationsListApi').then((interception) => {
-      expect(interception.response.body.results[0].name).to.eq('foo 4')
+      expect(interception.response.body.results[0].name).to.eq('foo 10')
     })
+
+    cy.get(selectors.list.pageNumber.option('1')).should('be.visible')
+    cy.get(selectors.list.pageNumber.option('1')).should('have.class', 'p-highlight')
   })
 
   it('should change page size of edge applications list', function () {

--- a/cypress/fixtures/edge-application/edge-applications-ordering-name.json
+++ b/cypress/fixtures/edge-application/edge-applications-ordering-name.json
@@ -1,23 +1,59 @@
 {
-  "count": 4,
+  "count": 100,
   "results": [
     {
-      "id": 1727358635,
+      "id": 1727808955,
+      "name": "foo 10",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-10T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808954,
+      "name": "foo 9",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-09T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808953,
+      "name": "foo 8",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-08T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808952,
+      "name": "foo 7",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-07T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808951,
+      "name": "foo 6",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-06T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808950,
+      "name": "foo 5",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-05T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808949,
       "name": "foo 4",
       "last_editor": "foobar@azion.com",
-      "last_modified": "2024-09-26T13:59:19.774481Z"
+      "last_modified": "2024-10-04T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808948,
+      "name": "foo 3",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-03T18:45:58.915153Z"
     },
     {
       "id": 1727808947,
-      "name": "foo 3",
-      "last_editor": "foobar@azion.com",
-      "last_modified": "2024-10-01T18:45:05.794393Z"
-    },
-    {
-      "id": 1728329401,
       "name": "foo 2",
       "last_editor": "foobar@azion.com",
-      "last_modified": "2024-10-09T19:55:33.892829Z"
+      "last_modified": "2024-10-02T18:45:58.915153Z"
     },
     {
       "id": 1727808946,

--- a/cypress/fixtures/edge-application/edge-applications.json
+++ b/cypress/fixtures/edge-application/edge-applications.json
@@ -1,5 +1,5 @@
 {
-  "count": 4,
+  "count": 100,
   "results": [
     {
       "id": 1727808946,
@@ -8,22 +8,58 @@
       "last_modified": "2024-10-01T18:45:58.915153Z"
     },
     {
-      "id": 1728329401,
+      "id": 1727808947,
       "name": "foo 2",
       "last_editor": "foobar@azion.com",
-      "last_modified": "2024-10-09T19:55:33.892829Z"
+      "last_modified": "2024-10-02T18:45:58.915153Z"
     },
     {
-      "id": 1727808947,
+      "id": 1727808948,
       "name": "foo 3",
       "last_editor": "foobar@azion.com",
-      "last_modified": "2024-10-01T18:45:05.794393Z"
+      "last_modified": "2024-10-03T18:45:58.915153Z"
     },
     {
-      "id": 1727358635,
+      "id": 1727808949,
       "name": "foo 4",
       "last_editor": "foobar@azion.com",
-      "last_modified": "2024-09-26T13:59:19.774481Z"
+      "last_modified": "2024-10-04T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808950,
+      "name": "foo 5",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-05T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808951,
+      "name": "foo 6",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-06T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808952,
+      "name": "foo 7",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-07T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808953,
+      "name": "foo 8",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-08T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808954,
+      "name": "foo 9",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-09T18:45:58.915153Z"
+    },
+    {
+      "id": 1727808955,
+      "name": "foo 10",
+      "last_editor": "foobar@azion.com",
+      "last_modified": "2024-10-10T18:45:58.915153Z"
     }
   ]
 }

--- a/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
+++ b/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
@@ -671,7 +671,8 @@
     const { sortField, sortOrder } = event
     let ordering = sortOrder === -1 ? `-${sortField}` : sortField
     ordering = ordering === null ? props.defaultOrderingFieldName : ordering
-
+    const firstPage = 1
+    firstItemIndex.value = firstPage
     await reload({ ordering })
 
     savedOrdering.value = ordering


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
The issue where pagination was not reset when changing the sorting order in the with-fetch-ordering-and-pagination.vue component has been fixed. Now, when the sorting criteria are modified, the first page index is reset, ensuring users are directed to the first page of the sorted results. Additionally, tests were improved with more realistic datasets, increasing from 4 to 100 entries with diverse names and dates to better simulate real-world scenarios. Cypress tests were updated to validate pagination and sorting functionality, checking the active page state and ensuring results are displayed correctly.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/33e455e8-d803-4b64-974a-6990d29bf11d

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
