### PR TITLE
[NO-ISSUE] chore: add rules engine manually in IAC

### DIFF
--- a/azion/production/azion.json
+++ b/azion/production/azion.json
@@ -2,7 +2,6 @@
   "name": "console_kit_31-07-2024",
   "bucket": "consolekit31-07-2024",
   "preset": "vue",
-  "mode": "deliver",
   "env": "production",
   "prefix": "20240731102422",
   "not-first-run": true,
@@ -162,6 +161,41 @@
         "id": 318350,
         "name": "Route GraphQL Accounting Queries to Manager Origin",
         "phase": "request"
+      },
+      {
+        "id": 364147,
+        "name": "Route SIEM Azion (BB)",
+        "phase": "request"
+      },
+      {
+        "id": 368275,
+        "name": "Rewrite azrt Cookie in azion.com",
+        "phase": "response"
+      },
+      {
+        "id": 368276,
+        "name": "Rewrite azrt Cookie in azionedge.net",
+        "phase": "response"
+      },
+      {
+        "id": 368277,
+        "name": "Rewrite azsid Cookie in azion.com",
+        "phase": "response"
+      },
+      {
+        "id": 368278,
+        "name": "Rewrite azsid Cookie in azionedge.net",
+        "phase": "response"
+      },
+      {
+        "id": 368279,
+        "name": "Rewrite azat Cookie in azion.com",
+        "phase": "response"
+      },
+      {
+        "id": 368280,
+        "name": "Rewrite azat Cookie in azionedge.net",
+        "phase": "response"
       }
     ]
   },

--- a/azion/production/azion.json
+++ b/azion/production/azion.json
@@ -163,11 +163,6 @@
         "phase": "request"
       },
       {
-        "id": 364147,
-        "name": "Route SIEM Azion (BB)",
-        "phase": "request"
-      },
-      {
         "id": 368275,
         "name": "Rewrite azrt Cookie in azion.com",
         "phase": "response"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request includes updates to the `azion/production/azion.json` file to enhance routing and cookie rewriting configurations. The most important changes include the removal of the `mode` property and the addition of several new routing rules.

Configuration updates:

* Removed the `mode` property from the configuration.

Routing rules enhancements:

* Added new routing rules for various phases, including requests and responses. These rules cover routing for SIEM Azion (BB) and rewriting cookies (`azrt`, `azsid`, `azat`) for both `azion.com` and `azionedge.net` domains.

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
NO
### Does it have a link on Figma?
NO

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
