### PR TITLE
[UXE-5976] fix: correct typo in 'does not start with' label on edge firewall

### DIFF
--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -103,7 +103,7 @@
           { label: 'is equal', value: 'is_equal' },
           { label: 'is not equal', value: 'is_not_equal' },
           { label: 'starts with', value: 'starts_with' },
-          { label: 'does not start with', value: 'does_not_starts_with' },
+          { label: 'does not start with', value: 'does_not_start_with' },
           { label: 'matches', value: 'matches' },
           { label: 'does not match', value: 'does_not_match' }
         ]


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
This pull request includes a minor correction in the `FormFieldsEdgeFirewallRulesEngine.vue` file. The change corrects a typo in one of the label values to ensure consistency and accuracy.

* [`src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue`](diffhunk://#diff-c5cb401b82e409e087ec860087ce449709bd715129595ada980cc377b6391d9fL106-R106): Corrected the label value from `does_not_starts_with` to `does_not_start_with`.

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
