### PR TITLE
[UXE-6013] feat: add Manager EOL URLs and User Interaction Tracking in HomeView

### DIFF
--- a/src/helpers/get-static-urls-by-environment.js
+++ b/src/helpers/get-static-urls-by-environment.js
@@ -5,6 +5,10 @@ const urls = {
     stage: 'https://stage-manager.azion.com',
     production: 'https://manager.azion.com'
   },
+  managerEOL: {
+    stage: 'https://stage-manager.azion.com/home',
+    production: 'https://manager.azion.com/home'
+  },
   billing: {
     stage: 'https://stage-manager.azion.com/billing-subscriptions',
     production: 'https://manager.azion.com/billing-subscriptions'

--- a/src/plugins/analytics/trackers/ProductTracker.js
+++ b/src/plugins/analytics/trackers/ProductTracker.js
@@ -167,4 +167,17 @@ export class ProductTracker {
     })
     return this.#trackerAdapter
   }
+
+  /**
+   * @param {Object} payload
+   * @param {String} payload.target
+   * @returns {AnalyticsTrackerAdapter}
+   */
+  clickedTo(payload) {
+    this.#trackerAdapter.addEvent({
+      eventName: `Clicked to ${payload.target}`,
+      props: {}
+    })
+    return this.#trackerAdapter
+  }
 }

--- a/src/tests/helpers/get-static-urls-by-environment.test.js
+++ b/src/tests/helpers/get-static-urls-by-environment.test.js
@@ -26,6 +26,21 @@ const scenarios = [
     expected: 'https://manager.azion.com'
   },
   {
+    section: 'managerEOL',
+    env: 'development',
+    expected: 'https://stage-manager.azion.com/home'
+  },
+  {
+    section: 'managerEOL',
+    env: 'stage',
+    expected: 'https://stage-manager.azion.com/home'
+  },
+  {
+    section: 'managerEOL',
+    env: 'production',
+    expected: 'https://manager.azion.com/home'
+  },
+  {
     section: 'billing',
     env: 'stage',
     expected: 'https://stage-manager.azion.com/billing-subscriptions'

--- a/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
@@ -544,6 +544,21 @@ describe('AnalyticsTrackerAdapter', () => {
     })
   })
 
+  it('should be able to track clicked to with correct params', () => {
+    const { sut, analyticsClientSpy } = makeSut()
+    const targetName = 'RTM'
+
+    sut.product.clickedTo({
+      target: targetName
+    })
+
+    sut.track()
+
+    expect(analyticsClientSpy.track).toHaveBeenCalledWith('Clicked to RTM', {
+      application: fixtures.application
+    })
+  }
+
   // Waf Rules Tracker - Scenarios
   it('should be able to track click to allow rules with correct params', () => {
     const { sut, analyticsClientSpy } = makeSut()

--- a/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
+++ b/src/tests/plugins/analytics/AnalyticsTrackerAdapter.test.js
@@ -557,7 +557,7 @@ describe('AnalyticsTrackerAdapter', () => {
     expect(analyticsClientSpy.track).toHaveBeenCalledWith('Clicked to RTM', {
       application: fixtures.application
     })
-  }
+  })
 
   // Waf Rules Tracker - Scenarios
   it('should be able to track click to allow rules with correct params', () => {

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -13,6 +13,7 @@
   import CreateFormBlock from '@/templates/create-form-block'
   import { useLayout } from '@/composables/use-layout'
   import InlineMessage from 'primevue/inlinemessage'
+  import { getStaticUrlsByEnvironment } from '@/helpers'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
@@ -114,6 +115,12 @@
     }
   }
 
+  const openRTM = async () => {
+    const urlEOL = getStaticUrlsByEnvironment('managerEOL')
+    await tracker.product.clickedTo({ target: 'RTM' }).track()
+    window.location.href = urlEOL
+  }
+
   onMounted(async () => {
     teams.value = await props.listTeamsService()
     showOnboardingSchedulingDialog()
@@ -134,11 +141,11 @@
         >
           <PrimeButton
             label="Real-Time Manager (RTM)"
-            @click="openContactSupport"
+            @click="openRTM"
             iconPos="right"
+            class="p-0"
             size="small"
             link
-            icon="pi pi-external-link"
           />
 
           will be deprecated and accessible only until January 27, 2025. Azion Console is now the

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -12,6 +12,7 @@
   import DialogOnboardingScheduling from '@/templates/dialogs-block/dialog-onboarding-scheduling.vue'
   import CreateFormBlock from '@/templates/create-form-block'
   import { useLayout } from '@/composables/use-layout'
+  import InlineMessage from 'primevue/inlinemessage'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
@@ -126,7 +127,24 @@
   <ContentBlock>
     <template #content>
       <section class="w-full flex flex-col gap-6 lg:gap-8">
-        <!-- Getting Started -->
+        <InlineMessage
+          class="p-3 gap-1"
+          severity="info"
+          data-testid="message-deprecation"
+        >
+          <PrimeButton
+            label="Real-Time Manager (RTM)"
+            @click="openContactSupport"
+            iconPos="right"
+            size="small"
+            link
+            icon="pi pi-external-link"
+          />
+
+          will be deprecated and accessible only until January 27, 2025. Azion Console is now the
+          primary way to access Azion's platform.
+        </InlineMessage>
+
         <div
           v-if="showExperimental"
           class="w-full p-3 surface-border border rounded-md flex flex-col gap-4 justify-between items-center sm:flex-row sm:p-8 lg:gap-10"

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -139,6 +139,7 @@
           severity="info"
           data-testid="message-deprecation"
         >
+          Azion Console is now the primary way to access Azion's platform.
           <PrimeButton
             label="Real-Time Manager (RTM)"
             @click="openRTM"
@@ -147,9 +148,8 @@
             size="small"
             link
           />
-
-          will be deprecated and accessible only until January 27, 2025. Azion Console is now the
-          primary way to access Azion's platform.
+          will be deprecated soon, and access will only be available for a limited time through this
+          link.
         </InlineMessage>
 
         <div


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

This pull request introduces new functionality to track user interactions and updates the URLs for different environments. The key changes include adding a new section for manager EOL URLs, implementing a new tracking method for user clicks, and updating the HomeView component to reflect these changes.

### Does this PR introduce breaking changes?
- [ ] No
- [x] Yes  

The HomeView component now depends on the `managerEOL` URLs and the new `clickedTo` tracking method. Ensure the updated methods and URLs are available in all environments to prevent issues.

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/3416d04c-5ea7-43b1-9c82-8b1c7d36a482


Yes, the HomeView component now includes an inline message with a button for RTM deprecation that navigates to the `managerEOL` URL and tracks click events.

### Does it have a link on Figma?

No specific Figma link is provided for these changes.

---

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: `[ISSUE_CODE] TYPE: TITLE`
- [x] Commits are tagged with the right word (`feat`, `test`, `refactor`, etc).
- [x] Application responsiveness was tested to different screen sizes.
- [x] Code is formatted and linted.
- [x] Tags are added to the PR.

#### These changes were tested on the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] Safari
