### PR TITLE
[UXE-5953] fix: Edge Function Instance Json Args is overwritten

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
@@ -145,6 +145,10 @@
     enableWorkaroundLabelToDisabledOptions: {
       type: Boolean,
       default: false
+    },
+    disableEmitFirstRender: {
+      type: Boolean,
+      default: false
     }
   })
 
@@ -166,6 +170,7 @@
   const page = ref(INITIAL_PAGE)
   const search = ref('')
   const focusSearch = ref(null)
+  const disableEmitInit = ref(props.disableEmitFirstRender)
 
   onMounted(async () => {
     await fetchData()
@@ -288,6 +293,11 @@
 
       if (!optionExists) {
         data.value = [newOption, ...data.value]
+      }
+
+      if (disableEmitInit.value) {
+        disableEmitInit.value = false
+        return
       }
       emitChange()
     } finally {

--- a/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -109,6 +109,7 @@
           :service="listEdgeFunctionsServiceDecorator"
           :loadService="loadEdgeFunctionService"
           :moreOptions="['args']"
+          disableEmitFirstRender
           optionLabel="label"
           optionValue="value"
           :value="edgeFunctionID"

--- a/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -34,7 +34,7 @@
 
   const changeArgs = async (target) => {
     if (target?.args) {
-      args.value = target?.args
+      args.value = target.args
     }
   }
 
@@ -109,6 +109,7 @@
           :loadService="props.loadEdgeFunctionService"
           :value="edgeFunctionID"
           :moreOptions="['args']"
+          disableEmitFirstRender
           @onSelectOption="changeArgs"
           optionLabel="label"
           optionValue="value"


### PR DESCRIPTION
## Bug fix
feat: add disable first render prop to lazy loader for improved control over initial emit behavior

### Explain what was fixed and the correct behavior.
should not emit args on first load for edge firewall function instance and edge application function instance

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/926f51ed-8fc7-4019-89f7-37af9b0f2986

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
