### PR TITLE
[UXE-5850] feat: Data Stream - disable inputs/buttons for users without edit permissions

### DIFF
--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -36,6 +36,11 @@ export const useAccountStore = defineStore({
         (permission) => permission.name === permissionToEditDataStream
       )
     },
+    hasPermissionToViewDataStream(state) {
+      return !!state.account.permissions.find(
+        (permission) => permission.name === 'View Data Stream'
+      )
+    },
     hasSamplingFlag(state) {
       return state.account?.client_flags?.includes(state.flags.DATA_STREAM_SAMPLING)
     },

--- a/src/views/DataStream/EditView.vue
+++ b/src/views/DataStream/EditView.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref } from 'vue'
+  import { ref, computed } from 'vue'
   import * as yup from 'yup'
   // Import the components
   import FormFieldsDataStream from './FormFields/FormFieldsDataStream'
@@ -8,6 +8,7 @@
   import ContentBlock from '@/templates/content-block'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import ActionBarBlockWithTeleport from '@/templates/action-bar-block/action-bar-with-teleport'
+  import { useAccountStore } from '@/stores/account'
 
   const props = defineProps({
     listDataStreamTemplateService: {
@@ -216,6 +217,9 @@
     })
   })
 
+  const store = useAccountStore()
+  const hasNoPermissionToEditDataStream = computed(() => store.hasPermissionToEditDataStream)
+
   const displaySamplingDialog = ref(false)
   const formSubmit = (onSubmit, values) => {
     if (!values.hasSampling) {
@@ -244,7 +248,10 @@
             :listDataStreamDomainsService="props.listDataStreamDomainsService"
           />
         </template>
-        <template #action-bar="{ onSubmit, onCancel, loading, values }">
+        <template
+          v-if="hasNoPermissionToEditDataStream"
+          #action-bar="{ onSubmit, onCancel, loading, values }"
+        >
           <ActionBarBlockWithTeleport
             @onSubmit="formSubmit(onSubmit, values)"
             @onCancel="onCancel"

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -1,4 +1,13 @@
 <template>
+  <InlineMessage
+    v-if="hasNoPermissionToEditDataStream"
+    class="w-fit"
+    severity="info"
+    data-testid="permission-rule-message-data-stream"
+  >
+    This account has <strong>View Data Stream</strong> permission only. It allows viewing the
+    account’s streams but doesn't permit creating, editing, or deleting streams.
+  </InlineMessage>
   <FormHorizontal
     title="General"
     description="Create a stream to feed your data platforms with logs from your applications."
@@ -13,6 +22,7 @@
           name="name"
           placeholder="My stream"
           data-testid="data-stream-form__general__name-field"
+          :disabled="hasNoPermissionToEditDataStream"
         />
       </div>
     </template>
@@ -37,6 +47,7 @@
             appendTo="self"
             description="Represents the data source the data will be collected from."
             data-testid="data-stream-form__data-settings__data-source-field"
+            :disabled="hasNoPermissionToEditDataStream"
           />
         </div>
         <div class="flex flex-col w-full sm:max-w-xs gap-2">
@@ -51,6 +62,7 @@
             appendTo="self"
             description="Represents a preset of variables for specific sources or an open template to choose variables."
             data-testid="data-stream-form__data-settings__template-field"
+            :disabled="hasNoPermissionToEditDataStream"
           />
         </div>
       </div>
@@ -67,13 +79,13 @@
           :options="dataSetMonacoOptions"
           class="min-h-[300px] surface-border border rounded-sm overflow-hidden"
           data-testid="data-stream-form__data-settings__data-set-field"
+          :readOnly="hasNoPermissionToEditDataStream"
         />
         <small
           class="text-xs text-color-secondary font-normal leading-5"
           data-testid="data-stream-form__data-settings__data-set-description"
         >
-          Exhibits or allows writing the variables that'll be sent to the connector in a JSON
-          format.
+          Exhibits or allows writing the variables that'll be sent to the in a JSON format.
         </small>
       </div>
     </template>
@@ -91,6 +103,7 @@
           :isCard="false"
           :options="domainsRadioOptions"
           data-testid="data-stream-form__domains__options-field"
+          :disabled="hasNoPermissionToEditDataStream"
         />
       </div>
       <div
@@ -105,6 +118,7 @@
         />
         <PickList
           v-model="domains"
+          :disabled="hasNoPermissionToEditDataStream"
           :pt="{
             sourceList: { class: ['h-80'] },
             targetList: { class: ['h-80'] },
@@ -207,6 +221,7 @@
     <template #inputs>
       <div class="flex flex-col w-full sm:max-w-xs gap-2">
         <FieldDropdown
+          :disabled="hasNoPermissionToEditDataStream"
           label="Connector"
           required
           name="endpoint"
@@ -228,6 +243,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             description="Specific URL that'll receive the collected data."
@@ -251,6 +267,7 @@
             :key="index"
           >
             <InputText
+              :disabled="hasNoPermissionToEditDataStream"
               v-model="header.value"
               type="text"
               id="header-value"
@@ -258,6 +275,7 @@
               data-testid="data-stream-form__destination__headers-field__input"
             />
             <ButtonPrimer
+              :disabled="hasNoPermissionToEditDataStream"
               icon="pi pi-trash"
               size="small"
               outlined
@@ -268,6 +286,7 @@
           </div>
 
           <ButtonPrimer
+            :disabled="hasNoPermissionToEditDataStream"
             outlined
             icon="pi pi-plus-circle"
             v-if="hasLessThanFive"
@@ -288,6 +307,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldTextArea
+            :disabled="hasNoPermissionToEditDataStream"
             label="Bootstrap Servers"
             required
             name="bootstrapServers"
@@ -301,6 +321,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Kafka Topic"
             required
             name="kafkaTopic"
@@ -313,6 +334,7 @@
 
         <div class="flex sm:max-w-lg w-full gap-2 items-top">
           <InputSwitch
+            :disabled="hasNoPermissionToEditDataStream"
             v-model="useTls"
             id="useTls"
             class="flex-shrink-0 flex-grow"
@@ -344,6 +366,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             name="host"
@@ -356,6 +379,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Bucket Name"
             required
             name="bucket"
@@ -368,6 +392,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Region"
             required
             name="region"
@@ -392,13 +417,14 @@
             class="flex flex-col w-full"
             :class="{ 'p-invalid': accessKeyError }"
             :feedback="false"
+            :disabled="hasNoPermissionToEditDataStream"
             toggleMask
             placeholder="ORIA5ZEH9MW4NL5OITY4"
             data-testid="data-stream-form__destination__access-key-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -432,12 +458,13 @@
             class="flex flex-col w-full"
             :class="{ 'p-invalid': secretKeyError }"
             :feedback="false"
+            :disabled="hasNoPermissionToEditDataStream"
             toggleMask
             data-testid="data-stream-form__destination__secret-key-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -471,12 +498,13 @@
             class="flex flex-col w-full"
             :class="{ 'p-invalid': objectKeyError }"
             :feedback="false"
+            :disabled="hasNoPermissionToEditDataStream"
             toggleMask
             data-testid="data-stream-form__destination__object-key-prefix-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -509,6 +537,7 @@
               :key="contentTypeItem.value"
             >
               <RadioButton
+                :disabled="hasNoPermissionToEditDataStream"
                 :class="{ 'p-invalid': contentTypeError }"
                 v-model="contentType"
                 inputId="contentType"
@@ -533,6 +562,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Project ID"
             required
             name="projectID"
@@ -545,6 +575,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Dataset ID"
             required
             name="datasetID"
@@ -557,6 +588,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Table ID"
             required
             name="tableID"
@@ -581,6 +613,7 @@
             :options="serviceAccountMonacoOptions"
             class="min-h-[300px] surface-border border rounded-md overflow-hidden"
             data-testid="data-stream-form__destination__service-account-key-field__input"
+            :readOnly="hasNoPermissionToEditDataStream"
           />
           <small
             class="text-xs text-color-secondary font-normal leading-5"
@@ -604,6 +637,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             name="elasticsearchUrl"
@@ -616,6 +650,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldTextArea
+            :disabled="hasNoPermissionToEditDataStream"
             label="API Key"
             required
             name="apiKey"
@@ -635,6 +670,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             name="splunkUrl"
@@ -647,6 +683,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldTextArea
+            :disabled="hasNoPermissionToEditDataStream"
             label="API Key"
             required
             name="splunkApiKey"
@@ -665,6 +702,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Stream Name"
             required
             name="streamName"
@@ -677,6 +715,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Region"
             required
             name="awsRegion"
@@ -703,11 +742,12 @@
             :class="{ 'p-invalid': awsAccessKeyError }"
             :feedback="false"
             toggleMask
+            :disabled="hasNoPermissionToEditDataStream"
             data-testid="data-stream-form__destination__kinesis-access-key-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -743,11 +783,12 @@
             :class="{ 'p-invalid': awsSecretKeyError }"
             :feedback="false"
             toggleMask
+            :disabled="hasNoPermissionToEditDataStream"
             data-testid="data-stream-form__destination__kinesis-secret-key-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -774,6 +815,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             name="datadogUrl"
@@ -786,6 +828,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldTextArea
+            :disabled="hasNoPermissionToEditDataStream"
             label="API Key"
             required
             name="datadogApiKey"
@@ -804,6 +847,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="URL"
             required
             name="QRadarUrl"
@@ -822,6 +866,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Log Type"
             required
             name="logType"
@@ -848,11 +893,12 @@
             :class="{ 'p-invalid': sharedKeyError }"
             :feedback="false"
             toggleMask
+            :disabled="hasNoPermissionToEditDataStream"
             data-testid="data-stream-form__destination__azure-monitor-shared-key-field__input"
           >
             <template
               #showicon
-              v-if="hasNoPermissionToEditDataStream"
+              v-if="hasNoPermissionToViewDataStream"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -873,6 +919,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Time Generated Field"
             name="generatedField"
             :value="generatedField"
@@ -885,6 +932,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Workspace ID"
             required
             name="workspaceID"
@@ -903,6 +951,7 @@
       >
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Storage Account"
             required
             name="storageAccount"
@@ -915,6 +964,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Container Name"
             required
             name="containerName"
@@ -927,6 +977,7 @@
 
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
           <FieldText
+            :disabled="hasNoPermissionToEditDataStream"
             label="Blob SAS Token"
             required
             name="blobToken"
@@ -947,6 +998,7 @@
     <template #inputs>
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
+          :disabled="hasNoPermissionToEditDataStream"
           label="Payload Format"
           required
           name="payloadFormat"
@@ -959,6 +1011,7 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldText
+          :disabled="hasNoPermissionToEditDataStream"
           label="Payload Log Line Separator"
           required
           name="lineSeparator"
@@ -970,6 +1023,7 @@
 
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
         <FieldNumber
+          :disabled="hasNoPermissionToEditDataStream"
           label="Payload Max Size"
           name="maxSize"
           :min="MIN_PAYLOAD_SIZE_IN_BYTES"
@@ -990,6 +1044,7 @@
     <template #inputs>
       <div class="flex flex-col w-full gap-2">
         <FieldSwitchBlock
+          :disabled="hasNoPermissionToEditDataStream"
           nameField="status"
           name="status"
           auto
@@ -1192,6 +1247,7 @@
   })
 
   const hasNoPermissionToEditDataStream = computed(() => !store.hasPermissionToEditDataStream)
+  const hasNoPermissionToViewDataStream = computed(() => !store.hasPermissionToViewDataStream)
 
   const MAX_HEADER_COUNT = 5
   const hasLessThanFive = computed(() => {
@@ -1244,8 +1300,8 @@
 
   const initializeFormValues = async () => {
     const [domains, template] = await Promise.all([
-        loaderDataStreamDomains(),
-        loaderDataStreamTemplates()
+      loaderDataStreamDomains(),
+      loaderDataStreamTemplates()
     ])
 
     if (props.resetForm) {

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -85,7 +85,8 @@
           class="text-xs text-color-secondary font-normal leading-5"
           data-testid="data-stream-form__data-settings__data-set-description"
         >
-          Exhibits or allows writing the variables that'll be sent to the in a JSON format.
+          Exhibits or allows writing the variables that'll be sent to the connector in a JSON
+          format.
         </small>
       </div>
     </template>

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -1152,12 +1152,7 @@
     const templates = await props.listDataStreamTemplateService()
     listTemplates.value = templates
 
-    const hasFirstTemplates = listTemplates?.value[0]?.value
-    if (hasFirstTemplates) {
-      const firstTemplateValue = listTemplates.value[0].value
-      return firstTemplateValue
-    }
-    return ''
+    return listTemplates.value[0].value ?? ''
   }
 
   const loaderDataStreamDomains = async () => {
@@ -1248,8 +1243,10 @@
   )
 
   const initializeFormValues = async () => {
-    const domains = await loaderDataStreamDomains()
-    const template = await loaderDataStreamTemplates()
+    const [domains, template] = await Promise.all([
+        loaderDataStreamDomains(),
+        loaderDataStreamTemplates()
+    ])
 
     if (props.resetForm) {
       const initialValues = {

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -425,9 +425,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
           <small
@@ -465,9 +465,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
           <small
@@ -505,9 +505,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
           <small
@@ -748,9 +748,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
 
@@ -789,9 +789,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
           <small
@@ -899,9 +899,9 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewKeyFields"
+              v-if="hasNoPermissionToEditDataStream"
             >
-              <i class="pi pi-eye-slash"></i>
+              <i class="pi pi-lock"></i>
             </template>
           </PrimePassword>
           <small
@@ -1248,10 +1248,6 @@
   })
 
   const hasNoPermissionToEditDataStream = computed(() => !store.hasPermissionToEditDataStream)
-  const hasNoPermissionToViewDataStream = computed(() => !store.hasPermissionToViewDataStream)
-  const hasNoPermissionToViewKeyFields = computed(
-    () => hasNoPermissionToEditDataStream.value && hasNoPermissionToViewDataStream.value
-  )
 
   const MAX_HEADER_COUNT = 5
   const hasLessThanFive = computed(() => {

--- a/src/views/DataStream/FormFields/FormFieldsDataStream.vue
+++ b/src/views/DataStream/FormFields/FormFieldsDataStream.vue
@@ -425,7 +425,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -465,7 +465,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -505,7 +505,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -748,7 +748,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -789,7 +789,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -899,7 +899,7 @@
           >
             <template
               #showicon
-              v-if="hasNoPermissionToViewDataStream"
+              v-if="hasNoPermissionToViewKeyFields"
             >
               <i class="pi pi-eye-slash"></i>
             </template>
@@ -1249,6 +1249,9 @@
 
   const hasNoPermissionToEditDataStream = computed(() => !store.hasPermissionToEditDataStream)
   const hasNoPermissionToViewDataStream = computed(() => !store.hasPermissionToViewDataStream)
+  const hasNoPermissionToViewKeyFields = computed(
+    () => hasNoPermissionToEditDataStream.value && hasNoPermissionToViewDataStream.value
+  )
 
   const MAX_HEADER_COUNT = 5
   const hasLessThanFive = computed(() => {

--- a/src/views/DataStream/ListView.vue
+++ b/src/views/DataStream/ListView.vue
@@ -14,7 +14,7 @@
         </InlineMessage>
         <div class="w-full">
           <ListTableBlock
-            :disabledList="disabledList"
+            :disabledList="hasNoPermissionToCreateDataStream || disabledList"
             v-if="hasContentToList"
             addButtonLabel="Stream"
             createPagePath="/data-stream/create"
@@ -56,6 +56,8 @@
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import { listWorkloadsService } from '@/services/workloads-services'
+  import { useAccountStore } from '@/stores/account'
+
   defineOptions({ name: 'data-stream-view' })
 
   const props = defineProps({
@@ -72,6 +74,9 @@
       type: Function
     }
   })
+
+  const store = useAccountStore()
+  const hasNoPermissionToCreateDataStream = computed(() => !store.hasPermissionToEditDataStream)
 
   const domainsCount = ref(0)
   const domainsLoading = ref(true)


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Ao ter permissão de VIEW para Data Stream, todos os botões/inputs são desativados e uma mensagem é exibida.
Melhoria na concorrência de loading da página de Data Stream, afim de evitar erros de execução do JavaScript.

### Does this PR introduce breaking changes?
- [X] No
- [ ] Yes 

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [X] Application responsiveness was tested to different screen sizes
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
