### PR TITLE
[NO-ISSUE] chore: add debug flag to deployment command in production workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,7 +31,7 @@ jobs:
         run: azion -t ${{ secrets.PLATFORM_KIT_TOKEN }}
 
       - name: Build & Deploy
-        run: azion deploy --auto --local --config-dir azion/production
+        run: azion deploy --auto --local --debug --config-dir azion/production
         env:
           VITE_STRIPE_TOKEN_PROD: ${{ secrets.PROD_STRIPE_TOKEN }}
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.PROD_RECAPTCHA_SITE_KEY }}


### PR DESCRIPTION
This pull request includes a minor change to the deployment workflow configuration in the `.github/workflows/deploy-production.yml` file. The change adds a debug flag to the `azion deploy` command to enable more detailed logging during the deployment process.

* [`.github/workflows/deploy-production.yml`](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94L34-R34): Added `--debug` flag to the `azion deploy` command to enable detailed logging.