### PR TITLE
[UXE-6411] refactor:  add null value to cipher suite option and minimum tls version

### DIFF
--- a/src/services/domains-services/v4/create-domain-service.js
+++ b/src/services/domains-services/v4/create-domain-service.js
@@ -59,10 +59,11 @@ const adapt = (payload) => {
     dataRequest.tls.certificate = payload.edgeCertificate
   }
   if (payload.supportedCiphers && payload.useHttps) {
-    dataRequest.tls.ciphers = payload.supportedCiphers === 'all' ? null : payload.supportedCiphers
+    dataRequest.tls.ciphers = payload.supportedCiphers === 'null' ? null : payload.supportedCiphers
   }
   if (payload.minimumTlsVersion && payload.useHttps) {
-    dataRequest.tls.minimum_version = payload.minimumTlsVersion
+    dataRequest.tls.minimum_version =
+      payload.minimumTlsVersion === 'null' ? null : payload.minimumTlsVersion
   }
 
   return dataRequest

--- a/src/services/domains-services/v4/edit-domain-service.js
+++ b/src/services/domains-services/v4/edit-domain-service.js
@@ -34,7 +34,8 @@ const adapt = (payload) => {
     alternate_domains: payload.cnames.split('\n').filter((item) => item !== ''),
     active: payload.active,
     tls: {
-      minimum_version: null
+      minimum_version: null,
+      ciphers: null
     },
     protocols: {
       http: {

--- a/src/services/domains-services/v4/edit-domain-service.js
+++ b/src/services/domains-services/v4/edit-domain-service.js
@@ -60,10 +60,11 @@ const adapt = (payload) => {
     dataRequest.tls.certificate = payload.edgeCertificate
   }
   if (payload.supportedCiphers && payload.useHttps) {
-    dataRequest.tls.ciphers = payload.supportedCiphers === 'all' ? null : payload.supportedCiphers
+    dataRequest.tls.ciphers = payload.supportedCiphers === 'null' ? null : payload.supportedCiphers
   }
   if (payload.minimumTlsVersion && payload.useHttps) {
-    dataRequest.tls.minimum_version = payload.minimumTlsVersion
+    dataRequest.tls.minimum_version =
+      payload.minimumTlsVersion === 'null' ? null : payload.minimumTlsVersion
   }
 
   return dataRequest

--- a/src/services/domains-services/v4/load-domain-service.js
+++ b/src/services/domains-services/v4/load-domain-service.js
@@ -69,8 +69,8 @@ const adapt = (httpResponse) => {
     httpsPort: handlerHttp(body.protocols.http.https_ports, HTTPS_PORT_LIST_OPTIONS),
     quicPort: handlerHttp(body.protocols.http.quic_ports, HTTP3_PORT_LIST_OPTIONS),
     httpPort: handlerHttp(body.protocols.http.http_ports, HTTP_PORT_LIST_OPTIONS),
-    supportedCiphers: body.tls.ciphers,
-    minimumTlsVersion: body.tls.minimum_version
+    supportedCiphers: String(body.tls.ciphers),
+    minimumTlsVersion: String(body.tls.minimum_version)
   }
 
   return {

--- a/src/tests/services/domains-services/v4/edit-domain-service.test.js
+++ b/src/tests/services/domains-services/v4/edit-domain-service.test.js
@@ -172,7 +172,8 @@ describe('DomainsServicesV4', () => {
         active: fixtures.domainMock.active,
         tls: {
           certificate: fixtures.domainMock.edgeCertificate,
-          minimum_version: null
+          minimum_version: null,
+          ciphers: null
         },
         protocols: {
           http: {

--- a/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
@@ -97,14 +97,14 @@
     { name: '8090', value: 8090 }
   ]
   const TLS_VERSIONS_OPTIONS = [
-    { label: 'None', value: 'none' },
+    { label: 'None', value: 'null' },
     { label: 'TLS 1.0', value: 'tls_1_0' },
     { label: 'TLS 1.1', value: 'tls_1_1' },
     { label: 'TLS 1.2', value: 'tls_1_2' },
     { label: 'TLS 1.3', value: 'tls_1_3' }
   ]
   const SUPPORTED_CIPHERS_LIST_OPTIONS = [
-    { label: 'All', value: 'all' },
+    { label: 'All', value: 'null' },
     { label: 'TLSv1.2_2018', value: 'TLSv1.2_2018' },
     { label: 'TLSv1.2_2019', value: 'TLSv1.2_2019' },
     { label: 'TLSv1.2_2021', value: 'TLSv1.2_2021' },

--- a/src/views/Domains/FormFields/FormFieldsEditDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsEditDomains.vue
@@ -80,14 +80,14 @@
     { name: '8090', value: 8090 }
   ]
   const TLS_VERSIONS_OPTIONS = [
-    { label: 'None', value: 'none' },
+    { label: 'None', value: 'null' },
     { label: 'TLS 1.0', value: 'tls_1_0' },
     { label: 'TLS 1.1', value: 'tls_1_1' },
     { label: 'TLS 1.2', value: 'tls_1_2' },
     { label: 'TLS 1.3', value: 'tls_1_3' }
   ]
   const SUPPORTED_CIPHERS_LIST_OPTIONS = [
-    { label: 'All', value: 'all' },
+    { label: 'All', value: 'null' },
     { label: 'TLSv1.2_2018', value: 'TLSv1.2_2018' },
     { label: 'TLSv1.2_2019', value: 'TLSv1.2_2019' },
     { label: 'TLSv1.2_2021', value: 'TLSv1.2_2021' },
@@ -152,6 +152,12 @@
   watch(useHttp3, (newValue) => {
     if (newValue) {
       quicPort.value = HTTP3_PORT_LIST_OPTIONS
+    }
+  })
+
+  watch(useHttps, (newValue) => {
+    if (newValue && !httpsPort.value) {
+      httpsPort.value = [HTTPS_PORT_LIST_OPTIONS[0]]
     }
   })
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-6411] refactor: add null value to cipher suite option and minimum tls version

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/763ecc90-2a6a-42b4-914c-7e3af56d6021


### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave


[UXE-6411]: https://aziontech.atlassian.net/browse/UXE-6411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ