### PR TITLE
[UXE-5138] fix: waf rules not triggering toast error

### DIFF
--- a/src/services/domains-services/v4/list-domain-service.js
+++ b/src/services/domains-services/v4/list-domain-service.js
@@ -27,13 +27,13 @@ const adapt = async (httpResponse) => {
       name: domain.name,
       active: domain.active
         ? {
-          content: 'Active',
-          severity: 'success'
-        }
+            content: 'Active',
+            severity: 'success'
+          }
         : {
-          content: 'Inactive',
-          severity: 'danger'
-        },
+            content: 'Inactive',
+            severity: 'danger'
+          },
       activeSort: domain.active,
       domainName: {
         content: domain.domains[0].domain

--- a/src/services/waf-rules-services/create-waf-rules-service.js
+++ b/src/services/waf-rules-services/create-waf-rules-service.js
@@ -1,6 +1,7 @@
 import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 import { makeWafRulesBaseUrl } from './make-waf-rules-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const createWafRulesService = async (payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -51,38 +52,9 @@ const parseHttpResponse = (httpResponse) => {
         feedback: 'Your waf rule has been created',
         urlToEditView: `/waf/edit/${httpResponse.body.id}`
       }
-    case 400:
-      const apiError = extractApiError(httpResponse)
-      throw new Error(apiError).message
-    case 401:
-      throw new Errors.InvalidApiTokenError().message
-    case 403:
-      throw new Errors.PermissionError().message
-    case 404:
-      throw new Errors.NotFoundError().message
     case 500:
       throw new Errors.InternalServerError().message
     default:
-      throw new Errors.UnexpectedError().message
+      throw new Error(extractApiError(httpResponse)).message
   }
-}
-
-/**
- * @param {Object} errorSchema - The error schema.
- * @param {string} key - The error key of error schema.
- * @returns {string|undefined} The result message based on the status code.
- */
-const extractErrorKey = (errorSchema, key) => {
-  return errorSchema[key]?.[0]
-}
-
-/**
- * @param {Object} httpResponse - The HTTP response object.
- * @param {Object} httpResponse.body - The response body.
- * @returns {string} The result message based on the status code.
- */
-const extractApiError = (httpResponse) => {
-  const errorMessage = extractErrorKey(httpResponse.body, 'detail')
-
-  return errorMessage
 }

--- a/src/tests/services/domains-services/v4/list-domain-service.test.js
+++ b/src/tests/services/domains-services/v4/list-domain-service.test.js
@@ -39,12 +39,10 @@ const makeSut = () => {
 
 describe('DomainsServices', () => {
   it('should call api with correct params', async () => {
-    const requestSpy = vi
-      .spyOn(AxiosHttpClientAdapter, 'request')
-      .mockResolvedValueOnce({
-        statusCode: 200,
-        body: { results: [] }
-      })
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [] }
+    })
 
     const { sut } = makeSut()
     const version = 'v4'
@@ -57,11 +55,10 @@ describe('DomainsServices', () => {
   })
 
   it('should parsed correctly all returned domains', async () => {
-    vi.spyOn(AxiosHttpClientAdapter, 'request')
-      .mockResolvedValueOnce({
-        statusCode: 200,
-        body: { results: [fixtures.domainMock, fixtures.disabledDomainMock] }
-      })
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: { results: [fixtures.domainMock, fixtures.disabledDomainMock] }
+    })
 
     const { sut } = makeSut()
 

--- a/src/tests/services/waf-rules-services/create-waf-rules-service.test.js
+++ b/src/tests/services/waf-rules-services/create-waf-rules-service.test.js
@@ -103,38 +103,16 @@ describe('WafRulesServices', () => {
     expect(feedbackMessage).rejects.toThrow(apiErrorMock)
   })
 
-  it.each([
-    {
-      statusCode: 401,
-      expectedError: new Errors.InvalidApiTokenError().message
-    },
-    {
-      statusCode: 403,
-      expectedError: new Errors.PermissionError().message
-    },
-    {
-      statusCode: 404,
-      expectedError: new Errors.NotFoundError().message
-    },
-    {
-      statusCode: 500,
-      expectedError: new Errors.InternalServerError().message
-    },
-    {
-      statusCode: 'unmappedStatusCode',
-      expectedError: new Errors.UnexpectedError().message
-    }
-  ])(
-    'should throw when request fails with status code $statusCode',
-    async ({ statusCode, expectedError }) => {
-      vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
-        statusCode
-      })
-      const { sut } = makeSut()
+  it('should throw when request fails with status code 500', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 500
+    })
+    const { sut } = makeSut()
 
-      const response = sut(fixtures.wafRulesMock)
+    const expectedError = new Errors.InternalServerError().message
 
-      expect(response).rejects.toBe(expectedError)
-    }
-  )
+    const response = sut(fixtures.wafRulesMock)
+
+    expect(response).rejects.toBe(expectedError)
+  })
 })


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-5138] fix: waf rules not triggering toast error
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/98b2636d-3824-4018-af05-72aed4f4b41c


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari


[UXE-5138]: https://aziontech.atlassian.net/browse/UXE-5138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ