### PR TITLE
[UXE-6402] feat: implement banner visibility logic based on FORCE_REDIRECT_TO_CONSOLE flag

### DIFF
--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -21,7 +21,8 @@ export const useAccountStore = defineStore({
       SSO_MANAGEMENT: 'federated_auth',
       DATA_STREAM_SAMPLING: 'data_streaming_sampling',
       MARKETPLACE_PRODUCTS: 'marketplace_products',
-      HIDE_CREATE_OPTIONS: 'hide_create_options'
+      HIDE_CREATE_OPTIONS: 'hide_create_options',
+      FORCE_REDIRECT_TO_CONSOLE: 'force_redirect_to_console'
     }
   }),
   getters: {
@@ -60,6 +61,10 @@ export const useAccountStore = defineStore({
     hasAccessConsole(state) {
       const { client_flags = [], isDeveloperSupportPlan } = state.account
       return client_flags.includes(state.flags.FULL_CONSOLE_ACCESS) || !!isDeveloperSupportPlan
+    },
+    isBannerVisible(state) {
+      const { client_flags = [] } = state.account
+      return !client_flags.includes(state.flags.FORCE_REDIRECT_TO_CONSOLE)
     },
     currentTheme(state) {
       return state.account?.colorTheme

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -42,7 +42,8 @@
   const router = useRouter()
   const route = useRoute()
   const dialog = useDialog()
-  const user = useAccountStore().accountData
+  const { accountData, isBannerVisible } = useAccountStore()
+  const user = accountData
 
   const teams = ref([])
   const showInviteSession = ref(props.inviteSession.show())
@@ -135,6 +136,7 @@
     <template #content>
       <section class="w-full flex flex-col gap-6 lg:gap-8">
         <InlineMessage
+          v-if="isBannerVisible"
           class="p-3 gap-1"
           severity="info"
           data-testid="message-deprecation"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request includes changes to the `src/stores/account.js` and `src/views/Home/HomeView.vue` files. The main focus of these changes is to introduce a new feature flag and utilize it to control the visibility of a banner on the home view.

Feature flag additions and usage:

* [`src/stores/account.js`](diffhunk://#diff-5ed700a1574dab2e3c695a0c0d661d6e97c4f9d389a12fc15e3f94a9ad8bd4cbL24-R25): Added a new feature flag `FORCE_REDIRECT_TO_CONSOLE` to the `flags` object and implemented a new getter `isBannerVisible` to determine the visibility of a banner based on this flag. [[1]](diffhunk://#diff-5ed700a1574dab2e3c695a0c0d661d6e97c4f9d389a12fc15e3f94a9ad8bd4cbL24-R25) [[2]](diffhunk://#diff-5ed700a1574dab2e3c695a0c0d661d6e97c4f9d389a12fc15e3f94a9ad8bd4cbR65-R68)

Home view modifications:

* [`src/views/Home/HomeView.vue`](diffhunk://#diff-01d730d78411fcdbec8996b9983bfe06336d59183f2b15c6b2e1b1f2cc123e70L45-R46): Updated the usage of `useAccountStore` to include the `isBannerVisible` getter and conditionally rendered the `InlineMessage` component based on the value of `isBannerVisible`. [[1]](diffhunk://#diff-01d730d78411fcdbec8996b9983bfe06336d59183f2b15c6b2e1b1f2cc123e70L45-R46) [[2]](diffhunk://#diff-01d730d78411fcdbec8996b9983bfe06336d59183f2b15c6b2e1b1f2cc123e70R139)

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
NO
### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
