### PR TITLE
[UXE-5366] fix: standardize  edge functions titles to display item names instead of product names

### DIFF
--- a/src/views/EdgeFunctions/EditView.vue
+++ b/src/views/EdgeFunctions/EditView.vue
@@ -27,6 +27,7 @@
   })
   const updateObject = ref({})
   const language = ref(null)
+  const name = ref('')
 
   const handleTrackSuccessEdit = () => {
     tracker.product
@@ -67,7 +68,7 @@
 <template>
   <ContentBlock>
     <template #heading>
-      <PageHeadingBlock pageTitle="Edit Edge Function">
+      <PageHeadingBlock :pageTitle="name">
         <MobileCodePreview
           :updateObject="updateObject"
           :language="language"
@@ -87,6 +88,7 @@
           <FormFieldsEditEdgeFunctions
             v-model:preview-data="updateObject"
             v-model:lang="language"
+            v-model:name="name"
           />
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading }">

--- a/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
@@ -14,7 +14,7 @@
   import { computed, ref, watch } from 'vue'
 
   defineProps(['previewData', 'lang'])
-  const emit = defineEmits(['update:previewData', 'update:lang'])
+  const emit = defineEmits(['update:previewData', 'update:lang', 'update:name'])
 
   const SPLITTER_PROPS = {
     height: '50vh',
@@ -40,6 +40,7 @@
   const unwatch = watch(name, () => {
     initialCodeValue = code.value
     initialJsonArgsValue = jsonArgs.value
+    emit('update:name', name.value)
 
     if (initialCodeValue) {
       unwatch()


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

Foi alterado o título da página de Edit Edge Functions para receber o nome da function, no lugar do label genérico "Edit Edge Functions"

### Does this PR introduce UI changes? Add a video or screenshots here.
No.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [X] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:
- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
