### PR TITLE
[UXE-5760] fix: update edge firewall rules engine to use 'active' property instead of 'is_active'

### DIFF
--- a/src/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.js
@@ -90,7 +90,7 @@ const adapt = ({ body, statusCode }) => {
     id: ruleEngine.id,
     name: ruleEngine.name,
     description: ruleEngine.description,
-    active: ruleEngine.is_active,
+    active: ruleEngine.active,
     criteria: parseCriteria(ruleEngine.criteria),
     behaviors: parseBehaviors(ruleEngine.behaviors)
   }

--- a/src/tests/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.test.js
@@ -11,7 +11,7 @@ const fixture = {
     last_editor: 'test@azion.com',
     last_modified: '2024-07-30T16:38:23.405703Z',
     name: 'RT',
-    is_active: true,
+    active: true,
     description: '',
     behaviors: [
       {
@@ -78,7 +78,7 @@ describe('EdgeFirewallRulesEngineServices', () => {
       id: fixture.rulesEngine.id,
       name: fixture.rulesEngine.name,
       description: fixture.rulesEngine.description,
-      active: fixture.rulesEngine.is_active,
+      active: fixture.rulesEngine.active,
       criteria: fixture.criteriaParsed,
       behaviors: fixture.rulesEngine.behaviors
     })


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes 


### Does this PR introduce UI changes? Add a video or screenshots here.
https://github.com/user-attachments/assets/649d4903-1d0d-43c7-972e-8082c1dd1a91

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
