### PR TITLE
[UXE-5824] fix: real-time-purge route name conflict

### DIFF
--- a/src/router/routes/real-time-purge/index.js
+++ b/src/router/routes/real-time-purge/index.js
@@ -8,7 +8,7 @@ export const realTimePurgeRoutes = {
   children: [
     {
       path: '',
-      name: 'real-time-purge',
+      name: 'list-real-time-purge',
       component: () => import('@views/RealTimePurge/ListView.vue'),
       props: {
         listRealTimePurgeService: RealTimePurgeService.listRealTimePurgeService,


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

### Does this PR introduce UI changes? Add a video or screenshots here.

O nome da real-time-purge estava conflitando com o primeiro item do array, fazendo o Vite renderizar o primeiro hit, o qual não tem uma página associada. 

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
