### PR TITLE
[UXE-6083] fix: empty criteria argument for network lists in edge firewall rules engine

### DIFF
--- a/cypress/e2e/edge-firewall/create-edge-firewall-network-list.cy.js
+++ b/cypress/e2e/edge-firewall/create-edge-firewall-network-list.cy.js
@@ -51,16 +51,19 @@ describe('Edge Firewall spec', { tags: ['@dev5', '@xfail'] }, () => {
     cy.get(selectors.edgeFirewall.ruleDescriptionInput).type('My Rule Description')
 
     // Act - Set Criteria
-    cy.intercept('GET', '/api/v3/network_lists?page=1&page_size=200').as('networkList')
+    cy.intercept('GET', '/api/v4/workspace/network_lists?ordering=name&page=1&page_size=100&fields=&search=').as('networkList')
+    cy.intercept('GET', `/api/v4/workspace/network_lists?ordering=name&page=1&page_size=100&fields=&search=${networkListName}`).as('networkListSearch')
     cy.get(selectors.edgeFirewall.ruleCriteriaVariableDropdown).click()
     cy.get(selectors.edgeFirewall.ruleCriteriaVariableDropdownNetworkLists).click()
     cy.get(selectors.edgeFirewall.ruleCriteriaOperatorDropdown).click()
     cy.get(selectors.edgeFirewall.ruleCriteriaOperatorFirstOption).click()
     cy.wait('@networkList')
     cy.get(selectors.edgeFirewall.ruleCriteriaNetworkListDropdown).click()
+    cy.get(selectors.edgeFirewall.ruleCriteriaNetworkListFilter).click()
     cy.get(selectors.edgeFirewall.ruleCriteriaNetworkListFilter).clear()
     cy.get(selectors.edgeFirewall.ruleCriteriaNetworkListFilter).type(networkListName)
     cy.get(selectors.edgeFirewall.ruleCriteriaNetworkListDropdown).click()
+    cy.wait('@networkListSearch')
     cy.get(selectors.edgeFirewall.ruleCriteriaValueFirstOption).click()
 
     // Act - Set Behavior

--- a/cypress/support/selectors/product-selectors/edge-firewall.js
+++ b/cypress/support/selectors/product-selectors/edge-firewall.js
@@ -41,9 +41,9 @@ export default {
   ruleCriteriaValueFirstOption: '#criteria\\[0\\]\\[0\\]\\.argument_0',
   ruleCriteriaInput: '[data-testid="edge-firewall-rules-form__argument[0][0]__input"]',
   ruleCriteriaNetworkListDropdown:
-    '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown-trigger"]',
+    '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown"]',
   ruleCriteriaNetworkListFilter:
-    '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown-filter-input"]',
+    '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown-search"]',
   ruleBehaviorDropdown: '[data-testid="edge-firewall-rules-form__behaviors[0]-dropdown__dropdown"]',
   ruleBehaviorRunFunction: '#behaviors\\[0\\]\\.name_4',
   ruleBehaviorSetRateLimit: '#behaviors\\[0\\]\\.name_2',

--- a/src/router/routes/edge-firewall-routes/index.js
+++ b/src/router/routes/edge-firewall-routes/index.js
@@ -63,6 +63,7 @@ export const edgeFirewallRoutes = {
       props: {
         listDomainsService: DomainServices.listDomainsService,
         listNetworkListService: NetworkListsServiceV4.listNetworkListService,
+        loadNetworkListService: NetworkListsServiceV4.loadNetworkListService,
         edgeFirewallServices: {
           loadEdgeFirewallService: EdgeFirewallServicesV4.loadEdgeFirewallService,
           editEdgeFirewallService: EdgeFirewallServicesV4.editEdgeFirewallService,

--- a/src/router/routes/edge-firewall-routes/index.js
+++ b/src/router/routes/edge-firewall-routes/index.js
@@ -10,7 +10,7 @@ import * as EdgeFunctionServiceV4 from '@/services/edge-functions-services/v4'
 import * as EdgeFirewallRulesEngineServicesV4 from '@/services/edge-firewall-rules-engine-services/v4'
 
 import * as WafRulesServices from '@/services/waf-rules-services'
-import * as NetworkListsService from '@/services/network-lists-services'
+import * as NetworkListsServiceV4 from '@/services/network-lists-services/v4'
 
 /** @type {import('vue-router').RouteRecordRaw} */
 export const edgeFirewallRoutes = {
@@ -62,7 +62,7 @@ export const edgeFirewallRoutes = {
       component: () => import('@/views/EdgeFirewall/TabsView.vue'),
       props: {
         listDomainsService: DomainServices.listDomainsService,
-        listNetworkListService: NetworkListsService.listNetworkListService,
+        listNetworkListService: NetworkListsServiceV4.listNetworkListService,
         edgeFirewallServices: {
           loadEdgeFirewallService: EdgeFirewallServicesV4.loadEdgeFirewallService,
           editEdgeFirewallService: EdgeFirewallServicesV4.editEdgeFirewallService,

--- a/src/router/routes/switch-account-routes/index.js
+++ b/src/router/routes/switch-account-routes/index.js
@@ -19,7 +19,11 @@ export const switchAccountRoutes = {
 
     try {
       const EnableSocialLogin = true
-      const redirect = await accountHandler.switchAccountFromSocialIdp(verify, refresh, EnableSocialLogin)
+      const redirect = await accountHandler.switchAccountFromSocialIdp(
+        verify,
+        refresh,
+        EnableSocialLogin
+      )
       next(redirect)
     } catch {
       next({ name: 'login' })

--- a/src/services/network-lists-services/v4/index.js
+++ b/src/services/network-lists-services/v4/index.js
@@ -1,4 +1,5 @@
 import { listNetworkListService } from './list-network-list-service'
+import { loadNetworkListService } from './load-network-list-service'
 
 /**
  * @typedef {Object} ExportedServicesType - The type of the exported services
@@ -8,4 +9,4 @@ import { listNetworkListService } from './list-network-list-service'
 /**
  * @type {ExportedServicesType}
  */
-export { listNetworkListService }
+export { listNetworkListService, loadNetworkListService }

--- a/src/services/network-lists-services/v4/list-network-list-service.js
+++ b/src/services/network-lists-services/v4/list-network-list-service.js
@@ -11,17 +11,18 @@ export const listNetworkListService = async ({
   pageSize = 10,
   allResults = false
 }) => {
-  const searchParams = makeListServiceQueryParams({ fields, ordering, page, pageSize, search })
+  const newPageSize = allResults ? 100 : pageSize
+  const searchParams = makeListServiceQueryParams({ fields, ordering, page, pageSize: newPageSize, search })
   let httpResponse = await fetchAndAdaptNetworkList(searchParams)
 
   if (allResults) {
     const count = httpResponse.count
     let currentPage = page
 
-    while (count > currentPage * 100) {
+    while (count > currentPage * newPageSize) {
       currentPage += 1
 
-      const newSearchParams = makeListServiceQueryParams({ fields, ordering, page: currentPage, pageSize, search, allResults })
+      const newSearchParams = makeListServiceQueryParams({ fields, ordering, page: currentPage, pageSize: newPageSize, search, allResults })
       let response = await fetchAndAdaptNetworkList(newSearchParams)
       httpResponse.body = [...httpResponse.body, ...response.body]
     }

--- a/src/services/network-lists-services/v4/list-network-list-service.js
+++ b/src/services/network-lists-services/v4/list-network-list-service.js
@@ -8,26 +8,22 @@ export const listNetworkListService = async ({
   search = '',
   ordering = '',
   page = 1,
-  pageSize = 10,
-  allResults = false
+  pageSize = 10
 }) => {
-  const newPageSize = allResults ? 100 : pageSize
-  const searchParams = makeListServiceQueryParams({ fields, ordering, page, pageSize: newPageSize, search })
-  let httpResponse = await fetchAndAdaptNetworkList(searchParams)
+  const searchParams = makeListServiceQueryParams({
+    fields,
+    ordering,
+    page,
+    pageSize,
+    search
+  })
 
-  if (allResults) {
-    const count = httpResponse.count
-    let currentPage = page
+  let httpResponse = await AxiosHttpClientAdapter.request({
+    url: `${makeNetworkListBaseUrl()}?${searchParams.toString()}`,
+    method: 'GET'
+  })
 
-    while (count > currentPage * newPageSize) {
-      currentPage += 1
-
-      const newSearchParams = makeListServiceQueryParams({ fields, ordering, page: currentPage, pageSize: newPageSize, search, allResults })
-      let response = await fetchAndAdaptNetworkList(newSearchParams)
-      httpResponse.body = [...httpResponse.body, ...response.body]
-    }
-  }
-
+  httpResponse = adapt(httpResponse)
   return parseHttpResponse(httpResponse)
 }
 
@@ -58,12 +54,4 @@ const adapt = (httpResponse) => {
     body: networkList,
     statusCode: httpResponse.statusCode
   }
-}
-
-const fetchAndAdaptNetworkList = async (searchParams) => {
-  const httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeNetworkListBaseUrl()}?${searchParams.toString()}`,
-    method: 'GET'
-  })
-  return adapt(httpResponse)
 }

--- a/src/services/network-lists-services/v4/list-network-list-service.js
+++ b/src/services/network-lists-services/v4/list-network-list-service.js
@@ -37,14 +37,14 @@ const adapt = (httpResponse) => {
 
   const networkList = isArray
     ? httpResponse.body.results.map((element) => ({
-      id: element.id,
-      stringId: element.id.toString(),
-      name: element.name,
-      lastEditor: element.last_editor,
-      listType: listTypeMap[element.type],
-      lastModified: formatExhibitionDate(element.last_modified, 'full', 'short'),
-      lastModifiedDate: element.last_modified
-    }))
+        id: element.id,
+        stringId: element.id.toString(),
+        name: element.name,
+        lastEditor: element.last_editor,
+        listType: listTypeMap[element.type],
+        lastModified: formatExhibitionDate(element.last_modified, 'full', 'short'),
+        lastModifiedDate: element.last_modified
+      }))
     : []
 
   const count = httpResponse.body?.count ?? 0

--- a/src/services/network-lists-services/v4/load-network-list-service.js
+++ b/src/services/network-lists-services/v4/load-network-list-service.js
@@ -1,0 +1,37 @@
+import { AxiosHttpClientAdapter, parseHttpResponse } from '@/services/axios/AxiosHttpClientAdapter'
+import { makeNetworkListBaseUrl } from './make-network-list-service'
+import { formatExhibitionDate } from '@/helpers/convert-date'
+
+export const loadNetworkListService = async ({ id }) => {
+  let httpResponse = await AxiosHttpClientAdapter.request({
+    url: `${makeNetworkListBaseUrl()}/${id}`,
+    method: 'GET'
+  })
+
+  httpResponse = adapt(httpResponse)
+  return parseHttpResponse(httpResponse)
+}
+
+const adapt = (httpResponse) => {
+  const { data } = httpResponse.body
+  const listTypeMap = {
+    ip_cidr: 'IP/CIDR',
+    asn: 'ASN',
+    countries: 'Countries'
+  }
+
+  const networkList = {
+    id: data.id,
+    stringId: data.id.toString(),
+    name: data.name,
+    lastEditor: data.last_editor,
+    listType: listTypeMap[data.type],
+    lastModified: formatExhibitionDate(data.last_modified, 'full', 'short'),
+    lastModifiedDate: data.last_modified
+  }
+
+  return {
+    body: networkList,
+    statusCode: httpResponse.statusCode
+  }
+}

--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -154,6 +154,11 @@
     disableEmitFirstRender: {
       type: Boolean,
       default: false
+    },
+    initalData: {
+      type: Array,
+      default: () => [],
+      require: true
     }
   })
 
@@ -178,7 +183,6 @@
   const disableEmitInit = ref(props.disableEmitFirstRender)
 
   onMounted(async () => {
-    await fetchData()
     loadSelectedValue(props.value)
   })
 
@@ -348,6 +352,28 @@
       if (!existitemInList) {
         loadSelectedValue(newValue)
       }
+    }
+  )
+
+  watch(
+    () => props.initalData,
+    (newValue) => {
+      let results = newValue.body?.map((item) => {
+        return {
+          [props.optionLabel]: item.name,
+          [props.optionValue]: item.id,
+          ...props?.moreOptions?.reduce(
+            (additionalFields, option) => ({
+              ...additionalFields,
+              [option]: item[option]
+            }),
+            {}
+          )
+        }
+      })
+
+      data.value = results
+      totalCount.value = newValue.count
     }
   )
 

--- a/src/tests/services/network-lists-services/v4/load-network-list-service.test.js
+++ b/src/tests/services/network-lists-services/v4/load-network-list-service.test.js
@@ -1,0 +1,72 @@
+import { AxiosHttpClientAdapter } from '@/services/axios/AxiosHttpClientAdapter'
+import { loadNetworkListService } from '@/services/network-lists-services/v4'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { localeMock } from '@/tests/utils/localeMock'
+
+const fixtures = {
+  networkMock: {
+    id: 123123123,
+    name: 'Network AZ',
+    last_editor: 'John A',
+    type: 'ip_cidr',
+    last_modified: new Date(2023, 10, 10)
+  }
+}
+
+const makeSut = () => {
+  const sut = loadNetworkListService
+
+  return {
+    sut
+  }
+}
+
+describe('NetworkListsServices', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should call api with correct params', async () => {
+    const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        data: fixtures.networkMock
+      }
+    })
+
+    const { sut } = makeSut()
+    await sut({ id: fixtures.networkMock.id })
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      url: `v4/workspace/network_lists/${fixtures.networkMock.id}`,
+      method: 'GET'
+    })
+  })
+
+  it('should parse correctly the network record', async () => {
+    localeMock()
+    vi.setSystemTime(new Date(2023, 10, 10, 10))
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 200,
+      body: {
+        data: fixtures.networkMock
+      }
+    })
+    const { sut } = makeSut()
+
+    const result = await sut({ id: fixtures.networkMock.id })
+
+    expect(result).toEqual({
+      id: fixtures.networkMock.id,
+      stringId: fixtures.networkMock.id.toString(),
+      name: fixtures.networkMock.name,
+      lastEditor: fixtures.networkMock.last_editor,
+      listType: 'IP/CIDR',
+      lastModified: 'Friday, November 10, 2023 at 12:00 AM',
+      lastModifiedDate: new Date('2023-11-10T00:00:00.000Z')
+    })
+  })
+})

--- a/src/views/EdgeFirewall/TabsView.vue
+++ b/src/views/EdgeFirewall/TabsView.vue
@@ -18,7 +18,8 @@
     edgeFirewallServices: { type: Object, required: true },
     listDomainsService: { type: Function, required: true },
     rulesEngineServices: { type: Object, required: true },
-    listNetworkListService: { type: Function, required: true }
+    listNetworkListService: { type: Function, required: true },
+    loadNetworkListService: { type: Function, required: true }
   })
 
   const defaultTabs = {
@@ -215,6 +216,7 @@
             :edgeFirewallId="edgeFirewallId"
             v-bind="props.rulesEngineServices"
             :listNetworkListService="props.listNetworkListService"
+            :loadNetworkListService="loadNetworkListService"
           />
         </TabPanel>
       </TabView>

--- a/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
+++ b/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
@@ -49,6 +49,10 @@
     listNetworkListService: {
       type: Function,
       required: true
+    },
+    loadNetworkListService: {
+      type: Function,
+      required: true
     }
   })
 
@@ -272,6 +276,7 @@
         :edgeFirewallFunctionsOptions="edgeFirewallFunctionsOptions"
         :wafRulesOptions="wafRulesOptions"
         :listNetworkListService="listNetworkListService"
+        :loadNetworkListService="loadNetworkListService"
       />
     </template>
   </CreateDrawerBlock>
@@ -293,6 +298,7 @@
         :edgeFirewallFunctionsOptions="edgeFirewallFunctionsOptions"
         :wafRulesOptions="wafRulesOptions"
         :listNetworkListService="listNetworkListService"
+        :loadNetworkListService="loadNetworkListService"
       />
     </template>
   </EditDrawerBlock>

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -467,8 +467,8 @@
   const setNetworkListOptions = async () => {
     try {
       loadingNetworkList.value = true
-      const result = await props.listNetworkListService()
-      networkListOptions.value = result
+      const result = await props.listNetworkListService({ allResults: true })
+      networkListOptions.value = result?.body || []
     } catch (error) {
       toast.add({
         closable: true,

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -1,6 +1,7 @@
 <script setup>
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
   import FieldDropdown from '@/templates/form-fields-inputs/fieldDropdown.vue'
+  import FieldDropdownLazyLoader from '@/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue'
   import FieldDropdownIcon from '@/templates/form-fields-inputs/fieldDropdownIcon.vue'
   import FieldNumber from '@/templates/form-fields-inputs/fieldNumber.vue'
   import FieldSwitchBlock from '@/templates/form-fields-inputs/fieldSwitchBlock'
@@ -9,10 +10,7 @@
   import Divider from 'primevue/divider'
   import PrimeMenu from 'primevue/menu'
   import { useFieldArray } from 'vee-validate'
-  import { computed, nextTick, ref } from 'vue'
-  import { useToast } from 'primevue/usetoast'
-
-  const toast = useToast()
+  import { computed, nextTick, ref, onMounted } from 'vue'
 
   defineOptions({
     name: 'edge-firewall-rules-engine-form-fields'
@@ -34,6 +32,10 @@
     listNetworkListService: {
       type: Function,
       required: true
+    },
+    loadNetworkListService: {
+      type: Function,
+      required: true
     }
   })
 
@@ -53,6 +55,20 @@
   const conditionalMenuRef = ref({})
   const criteriaMenuRef = ref({})
   const { push: pushCriteria, remove: removeCriteria, fields: criteria } = useFieldArray('criteria')
+  const networkList = ref([])
+
+  onMounted(async () => {
+    await listNetworkList()
+  })
+
+  const listNetworkList = async () => {
+    networkList.value = await props.listNetworkListService({
+      ordering: 'name',
+      pageSize: 100,
+      page: 1
+    })
+    return networkList.value
+  }
 
   const getOperatorsOptionsByCriteriaVariable = ({ criteriaIndex, criteriaInnerRowIndex }) => {
     const criteriaVariable = criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable
@@ -160,11 +176,6 @@
   const showNetworkListDropdownField = ({ criteriaIndex, criteriaInnerRowIndex }) => {
     const criteriaVariable = criteria.value[criteriaIndex].value[criteriaInnerRowIndex].variable
     const isCriteriaNetworkSelected = criteriaVariable === '${network}'
-    const hasNetworkOptionsToSelect = networkListOptions.value.length
-
-    if (isCriteriaNetworkSelected && !hasNetworkOptionsToSelect) {
-      setNetworkListOptions()
-    }
 
     return isCriteriaNetworkSelected
   }
@@ -462,24 +473,6 @@
     return !optionsThatEnableAddBehaviors.includes(lastBehavior.value.name)
   })
 
-  const networkListOptions = ref([])
-  const loadingNetworkList = ref(false)
-  const setNetworkListOptions = async () => {
-    try {
-      loadingNetworkList.value = true
-      const result = await props.listNetworkListService({ allResults: true })
-      networkListOptions.value = result?.body || []
-    } catch (error) {
-      toast.add({
-        closable: true,
-        severity: 'error',
-        summary: error
-      })
-    } finally {
-      loadingNetworkList.value = false
-    }
-  }
-
   const clearCriteriaArgument = ({
     selectedCriteriaVariable,
     criteriaIndex,
@@ -621,19 +614,19 @@
                 class="w-full"
                 :disabled="!criteria[criteriaIndex].value[criteriaInnerRowIndex].operator"
               />
-              <FieldDropdown
+              <FieldDropdownLazyLoader
                 v-if="showNetworkListDropdownField({ criteriaIndex, criteriaInnerRowIndex })"
                 :data-testid="`edge-firewall-rules-form__network-list[${criteriaInnerRowIndex}]`"
                 :name="`criteria[${criteriaIndex}][${criteriaInnerRowIndex}].argument`"
-                :options="networkListOptions"
-                :loading="loadingNetworkList"
+                :service="listNetworkListService"
+                :loadService="loadNetworkListService"
                 placeholder="Select a Network"
                 optionLabel="name"
-                optionValue="stringId"
-                v-bind:value="criteria[criteriaIndex].value[criteriaInnerRowIndex].argument"
+                optionValue="id"
+                :value="Number(criteria[criteriaIndex].value[criteriaInnerRowIndex].argument)"
                 inputClass="w-full"
-                :filter="true"
                 :disabled="!criteria[criteriaIndex].value[criteriaInnerRowIndex].operator"
+                :initalData="networkList"
               />
             </div>
           </div>

--- a/src/views/EdgeFirewallRulesEngine/ListView.vue
+++ b/src/views/EdgeFirewallRulesEngine/ListView.vue
@@ -65,6 +65,10 @@
       type: Function,
       required: true
     },
+    loadNetworkListService: {
+      type: Function,
+      required: true
+    },
     reorderRulesEngine: {
       type: Function,
       required: true
@@ -247,6 +251,7 @@
     :loadService="loadEdgeFirewallRulesEngineService"
     :editService="editEdgeFirewallRulesEngineService"
     :listNetworkListService="listNetworkListService"
+    :loadNetworkListService="loadNetworkListService"
     @onSuccess="reloadList"
   />
 


### PR DESCRIPTION
## Bug fix
fix: criteria empty argument in edge firewall rules engine

### Explain what was fixed and the correct behavior.
should load arguments in edge firewall rules engine

### Does this PR introduce UI changes? Add a video or screenshots here.
https://jam.dev/c/3f302aa3-b026-45b2-a340-94c11c284782

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
