### PR TITLE
[UXE-6068] fix: ensuring that the behavior is a string

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -853,7 +853,7 @@
                 optionLabel="name"
                 optionValue="id"
                 :key="behaviorItem.key"
-                :value="behaviors[behaviorIndex].value.cacheId"
+                :value="`${behaviors[behaviorIndex].value.cacheId}`"
                 :data-testid="`edge-application-rule-form__cache-settings-item[${behaviorIndex}]`"
               >
                 <template #footer>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
set cache police behavior should be rendered even when api returns int

### Does this PR introduce UI changes? Add a video or screenshots here.
No
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
