### PR TITLE
[HOTFIX][NO-ISSUE] fix: correct label typo, improve criteria parsing, and enhance tests in Edge Firewall Rules Engine

### DIFF
--- a/src/services/edge-firewall-rules-engine-services/v4/create-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/create-edge-firewall-rules-engine-service.js
@@ -68,12 +68,30 @@ const parseBehaviors = (behaviors) => {
 
   return parsedBehaviors
 }
+
+const parseCriteria = (criteria) => {
+  const argumentTransformers = {
+    '${network}': (arg) => Number(arg)
+  }
+
+  return criteria.map((criterionGroup) =>
+    criterionGroup.map((criterion) => {
+      return {
+        ...criterion,
+        argument: argumentTransformers[criterion.variable]
+          ? argumentTransformers[criterion.variable](criterion.argument)
+          : criterion.argument
+      }
+    })
+  )
+}
+
 const adapt = (payload) => {
   const parsedPayload = {
     name: payload.name,
     description: payload.description,
     active: payload.active,
-    criteria: payload.criteria,
+    criteria: parseCriteria(payload.criteria),
     behaviors: parseBehaviors(payload.behaviors)
   }
   return parsedPayload

--- a/src/services/edge-firewall-rules-engine-services/v4/create-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/create-edge-firewall-rules-engine-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import { makeEdgeFirewallBaseUrl } from '../../edge-firewall-services/v4/make-edge-firewall-base-url'
 import * as Errors from '@/services/axios/errors'
 import { extractApiError } from '@/helpers/extract-api-error'
+import { parseCriteria, parseBehaviors } from './parser-utils'
 
 export const createEdgeFirewallRulesEngineService = async ({ edgeFirewallId, payload }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -18,73 +19,6 @@ export const createEdgeFirewallRulesEngineService = async ({ edgeFirewallId, pay
  * @param {Array} behaviors
  * @returns {Array}
  */
-const parseBehaviors = (behaviors) => {
-  const parsedBehaviors = behaviors.map((behavior) => {
-    switch (behavior.name) {
-      case 'run_function':
-        return {
-          name: behavior.name,
-          argument: behavior.functionId
-        }
-      case 'set_waf_ruleset':
-        return {
-          name: behavior.name,
-          argument: {
-            mode: behavior.mode,
-            id: behavior.waf_id
-          }
-        }
-      case 'set_rate_limit':
-        const typeToEnableBurstSize = 'second'
-        const argument = {
-          type: behavior.type,
-          limit_by: behavior.limit_by,
-          average_rate_limit: Number(behavior.average_rate_limit)
-        }
-
-        if (behavior.type === typeToEnableBurstSize) {
-          argument.maximum_burst_size = Number(behavior.maximum_burst_size)
-        }
-
-        return {
-          name: behavior.name,
-          argument
-        }
-      case 'set_custom_response':
-        return {
-          name: behavior.name,
-          argument: {
-            status_code: behavior.status_code,
-            content_type: behavior.content_type,
-            content_body: behavior.content_body
-          }
-        }
-      default:
-        return {
-          name: behavior.name
-        }
-    }
-  })
-
-  return parsedBehaviors
-}
-
-const parseCriteria = (criteria) => {
-  const argumentTransformers = {
-    '${network}': (arg) => Number(arg)
-  }
-
-  return criteria.map((criterionGroup) =>
-    criterionGroup.map((criterion) => {
-      return {
-        ...criterion,
-        argument: argumentTransformers[criterion.variable]
-          ? argumentTransformers[criterion.variable](criterion.argument)
-          : criterion.argument
-      }
-    })
-  )
-}
 
 const adapt = (payload) => {
   const parsedPayload = {

--- a/src/services/edge-firewall-rules-engine-services/v4/edit-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/edit-edge-firewall-rules-engine-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
 import { makeEdgeFirewallBaseUrl } from '../../edge-firewall-services/v4/make-edge-firewall-base-url'
 import { extractApiError } from '@/helpers/extract-api-error'
 import * as Errors from '@/services/axios/errors'
+import { parseCriteria, parseBehaviors } from './parser-utils'
 
 export const editEdgeFirewallRulesEngineService = async ({ edgeFirewallId, payload }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -18,73 +19,6 @@ export const editEdgeFirewallRulesEngineService = async ({ edgeFirewallId, paylo
  * @param {Array} behaviors
  * @returns {Array}
  */
-const parseBehaviors = (behaviors) => {
-  const parsedBehaviors = behaviors.map((behavior) => {
-    switch (behavior.name) {
-      case 'run_function':
-        return {
-          name: behavior.name,
-          argument: behavior.functionId
-        }
-      case 'set_waf_ruleset':
-        return {
-          name: behavior.name,
-          argument: {
-            mode: behavior.mode,
-            id: behavior.waf_id
-          }
-        }
-      case 'set_rate_limit':
-        const typeToEnableBurstSize = 'second'
-        const argument = {
-          type: behavior.type,
-          limit_by: behavior.limit_by,
-          average_rate_limit: Number(behavior.average_rate_limit)
-        }
-
-        if (behavior.type === typeToEnableBurstSize) {
-          argument.maximum_burst_size = Number(behavior.maximum_burst_size)
-        }
-
-        return {
-          name: behavior.name,
-          argument
-        }
-      case 'set_custom_response':
-        return {
-          name: behavior.name,
-          argument: {
-            status_code: behavior.status_code,
-            content_type: behavior.content_type,
-            content_body: behavior.content_body
-          }
-        }
-      default:
-        return {
-          name: behavior.name
-        }
-    }
-  })
-
-  return parsedBehaviors
-}
-
-const parseCriteria = (criteria) => {
-  const argumentTransformers = {
-    '${network}': (arg) => Number(arg)
-  }
-
-  return criteria.map((criterionGroup) =>
-    criterionGroup.map((criterion) => {
-      return {
-        ...criterion,
-        argument: argumentTransformers[criterion.variable]
-          ? argumentTransformers[criterion.variable](criterion.argument)
-          : criterion.argument
-      }
-    })
-  )
-}
 
 const adapt = (payload) => {
   const parsedPayload = {

--- a/src/services/edge-firewall-rules-engine-services/v4/edit-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/edit-edge-firewall-rules-engine-service.js
@@ -69,12 +69,29 @@ const parseBehaviors = (behaviors) => {
   return parsedBehaviors
 }
 
+const parseCriteria = (criteria) => {
+  const argumentTransformers = {
+    '${network}': (arg) => Number(arg)
+  }
+
+  return criteria.map((criterionGroup) =>
+    criterionGroup.map((criterion) => {
+      return {
+        ...criterion,
+        argument: argumentTransformers[criterion.variable]
+          ? argumentTransformers[criterion.variable](criterion.argument)
+          : criterion.argument
+      }
+    })
+  )
+}
+
 const adapt = (payload) => {
   const parsedPayload = {
     name: payload.name,
     description: payload.description,
     active: payload.active,
-    criteria: payload.criteria,
+    criteria: parseCriteria(payload.criteria),
     behaviors: parseBehaviors(payload.behaviors)
   }
   return parsedPayload

--- a/src/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.js
@@ -21,7 +21,7 @@ const parseCriteria = (criteria) => {
   const parsedCriteria = criteria.map((criterionGroup) => {
     return criterionGroup.map((criterion) => {
       switch (criterion.variable) {
-        case 'network':
+        case '${network}':
           return {
             ...criterion,
             argument: criterion.argument.toString()

--- a/src/services/edge-firewall-rules-engine-services/v4/parser-utils.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/parser-utils.js
@@ -1,0 +1,67 @@
+export const parseCriteria = (criteria) => {
+  const argumentTransformers = {
+    '${network}': (arg) => parseInt(arg)
+  }
+
+  return criteria.map((criterionGroup) =>
+    criterionGroup.map((criterion) => {
+      return {
+        ...criterion,
+        argument: argumentTransformers[criterion.variable]
+          ? argumentTransformers[criterion.variable](criterion.argument)
+          : criterion.argument
+      }
+    })
+  )
+}
+
+export const parseBehaviors = (behaviors) => {
+  const parsedBehaviors = behaviors.map((behavior) => {
+    switch (behavior.name) {
+      case 'run_function':
+        return {
+          name: behavior.name,
+          argument: behavior.functionId
+        }
+      case 'set_waf_ruleset':
+        return {
+          name: behavior.name,
+          argument: {
+            mode: behavior.mode,
+            id: behavior.waf_id
+          }
+        }
+      case 'set_rate_limit':
+        const typeToEnableBurstSize = 'second'
+        const argument = {
+          type: behavior.type,
+          limit_by: behavior.limit_by,
+          average_rate_limit: Number(behavior.average_rate_limit)
+        }
+
+        if (behavior.type === typeToEnableBurstSize) {
+          argument.maximum_burst_size = Number(behavior.maximum_burst_size)
+        }
+
+        return {
+          name: behavior.name,
+          argument
+        }
+      case 'set_custom_response':
+        return {
+          name: behavior.name,
+          argument: {
+            status_code: behavior.status_code,
+            content_type: behavior.content_type,
+            content_body: behavior.content_body
+          }
+        }
+      default:
+        return {
+          name: behavior.name
+        }
+    }
+  })
+
+  return parsedBehaviors
+}

--- a/src/templates/form-fields-inputs/fieldDropdownIcon.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownIcon.vue
@@ -3,6 +3,8 @@
   import { useField } from 'vee-validate'
   import Dropdown from 'primevue/dropdown'
 
+  const emit = defineEmits(['onChange'])
+
   const props = defineProps({
     value: {
       type: String,
@@ -62,6 +64,10 @@
     initialValue: props.value
   })
 
+  const handleChangeEvent = ({ value }) => {
+    emit('onChange', value)
+  }
+
   defineExpose({
     autoCompleteRef
   })
@@ -104,6 +110,7 @@
       @input="handleChange"
       @blur="handleBlur"
       v-bind="$attrs"
+      @change="handleChangeEvent"
     />
   </div>
 

--- a/src/tests/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/v4/load-edge-firewall-rules-engine-service.test.js
@@ -21,7 +21,7 @@ const fixture = {
     criteria: [
       [
         {
-          variable: 'network',
+          variable: '${network}',
           operator: 'is_in_list',
           conditional: 'if',
           argument: 66
@@ -33,7 +33,7 @@ const fixture = {
   criteriaParsed: [
     [
       {
-        variable: 'network',
+        variable: '${network}',
         operator: 'is_in_list',
         conditional: 'if',
         argument: '66'
@@ -90,7 +90,7 @@ describe('EdgeFirewallRulesEngineServices', () => {
       criteria: [
         [
           {
-            variable: 'network',
+            variable: '${network}',
             operator: 'is_in_list',
             conditional: 'if',
             argument: 66
@@ -109,7 +109,7 @@ describe('EdgeFirewallRulesEngineServices', () => {
     expect(result.criteria).toEqual([
       [
         {
-          variable: 'network',
+          variable: '${network}',
           operator: 'is_in_list',
           conditional: 'if',
           argument: '66'

--- a/src/tests/services/edge-firewall-rules-engine-services/v4/parser-utils.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/v4/parser-utils.test.js
@@ -1,0 +1,81 @@
+import {
+  parseCriteria,
+  parseBehaviors
+} from '@/services/edge-firewall-rules-engine-services/v4/parser-utils'
+import { describe, expect, it } from 'vitest'
+
+describe('parser-utils', () => {
+  describe('parseCriteria', () => {
+    it('should correctly parse criteria with network variable', () => {
+      const criteria = [[{ variable: '${network}', argument: '100' }]]
+      const expected = [[{ variable: '${network}', argument: 100 }]]
+      expect(parseCriteria(criteria)).toEqual(expected)
+    })
+
+    it('should leave argument unchanged if variable does not match', () => {
+      const criteria = [[{ variable: '${unknown}', argument: 'test' }]]
+      const expected = [[{ variable: '${unknown}', argument: 'test' }]]
+      expect(parseCriteria(criteria)).toEqual(expected)
+    })
+  })
+
+  describe('parseBehaviors', () => {
+    it('should correctly parse run_function behavior', () => {
+      const behaviors = [{ name: 'run_function', functionId: 123 }]
+      const expected = [{ name: 'run_function', argument: 123 }]
+      expect(parseBehaviors(behaviors)).toEqual(expected)
+    })
+
+    it('should correctly parse set_waf_ruleset behavior', () => {
+      const behaviors = [{ name: 'set_waf_ruleset', mode: 'block', waf_id: 1 }]
+      const expected = [{ name: 'set_waf_ruleset', argument: { mode: 'block', id: 1 } }]
+      expect(parseBehaviors(behaviors)).toEqual(expected)
+    })
+
+    it('should correctly parse set_rate_limit behavior with burst size', () => {
+      const behaviors = [
+        {
+          name: 'set_rate_limit',
+          type: 'second',
+          limit_by: 'ip',
+          average_rate_limit: '100',
+          maximum_burst_size: '20'
+        }
+      ]
+      const expected = [
+        {
+          name: 'set_rate_limit',
+          argument: {
+            type: 'second',
+            limit_by: 'ip',
+            average_rate_limit: 100,
+            maximum_burst_size: 20
+          }
+        }
+      ]
+      expect(parseBehaviors(behaviors)).toEqual(expected)
+    })
+
+    it('should correctly parse set_custom_response behavior', () => {
+      const behaviors = [
+        {
+          name: 'set_custom_response',
+          status_code: '404',
+          content_type: 'text/plain',
+          content_body: 'Not found'
+        }
+      ]
+      const expected = [
+        {
+          name: 'set_custom_response',
+          argument: {
+            status_code: '404',
+            content_type: 'text/plain',
+            content_body: 'Not found'
+          }
+        }
+      ]
+      expect(parseBehaviors(behaviors)).toEqual(expected)
+    })
+  })
+})

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -9,7 +9,7 @@
   import Divider from 'primevue/divider'
   import PrimeMenu from 'primevue/menu'
   import { useFieldArray } from 'vee-validate'
-  import { computed, ref } from 'vue'
+  import { computed, nextTick, ref } from 'vue'
   import { useToast } from 'primevue/usetoast'
 
   const toast = useToast()
@@ -485,8 +485,10 @@
     criteriaIndex,
     criteriaInnerRowIndex
   }) => {
-    criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable = selectedCriteriaVariable
-    criteria.value[criteriaIndex].value[criteriaInnerRowIndex].argument = ''
+    nextTick(() => {
+      criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable = selectedCriteriaVariable
+      criteria.value[criteriaIndex].value[criteriaInnerRowIndex].argument = ''
+    })
   }
 </script>
 <template>

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -103,7 +103,7 @@
           { label: 'is equal', value: 'is_equal' },
           { label: 'is not equal', value: 'is_not_equal' },
           { label: 'starts with', value: 'starts_with' },
-          { label: 'does not start with', value: 'does_not_starts_with' },
+          { label: 'does not start with', value: 'does_not_start_with' },
           { label: 'matches', value: 'matches' },
           { label: 'does not match', value: 'does_not_match' }
         ]

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -146,20 +146,20 @@
   const showArgumentBySelectedOperator = ({ criteriaIndex, criteriaInnerRowIndex }) => {
     const criteriaRow = criteria.value[criteriaIndex].value[criteriaInnerRowIndex]
     return (
-      criteriaRow.operator !== 'exists' &&
-      criteriaRow.operator !== 'does_not_exist' &&
-      criteriaRow.variable !== 'ssl_verification_status' &&
-      criteriaRow.variable !== 'network'
+      criteriaRow.operator !== '${exists}' &&
+      criteriaRow.operator !== '${does_not_exist}' &&
+      criteriaRow.variable !== '${ssl_verification_status}' &&
+      criteriaRow.variable !== '${network}'
     )
   }
   const showSSLStatusDropdownField = ({ criteriaIndex, criteriaInnerRowIndex }) => {
     const criteriaVariable = criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable
 
-    return criteriaVariable === 'ssl_verification_status'
+    return criteriaVariable === '${ssl_verification_status}'
   }
   const showNetworkListDropdownField = ({ criteriaIndex, criteriaInnerRowIndex }) => {
     const criteriaVariable = criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable
-    const isCriteriaNetworkSelected = criteriaVariable === 'network'
+    const isCriteriaNetworkSelected = criteriaVariable === '${network}'
     const hasNetworkOptionsToSelect = networkListOptions.value.length
 
     if (isCriteriaNetworkSelected && !hasNetworkOptionsToSelect) {


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

This pull request includes several changes to the edge firewall rules engine services and related components. The main changes involve adding a new `parseCriteria` function to handle criteria parsing, updating criteria variable names to use template literals, and enhancing test coverage for these changes.

### Criteria Parsing Enhancements:
* Added `parseCriteria` function to transform criteria arguments based on their variables in `create-edge-firewall-rules-engine-service.js` and `edit-edge-firewall-rules-engine-service.js` [[1]](diffhunk://#diff-b389e71e4ade07de541111799faf035dc8f5626147318b11d476f6ed6b584a80R71-R94) [[2]](diffhunk://#diff-b206e511bbe034d351bf8ca437056d9673e0f36b4d99ab5df5be82937411c4f2R72-R94).
* Updated criteria variable names to use template literals in `load-edge-firewall-rules-engine-service.js`.

### Form Fields Enhancements:
* Added `emit` for `onChange` event and `handleChangeEvent` function in `fieldDropdownIcon.vue` to handle change events [[1]](diffhunk://#diff-3085a03b085541c7d28385284f47b1e6103fe719c773c773f6ff8e34ebb5bb97R6-R7) [[2]](diffhunk://#diff-3085a03b085541c7d28385284f47b1e6103fe719c773c773f6ff8e34ebb5bb97R67-R70) [[3]](diffhunk://#diff-3085a03b085541c7d28385284f47b1e6103fe719c773c773f6ff8e34ebb5bb97R113).
* Corrected typo in operator value from `does_not_starts_with` to `does_not_start_with` and updated criteria variable checks in `FormFieldsEdgeFirewallRulesEngine.vue` [[1]](diffhunk://#diff-c5cb401b82e409e087ec860087ce449709bd715129595ada980cc377b6391d9fL106-R106) [[2]](diffhunk://#diff-c5cb401b82e409e087ec860087ce449709bd715129595ada980cc377b6391d9fL149-R162).

### Test Coverage Enhancements:
* Added tests to verify criteria variable conversion to numbers and ensure other criteria remain unchanged in `create-edge-firewall-rules-engine-service.test.js` and `edit-edge-firewall-rules-engine-service.test.js` [[1]](diffhunk://#diff-9524cedb2f7130ef56bc22adb8af8dae702ea687b79bb89ccc3f9b8bf8a37423R127-R175) [[2]](diffhunk://#diff-83bf746b16d62614577ff3a7aba379d6099502795ac421368a5705080c6a8abaR1-R181).
* Updated test fixtures to use template literals for criteria variables in `load-edge-firewall-rules-engine-service.test.js` [[1]](diffhunk://#diff-bffcc1a848adcdae7a4573659a5b30ab60aca4f9532b579c68b9753a5268ef91L24-R24) [[2]](diffhunk://#diff-bffcc1a848adcdae7a4573659a5b30ab60aca4f9532b579c68b9753a5268ef91L36-R36) [[3]](diffhunk://#diff-bffcc1a848adcdae7a4573659a5b30ab60aca4f9532b579c68b9753a5268ef91L93-R93) [[4]](diffhunk://#diff-bffcc1a848adcdae7a4573659a5b30ab60aca4f9532b579c68b9753a5268ef91L112-R112).

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
