### PR TITLE
[UXE-6039] fix: adjust alignment fields of criteria in edge firewall rules engine

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdown.vue
+++ b/src/templates/form-fields-inputs/fieldDropdown.vue
@@ -128,6 +128,7 @@
     :label="props.label"
     :isRequired="$attrs.required"
     :data-testid="customTestId.label"
+    v-if="props.label"
   />
   <Dropdown
     appendTo="self"

--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
@@ -4,6 +4,7 @@
     :label="props.label"
     :isRequired="$attrs.required"
     :data-testid="customTestId.label"
+    v-if="props.label"
   />
   <Dropdown
     appendTo="self"

--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -4,6 +4,7 @@
     :label="props.label"
     :isRequired="$attrs.required"
     :data-testid="customTestId.label"
+    v-if="props.label"
   />
   <Dropdown
     appendTo="self"

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -553,7 +553,9 @@
             />
           </div>
 
-          <div class="flex items-top gap-x-2 items-top mt-2 mb-4 flex-col sm:flex-row">
+          <div
+            class="flex items-top gap-x-2 items-top mt-2 mb-4 flex-col gap-2 sm:flex-row items-end"
+          >
             <div class="flex flex-col h-fit sm:max-w-lg w-full gap-2">
               <FieldDropdownIcon
                 :data-testid="`edge-firewall-rules-form__variable[${criteriaInnerRowIndex}]`"


### PR DESCRIPTION
## Bug fix
fix: adjust alignment fields of criteria in edge firewall rules engine
### Explain what was fixed and the correct behavior.
should render with alignment correct

### Does this PR introduce UI changes? Add a video or screenshots here.
![image](https://github.com/user-attachments/assets/a7e75d2b-4d3e-4fd3-836c-867d1adcc2d5)
![image](https://github.com/user-attachments/assets/c8adb06c-dfdd-44ea-9a56-f1e3c4c38a5b)

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
