### PR TITLE
[UXE-6217] fix: args is not being loaded in edge firewall and edge app

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoader.vue
@@ -180,7 +180,6 @@
 
   onMounted(async () => {
     await fetchData()
-    loadSelectedValue(props.value)
   })
 
   const hasDescriptionSlot = !!slots.description


### PR DESCRIPTION
## Bug fix
fix: args is not being loaded in edge firewall and edge application

### Explain what was fixed and the correct behavior.
Should render correct arguments in edge firewall and edge application

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
