### PR TITLE
[UXE-5966] fix: incorrect argument when saving criteria rules engine

### DIFF
--- a/src/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.js
+++ b/src/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import { makeEdgeApplicationV4BaseUrl } from '@/services/edge-application-services/v4/make-edge-application-v4-base-url'
 import * as Errors from '@/services/axios/errors'
 import { adaptBehavior } from './helper-behavior'
+import { adaptCriteria } from './helper-criteria'
 import { extractApiError } from '@/helpers/extract-api-error'
 
 export const editRulesEngineService = async ({ id, payload, reorder = false }) => {
@@ -28,7 +29,7 @@ const adapt = (payload, reorder) => {
       name,
       phase: phase.content || phase,
       behaviors: adaptBehavior(behaviors),
-      criteria,
+      criteria: adaptCriteria(criteria),
       active: isActive,
       description
     }

--- a/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
+++ b/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
@@ -1,13 +1,17 @@
+const isExistenceOperator = (operator) => ['exists', 'does_not_exist'].includes(operator)
+
+const processCriteria = (criteria) => {
+  if (!isExistenceOperator(criteria.operator)) {
+    return criteria
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  const { argument, ...processedCriteria } = criteria
+  return processedCriteria
+}
+
 export const adaptCriteria = (criterias) => {
-    return criterias.map(criteriaArray => {
-        return criteriaArray.map(criteria => {
-            if (criteria.operator === 'exists' || criteria.operator === 'does_not_exist') {
-                // eslint-disable-next-line no-unused-vars
-                const { argument, ...rest } = criteria
-                return rest
-            } else {
-                return criteria
-            }
-        })
-    })
+  return criterias.map(criteriaArray => {
+    return criteriaArray.map(processCriteria)
+  })
 }

--- a/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
+++ b/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
@@ -11,7 +11,7 @@ const processCriteria = (criteria) => {
 }
 
 export const adaptCriteria = (criterias) => {
-  return criterias.map(criteriaArray => {
+  return criterias.map((criteriaArray) => {
     return criteriaArray.map(processCriteria)
   })
 }

--- a/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
+++ b/src/services/edge-application-rules-engine-services/v4/helper-criteria.js
@@ -1,0 +1,13 @@
+export const adaptCriteria = (criterias) => {
+    return criterias.map(criteriaArray => {
+        return criteriaArray.map(criteria => {
+            if (criteria.operator === 'exists' || criteria.operator === 'does_not_exist') {
+                // eslint-disable-next-line no-unused-vars
+                const { argument, ...rest } = criteria
+                return rest
+            } else {
+                return criteria
+            }
+        })
+    })
+}

--- a/src/tests/services/edge-application-rules-engine-services/v4/create-rules-engine-service.test.js
+++ b/src/tests/services/edge-application-rules-engine-services/v4/create-rules-engine-service.test.js
@@ -2,7 +2,6 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 import { createRulesEngineService } from '@/services/edge-application-rules-engine-services/v4'
 import { describe, expect, it, vi } from 'vitest'
-import { adaptCriteria } from '@/services/edge-application-rules-engine-services/v4/helper-criteria'
 
 const fixtures = {
   rulesEngineMock: {
@@ -104,40 +103,5 @@ describe('EdgeApplicationRulesEngineService', () => {
     const apiErrorResponse = sut(fixtures.rulesEngineMock)
 
     expect(apiErrorResponse).rejects.toBe('api error message')
-  })
-
-  it('should remove argument from criteria when operator is "exists" or "does_not_exist"', () => {
-    const criterias = [
-      [
-        {
-          variable: 'remote_addr',
-          operator: 'exists',
-          argument: '192.168.1.1'
-        },
-        {
-          variable: 'remote_addr',
-          operator: 'is_equal',
-          argument: '192.168.1.1'
-        }
-      ]
-    ]
-
-    const expectedCriterias = [
-      [
-        {
-          variable: 'remote_addr',
-          operator: 'exists'
-        },
-        {
-          variable: 'remote_addr',
-          operator: 'is_equal',
-          argument: '192.168.1.1'
-        }
-      ]
-    ]
-
-    const result = adaptCriteria(criterias)
-
-    expect(result).toEqual(expectedCriterias)
   })
 })

--- a/src/tests/services/edge-application-rules-engine-services/v4/create-rules-engine-service.test.js
+++ b/src/tests/services/edge-application-rules-engine-services/v4/create-rules-engine-service.test.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 import { createRulesEngineService } from '@/services/edge-application-rules-engine-services/v4'
 import { describe, expect, it, vi } from 'vitest'
+import { adaptCriteria } from '@/services/edge-application-rules-engine-services/v4/helper-criteria'
 
 const fixtures = {
   rulesEngineMock: {
@@ -103,5 +104,40 @@ describe('EdgeApplicationRulesEngineService', () => {
     const apiErrorResponse = sut(fixtures.rulesEngineMock)
 
     expect(apiErrorResponse).rejects.toBe('api error message')
+  })
+
+  it('should remove argument from criteria when operator is "exists" or "does_not_exist"', () => {
+    const criterias = [
+      [
+        {
+          variable: 'remote_addr',
+          operator: 'exists',
+          argument: '192.168.1.1'
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'is_equal',
+          argument: '192.168.1.1'
+        }
+      ]
+    ]
+
+    const expectedCriterias = [
+      [
+        {
+          variable: 'remote_addr',
+          operator: 'exists'
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'is_equal',
+          argument: '192.168.1.1'
+        }
+      ]
+    ]
+
+    const result = adaptCriteria(criterias)
+
+    expect(result).toEqual(expectedCriterias)
   })
 })

--- a/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
+++ b/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
@@ -135,7 +135,12 @@ describe('EdgeApplicationRulesEngineServices', () => {
           variable: 'remote_addr',
           operator: 'is_equal',
           argument: '192.168.1.1'
-        }
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'does_not_exist',
+          argument: '192.168.1.2'
+        },
       ]
     ]
 
@@ -149,7 +154,11 @@ describe('EdgeApplicationRulesEngineServices', () => {
           variable: 'remote_addr',
           operator: 'is_equal',
           argument: '192.168.1.1'
-        }
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'does_not_exist'
+        },
       ]
     ]
 

--- a/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
+++ b/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 import { editRulesEngineService } from '@/services/edge-application-rules-engine-services/v4'
 import { describe, expect, it, vi } from 'vitest'
+import { adaptCriteria } from '@/services/edge-application-rules-engine-services/v4/helper-criteria'
 
 const fixtures = {
   ruleEngineMock: {
@@ -17,15 +18,13 @@ const fixtures = {
       }
     ],
     criteria: [
-      {
-        entries: [
-          {
-            variable: 'remote_addr',
-            operator: 'is_equal',
-            value: '127.0.0.1'
-          }
-        ]
-      }
+      [
+        {
+          variable: 'remote_addr',
+          operator: 'is_equal',
+          value: '127.0.0.1'
+        }
+      ]
     ],
     isActive: true,
     description: 'Test rule description'
@@ -122,5 +121,40 @@ describe('EdgeApplicationRulesEngineServices', () => {
     const promise = sut({ id: '987654', payload: fixtures.ruleEngineMock })
 
     expect(promise).rejects.toBe('Bad Request Error')
+  })
+
+  it('should remove argument from criteria when operator is "exists" or "does_not_exist"', () => {
+    const criterias = [
+      [
+        {
+          variable: 'remote_addr',
+          operator: 'exists',
+          argument: '192.168.1.1'
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'is_equal',
+          argument: '192.168.1.1'
+        }
+      ]
+    ]
+
+    const expectedCriterias = [
+      [
+        {
+          variable: 'remote_addr',
+          operator: 'exists'
+        },
+        {
+          variable: 'remote_addr',
+          operator: 'is_equal',
+          argument: '192.168.1.1'
+        }
+      ]
+    ]
+
+    const result = adaptCriteria(criterias)
+
+    expect(result).toEqual(expectedCriterias)
   })
 })


### PR DESCRIPTION
## Bug fix
incorrect argument when saving criteria rules engine

### Explain what was fixed and the correct behavior.
should save exists and do_not_exists criteria without errors and without arguments

### Does this PR introduce UI changes? Add a video or screenshots here.
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
