### PR TITLE
[UXE-5949] chore: downgrade Azion CLI version to 1.36.1 in deployment workflow

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Download Azion CLI
         run: |
-          wget https://github.com/aziontech/azion/releases/download/2.5.3/azion_2.5.3_linux_amd64.apk
-          apk add --allow-untrusted azion_2.5.3_linux_amd64.apk
+          wget https://github.com/aziontech/azion/releases/download/1.36.1/azion_1.36.1_linux_amd64.apk
+          apk add --allow-untrusted azion_1.36.1_linux_amd64.apk
 
       - name: Configure Azion CLI
         run: azion -t ${{ secrets.PLATFORM_KIT_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/deploy-stage.yml` file to update the version of the Azion CLI being downloaded and installed.

* Updated the Azion CLI version from `2.5.3` to `1.36.1` in the `jobs:` section of the `.github/workflows/deploy-stage.yml` file.