### PR TITLE
[UXE-5045] fix: remove origin key from origin creation via drawer

### DIFF
--- a/cypress/e2e/edge-application/add-origin.cy.js
+++ b/cypress/e2e/edge-application/add-origin.cy.js
@@ -62,16 +62,11 @@ describe('Edge Application', { tags: ['@dev4'] }, () => {
 
     cy.get(selectors.edgeApplication.origins.addressInput).type('teste.com')
     cy.get(selectors.form.actionsSubmitButton).click()
+    cy.get('.p-component-overlay > .p-dialog > .p-dialog-header').should('have.text', 'Origin Key has been created')
+    cy.get(selectors.edgeApplication.origins.dialogCopyButton).click()
     cy.verifyToast('success', 'Your origin has been created')
-
-
-    cy.get(selectors.personalTokens.copyTokenDialogHeader).should(
-        'have.text',
-        'Origin key has been created'
-      )
-      cy.get(selectors.edgeApplication.origins.dialogCopyButton).click()
-      cy.verifyToast('Successfully copied!')
-      cy.get(selectors.edgeApplication.origins.dialogCloseButton).click()
+    cy.verifyToast('Successfully copied!')
+    cy.get(selectors.edgeApplication.origins.dialogCloseButton).click()
 
     //Assert
     cy.get(selectors.list.searchInput).type(`${fixtures.originName}{enter}`)

--- a/cypress/e2e/edge-application/add-origin.cy.js
+++ b/cypress/e2e/edge-application/add-origin.cy.js
@@ -63,8 +63,15 @@ describe('Edge Application', { tags: ['@dev4'] }, () => {
     cy.get(selectors.edgeApplication.origins.addressInput).type('teste.com')
     cy.get(selectors.form.actionsSubmitButton).click()
     cy.verifyToast('success', 'Your origin has been created')
-    cy.get(selectors.form.goBackButton).click()
-    cy.get(selectors.form.leavePageButton).click()
+
+
+    cy.get(selectors.personalTokens.copyTokenDialogHeader).should(
+        'have.text',
+        'Origin key has been created'
+      )
+      cy.get(selectors.edgeApplication.origins.dialogCopyButton).click()
+      cy.verifyToast('Successfully copied!')
+      cy.get(selectors.edgeApplication.origins.dialogCloseButton).click()
 
     //Assert
     cy.get(selectors.list.searchInput).type(`${fixtures.originName}{enter}`)

--- a/cypress/e2e/edge-application/edit-origin.cy.js
+++ b/cypress/e2e/edge-application/edit-origin.cy.js
@@ -63,9 +63,11 @@ describe('Edge Application', { tags: ['@dev4'] }, () => {
 
     cy.get(selectors.edgeApplication.origins.addressInput).type('test.com')
     cy.get(selectors.form.actionsSubmitButton).click()
+    cy.get('.p-component-overlay > .p-dialog > .p-dialog-header').should('have.text', 'Origin Key has been created')
+    cy.get(selectors.edgeApplication.origins.dialogCopyButton).click()
     cy.verifyToast('success', 'Your origin has been created')
-    cy.get(selectors.form.goBackButton).click()
-    cy.get(selectors.form.leavePageButton).click()
+    cy.verifyToast('Successfully copied!')
+    cy.get(selectors.edgeApplication.origins.dialogCloseButton).click()
 
     //Assert
     cy.get(selectors.list.searchInput).type(`${fixtures.originName}{enter}`)

--- a/cypress/e2e/edge-application/rules-engine/create-rule-engine-set-origin.cy.js
+++ b/cypress/e2e/edge-application/rules-engine/create-rule-engine-set-origin.cy.js
@@ -75,8 +75,15 @@ describe('Edge Application', { tags: ['@dev3'] }, () => {
     cy.get(selectors.edgeApplication.rulesEngine.originActionBar)
       .find(selectors.form.actionsSubmitButton)
       .click()
+    cy.get('.p-component-overlay > .p-dialog > .p-dialog-header').should(
+      'have.text',
+      'Origin Key has been created'
+    )
+    cy.get(selectors.edgeApplication.origins.dialogCopyButton).click()
     cy.verifyToast('success', 'Your origin has been created')
-    cy.wait('@getOrigin')
+    cy.verifyToast('Successfully copied!')
+    cy.get(selectors.edgeApplication.origins.dialogCloseButton).click()
+
     cy.get(selectors.edgeApplication.rulesEngine.setOriginSelect(0)).click()
     cy.get(selectors.edgeApplication.rulesEngine.setOriginSelect(0))
       .find(selectors.edgeApplication.rulesEngine.originOption(fixtures.originName))

--- a/cypress/support/selectors/product-selectors/edge-application.js
+++ b/cypress/support/selectors/product-selectors/edge-application.js
@@ -63,7 +63,9 @@ export default {
     createButton: '[data-testid="origins__add-button"]',
     addressInput: '[data-testid="origin-form__address__input"]',
     originType: '[data-testid="origin-form__origin-type__dropdown"]',
-    nameInput: '[data-testid="form-horizontal-general-name__input"]'
+    nameInput: '[data-testid="form-horizontal-general-name__input"]',
+    dialogCopyButton: '[copy-key-dialog__dialog-footer__confirm-button"]',
+    dialogCloseButton: '[copy-key-dialog__token-field__copy-key-button"]',
   },
   errorResponses: {
     createButton: '[data-testid="error-responses-form__add-button"]',

--- a/cypress/support/selectors/product-selectors/edge-application.js
+++ b/cypress/support/selectors/product-selectors/edge-application.js
@@ -64,8 +64,8 @@ export default {
     addressInput: '[data-testid="origin-form__address__input"]',
     originType: '[data-testid="origin-form__origin-type__dropdown"]',
     nameInput: '[data-testid="form-horizontal-general-name__input"]',
-    dialogCopyButton: '[copy-key-dialog__dialog-footer__confirm-button"]',
-    dialogCloseButton: '[copy-key-dialog__token-field__copy-key-button"]',
+    dialogCopyButton: '[data-testid="copy-key-dialog__token-field__copy-key-button"]',
+    dialogCloseButton: '[data-testid="copy-key-dialog__dialog-footer__confirm-button"]',
   },
   errorResponses: {
     createButton: '[data-testid="error-responses-form__add-button"]',

--- a/src/templates/dialog-copy-key/index.vue
+++ b/src/templates/dialog-copy-key/index.vue
@@ -5,22 +5,14 @@
     visible
     :closable="false"
     class="max-w-2xl w-full"
-    :header="`${params.name} has been created`"
+    :header="`${params.title} has been created`"
   >
     <div class="flex flex-col sm:flex-row sm:items-end gap-6">
       <div class="flex flex-col w-full gap-2">
-        <label
-          for="key"
-          class="text-color text-base font-medium"
-          data-testid="copy-token-dialog__token-field__label"
-        >
-          {{ params.name }}
-        </label>
-
         <FieldText
           id="key"
-          :label="label"
-          :name="name"
+          :name="params.title"
+          :label="params.title"
           :value="keyValue"
           disabled
           ref="keyInput"
@@ -32,10 +24,10 @@
           icon="pi pi-clone"
           outlined
           type="button"
-          :aria-label="`Copy ${params.name}`"
+          :aria-label="`Copy ${params.title}`"
           label="Copy"
           @click="params.copy(keyValue)"
-          data-testid="copy-token-dialog__token-field__copy-token-button"
+          :data-testid="`copy-key-dialog__token-field__copy-key-button`"
         />
       </div>
     </div>
@@ -45,7 +37,7 @@
         label="Confirm"
         severity="secondary"
         @click="closeDialog"
-        data-testid="copy-token-dialog__dialog-footer__confirm-button"
+        :data-testid="`copy-key-dialog__dialog-footer__confirm-button`"
       />
     </template>
   </PrimeDialog>

--- a/src/templates/dialog-copy-key/index.vue
+++ b/src/templates/dialog-copy-key/index.vue
@@ -1,0 +1,73 @@
+<template>
+  <PrimeDialog
+    :blockScroll="true"
+    modal
+    visible
+    :closable="false"
+    class="max-w-2xl w-full"
+    :header="`${params.name} has been created`"
+  >
+    <div class="flex flex-col sm:flex-row sm:items-end gap-6">
+      <div class="flex flex-col w-full gap-2">
+        <label
+          for="key"
+          class="text-color text-base font-medium"
+          data-testid="copy-token-dialog__token-field__label"
+        >
+          {{ params.name }}
+        </label>
+
+        <FieldText
+          id="key"
+          :label="label"
+          :name="name"
+          :value="keyValue"
+          disabled
+          ref="keyInput"
+          icon="pi pi-lock"
+        />
+      </div>
+      <div>
+        <PrimeButton
+          icon="pi pi-clone"
+          outlined
+          type="button"
+          :aria-label="`Copy ${params.name}`"
+          label="Copy"
+          @click="params.copy(keyValue)"
+          data-testid="copy-token-dialog__token-field__copy-token-button"
+        />
+      </div>
+    </div>
+
+    <template #footer>
+      <PrimeButton
+        label="Confirm"
+        severity="secondary"
+        @click="closeDialog"
+        data-testid="copy-token-dialog__dialog-footer__confirm-button"
+      />
+    </template>
+  </PrimeDialog>
+</template>
+
+<script setup>
+  import { computed, inject } from 'vue'
+  import PrimeDialog from 'primevue/dialog'
+  import FieldText from '@/templates/form-fields-inputs/fieldText'
+  import PrimeButton from 'primevue/button'
+
+  defineOptions({ name: 'CopyKeyDialog' })
+
+  const dialogRef = inject('dialogRef')
+
+  const params = dialogRef.value.data
+
+  const keyValue = computed({
+    get: () => params.key
+  })
+
+  const closeDialog = () => {
+    dialogRef.value.close()
+  }
+</script>

--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -2,8 +2,10 @@
   import FormFieldsDrawerOrigin from '@/views/EdgeApplicationsOrigins/FormFields/FormFieldsEdgeApplicationsOrigins'
   import CreateDrawerBlock from '@templates/create-drawer-block'
   import EditDrawerBlock from '@templates/edit-drawer-block'
+  import CopyKeyDialog from '@templates/dialog-copy-key'
   import { refDebounced } from '@vueuse/core'
   import { useToast } from 'primevue/usetoast'
+  import { useDialog } from 'primevue/usedialog'
   import { createOriginService } from '@/services/edge-application-origins-services'
   import { inject, ref } from 'vue'
   import * as yup from 'yup'
@@ -14,6 +16,7 @@
   defineOptions({ name: 'drawer-origin' })
 
   const emit = defineEmits(['onSuccess'])
+  const dialog = useDialog()
 
   const props = defineProps({
     showBarGoBack: {
@@ -250,7 +253,15 @@
 
   const handleCreateOrigin = (feedback) => {
     handleTrackCreation()
-    createFormDrawer.value.scrollOriginKey()
+
+    dialog.open(CopyKeyDialog, {
+      data: {
+        name: 'Origin Key',
+        key: feedback.originKey,
+        copy: copyToKey
+      }
+    })
+
     originKey.value = feedback.originKey
     emit('onSuccess')
   }
@@ -272,7 +283,6 @@
     :initialValues="initialValues"
     @onSuccess="handleCreateOrigin"
     @onError="handleFailedCreateOrigin"
-    :showBarGoBack="showBarGoBack"
     title="Create Origin"
   >
     <template #formFields="{ disabledFields }">
@@ -281,7 +291,6 @@
         :disabledFields="disabledFields"
         :listOrigins="ORIGIN_TYPES_OPTIONS"
         :copyToClipboard="copyToKey"
-        :generatedOriginKey="originKey"
       />
     </template>
   </CreateDrawerBlock>

--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -299,6 +299,7 @@
   >
     <template #formFields="{ disabledFields }">
       <FormFieldsDrawerOrigin
+        isEditMode
         :disabledFields="disabledFields"
         :listOrigins="ORIGIN_TYPES_OPTIONS"
         :copyToClipboard="copyToKey"

--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -256,7 +256,7 @@
 
     dialog.open(CopyKeyDialog, {
       data: {
-        name: 'Origin Key',
+        title: 'Origin Key',
         key: feedback.originKey,
         copy: copyToKey
       }

--- a/src/views/EdgeApplicationsOrigins/FormFields/FormFieldsEdgeApplicationsOrigins.vue
+++ b/src/views/EdgeApplicationsOrigins/FormFields/FormFieldsEdgeApplicationsOrigins.vue
@@ -26,6 +26,10 @@
     generatedOriginKey: {
       type: String,
       required: false
+    },
+    isEditMode: {
+      type: Boolean,
+      default: false
     }
   })
 
@@ -152,6 +156,7 @@
   </FormHorizontal>
 
   <FormHorizontal
+    v-if="isEditMode"
     :isDrawer="true"
     title="Origin Key"
     description="Save the origin to visualize the key attributed by Azion to this configuration."


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

Foi removido o campo Origin Key do drawer de criação de uma nova Origin. 

### Does this PR introduce UI changes? Add a video or screenshots here.
EDIT MODE:
<img width="894" alt="Captura de Tela 2024-12-18 às 17 32 40" src="https://github.com/user-attachments/assets/55dcfdae-5e4e-49be-814d-07202f4c57fd" />

CREATE MODE:
<img width="895" alt="Captura de Tela 2024-12-18 às 17 32 29" src="https://github.com/user-attachments/assets/0e8e7ad0-2cc1-4b7c-800d-700f76a054de" />

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [X] Application responsiveness was tested to different screen sizes
- [] New tests are added to prevent the same issue from happening again
- [X] UI changes are validated by a team designer
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
