### PR TITLE
[UXE-5943] fix: reset page firstElement when Data Table is updated  @lfsigreja

### DIFF
--- a/cypress/e2mock/edge-application/list-edge-applications.cy.js
+++ b/cypress/e2mock/edge-application/list-edge-applications.cy.js
@@ -12,100 +12,129 @@ describe('Edge Application List Spec', { tags: ['@dev2'] }, () => {
     cy.wait('@edgeApplicationsListApi', { timeout: 30000 })
   })
 
-  it('Should filter the list of edge applications.', function () {
-    cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
-      if (req.url.includes('search=foo+1')) {
-        req.reply({
-          fixture: '/edge-application/edge-applications-filtered.json'
-        })
-      }
-    }).as('filteredEdgeApplicationsListApi')
+    it('Should filter the list of edge applications.', function () {
+      cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
+        if (req.url.includes('search=foo+1')) {
+          req.reply({
+            fixture: '/edge-application/edge-applications-filtered.json'
+          })
+        }
+      }).as('filteredEdgeApplicationsListApi')
 
-    cy.get(selectors.list.searchInput).clear()
-    cy.get(selectors.list.searchInput).type('foo 1{enter}')
+      cy.get(selectors.list.searchInput).clear()
+      cy.get(selectors.list.searchInput).type('foo 1{enter}')
 
-    cy.wait('@filteredEdgeApplicationsListApi')
-      .its('response.body')
-      .should('have.property', 'count', 1)
-    cy.get(selectors.list.filteredRow.column('name')).should('have.text', 'foo 1')
-  })
-
-  it('Should display empty state when filters result in no data', function () {
-    cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
-      if (req.url.includes('search=no+data')) {
-        req.reply({
-          count: 0,
-          results: []
-        })
-      }
-    }).as('filteredEdgeApplicationsListApi')
-
-    cy.get(selectors.list.searchInput).clear()
-    cy.get(selectors.list.searchInput).type('no data{enter}')
-
-    cy.wait('@filteredEdgeApplicationsListApi')
-      .its('response.body')
-      .should('have.property', 'count', 0)
-    cy.get(selectors.list.filteredRow.empty).should('have.text', 'No edge applications found.')
-  })
-
-  it('should ordering edge applications list', function () {
-    cy.get(selectors.list.pageNumber.option('5')).click()    
-
-    cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
-      if (req.url.includes('ordering=name')) {
-        req.reply({
-          fixture: '/edge-application/edge-applications-ordering-name.json'
-        })
-      }
-    }).as('filteredEdgeApplicationsListApi')
-  
-    
-    cy.get(selectors.list.orderingHeader.firstColumn).click()
-
-    cy.wait('@filteredEdgeApplicationsListApi').then((interception) => {
-      expect(interception.response.body.results[0].name).to.eq('foo 10')
+      cy.wait('@filteredEdgeApplicationsListApi')
+        .its('response.body')
+        .should('have.property', 'count', 1)
+      cy.get(selectors.list.filteredRow.column('name')).should('have.text', 'foo 1')
     })
 
-    cy.get(selectors.list.pageNumber.option('1')).should('be.visible')
-    cy.get(selectors.list.pageNumber.option('1')).should('have.class', 'p-highlight')
-  })
+    it('Should display empty state when filters result in no data', function () {
+      cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
+        if (req.url.includes('search=no+data')) {
+          req.reply({
+            count: 0,
+            results: []
+          })
+        }
+      }).as('filteredEdgeApplicationsListApi')
 
-  it('should change page size of edge applications list', function () {
-    cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
-      if (req.url.includes('page_size=100')) {
-        req.reply({
-          fixture: '/edge-application/edge-applications-page-size-100.json'
-        })
-      }
+      cy.get(selectors.list.searchInput).clear()
+      cy.get(selectors.list.searchInput).type('no data{enter}')
+
+      cy.wait('@filteredEdgeApplicationsListApi')
+        .its('response.body')
+        .should('have.property', 'count', 0)
+      cy.get(selectors.list.filteredRow.empty).should('have.text', 'No edge applications found.')
+    })
+
+    it('should ordering edge applications list', function () {
+      cy.get(selectors.list.pageNumber.option('5')).click()
+
+      cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
+        if (req.url.includes('ordering=name')) {
+          req.reply({
+            fixture: '/edge-application/edge-applications-ordering-name.json'
+          })
+        }
+      }).as('filteredEdgeApplicationsListApi')
+
+      cy.get(selectors.list.orderingHeader.firstColumn).click()
+
+      cy.wait('@filteredEdgeApplicationsListApi').then((interception) => {
+        expect(interception.response.body.results[0].name).to.eq('foo 10')
+      })
+
+      cy.get(selectors.list.pageNumber.option('1')).should('be.visible')
+      cy.get(selectors.list.pageNumber.option('1')).should('have.class', 'p-highlight')
+    })
+
+    it('should change page size of edge applications list', function () {
+      cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
+        if (req.url.includes('page_size=100')) {
+          req.reply({
+            fixture: '/edge-application/edge-applications-page-size-100.json'
+          })
+        }
+      }).as('filteredEdgeApplicationsListApi')
+
+      cy.get(selectors.list.rowsPerPage.dropdown).click()
+      cy.get(selectors.list.rowsPerPage.option('100')).click()
+
+      cy.wait('@filteredEdgeApplicationsListApi')
+        .its('response.body')
+        .should('have.property', 'count', 100)
+    })
+
+    it('should paginate correctly list', function () {
+      cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
+        if (req.url.includes('page_size=10')) {
+          req.reply({
+            fixture: '/edge-application/edge-applications-paginated.json'
+          })
+        }
+      }).as('paginatedEdgeApplicationsListApi')
+
+      cy.get(selectors.list.rowsPerPage.dropdown).click()
+      cy.get(selectors.list.rowsPerPage.option('10')).click()
+      cy.get(selectors.list.pageNumber.option('5')).click()
+      cy.wait('@paginatedEdgeApplicationsListApi')
+      cy.get(selectors.list.pageNumber.option('6')).should('be.visible')
+      cy.get(selectors.list.pageNumber.option('5')).should('have.class', 'p-highlight')
+
+      cy.get(selectors.list.searchInput).type('foo 1{enter}')
+      cy.get(selectors.list.pageNumber.option('1')).should('be.visible')
+      cy.get(selectors.list.pageNumber.option('1')).should('have.class', 'p-highlight')
+    })
+
+  it('should reset pagination after delete edge application', function () {
+    cy.intercept('DELETE', '/api/v4/edge_application/applications/*', {
+      statusCode: 202,
+      body: { state: 'pending', data: null }
+    }).as('deleteEdgeApplicationApi')
+
+    cy.intercept('GET', '/api/v4/edge_application/*', {
+      fixture: '/edge-application/edge-applications.json'
     }).as('filteredEdgeApplicationsListApi')
 
-    cy.get(selectors.list.rowsPerPage.dropdown).click()
-    cy.get(selectors.list.rowsPerPage.option('100')).click()
+    cy.get(selectors.list.pageNumber.option('5')).click()
+    cy.get(selectors.list.pageNumber.option('6')).should('be.visible')
+    cy.get(selectors.list.pageNumber.option('5')).should('have.class', 'p-highlight')
+
+    cy.get(selectors.list.actionsMenu.button).first().click()
+    cy.get(selectors.list.actionsMenu.deleteButton).click()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).clear()
+    cy.get(selectors.list.deleteDialog.confirmationInputField).type('delete')
+    cy.get('[data-testid="delete-dialog-confirmation-input-field"]')
+    cy.get(selectors.list.deleteDialog.deleteButton).click()
+
+    cy.wait('@deleteEdgeApplicationApi').its('response.statusCode').should('eq', 202)
 
     cy.wait('@filteredEdgeApplicationsListApi')
       .its('response.body')
       .should('have.property', 'count', 100)
-  })
 
-  it('should paginate correctly list', function () {
-    cy.intercept('GET', '/api/v4/edge_application/*', (req) => {
-      if (req.url.includes('page_size=10')) {
-        req.reply({
-          fixture: '/edge-application/edge-applications-paginated.json'
-        })
-      }
-    }).as('paginatedEdgeApplicationsListApi')
-
-    cy.get(selectors.list.rowsPerPage.dropdown).click()
-    cy.get(selectors.list.rowsPerPage.option('10')).click()
-    cy.get(selectors.list.pageNumber.option('5')).click()
-    cy.wait('@paginatedEdgeApplicationsListApi')
-    cy.get(selectors.list.pageNumber.option('6')).should('be.visible')
-    cy.get(selectors.list.pageNumber.option('5')).should('have.class', 'p-highlight')
-
-    cy.get(selectors.list.searchInput).type('foo 1{enter}')
-    cy.get(selectors.list.pageNumber.option('1')).should('be.visible')
     cy.get(selectors.list.pageNumber.option('1')).should('have.class', 'p-highlight')
   })
 })

--- a/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
+++ b/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
@@ -305,7 +305,7 @@
   import PrimeMenu from 'primevue/menu'
   import OverlayPanel from 'primevue/overlaypanel'
   import Skeleton from 'primevue/skeleton'
-  import { computed, onMounted, ref } from 'vue'
+  import { computed, onMounted, ref, onUpdated } from 'vue'
   import { useRouter } from 'vue-router'
   import DeleteDialog from './dialog/delete-dialog.vue'
   import { useDialog } from 'primevue/usedialog'
@@ -431,6 +431,7 @@
   const isRenderOneOption = props.actions?.length === 1
   const selectedId = ref(null)
   const dataTableRef = ref(null)
+  const paginationFirstElement = ref(0)
 
   const filters = ref({
     global: { value: '', matchMode: FilterMatchMode.CONTAINS }
@@ -585,6 +586,7 @@
           emit('on-load-data', !!hasData)
         }
         firstLoadData.value = false
+        paginationFirstElement.value = page
       }
     }
   }
@@ -688,6 +690,11 @@
     reload()
   }
 
+  const updateDataTablePagination = () => {
+    if (!dataTableRef.value) return
+    dataTableRef.value.d_first = (paginationFirstElement.value - 1) * dataTableRef.value.rows
+  }
+
   const handleSearchValue = () => {
     const search = filters.value.global.value
     savedSearch.value = search
@@ -703,6 +710,10 @@
       })
     }
     selectedColumns.value = props.columns
+  })
+
+  onUpdated(() => {
+    updateDataTablePagination()
   })
 
   defineExpose({ reload, handleExportTableDataToCSV })

--- a/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
+++ b/src/templates/list-table-block/with-fetch-ordering-and-pagination.vue
@@ -305,7 +305,7 @@
   import PrimeMenu from 'primevue/menu'
   import OverlayPanel from 'primevue/overlaypanel'
   import Skeleton from 'primevue/skeleton'
-  import { computed, onMounted, ref, onUpdated } from 'vue'
+  import { computed, onMounted, ref } from 'vue'
   import { useRouter } from 'vue-router'
   import DeleteDialog from './dialog/delete-dialog.vue'
   import { useDialog } from 'primevue/usedialog'
@@ -431,7 +431,6 @@
   const isRenderOneOption = props.actions?.length === 1
   const selectedId = ref(null)
   const dataTableRef = ref(null)
-  const paginationFirstElement = ref(0)
 
   const filters = ref({
     global: { value: '', matchMode: FilterMatchMode.CONTAINS }
@@ -542,7 +541,7 @@
                     deleteService: action.service,
                     rerender: Math.random()
                   },
-                  onClose: (opt) => opt.data.updated && reload()
+                  onClose: (opt) => opt.data.updated && reload() && updateDataTablePagination()
                 }
                 openDialog(DeleteDialog, bodyDelete)
               }
@@ -586,7 +585,6 @@
           emit('on-load-data', !!hasData)
         }
         firstLoadData.value = false
-        paginationFirstElement.value = page
       }
     }
   }
@@ -691,8 +689,8 @@
   }
 
   const updateDataTablePagination = () => {
-    if (!dataTableRef.value) return
-    dataTableRef.value.d_first = (paginationFirstElement.value - 1) * dataTableRef.value.rows
+    const FIRST_NUMBER_PAGE = 1
+    firstItemIndex.value = FIRST_NUMBER_PAGE
   }
 
   const handleSearchValue = () => {
@@ -710,10 +708,6 @@
       })
     }
     selectedColumns.value = props.columns
-  })
-
-  onUpdated(() => {
-    updateDataTablePagination()
   })
 
   defineExpose({ reload, handleExportTableDataToCSV })

--- a/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
+++ b/src/tests/services/edge-application-rules-engine-services/v4/edit-rules-engine-service.test.js
@@ -140,7 +140,7 @@ describe('EdgeApplicationRulesEngineServices', () => {
           variable: 'remote_addr',
           operator: 'does_not_exist',
           argument: '192.168.1.2'
-        },
+        }
       ]
     ]
 
@@ -158,7 +158,7 @@ describe('EdgeApplicationRulesEngineServices', () => {
         {
           variable: 'remote_addr',
           operator: 'does_not_exist'
-        },
+        }
       ]
     ]
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

Paginação não estava resetando ao atualizar a Data Table com novos dados após o delete. Agora, após o update da DOM, a Data Table checará os dados para garantir que a paginação está correta.

### Does this PR introduce UI changes? Add a video or screenshots here.

No.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [] Application responsiveness was tested to different screen sizes
- [X] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
