### PR TITLE
[NO-ISSUE] feat: add gzip enable rule to rules engine configuration

### DIFF
--- a/azion/production/azion.json
+++ b/azion/production/azion.json
@@ -73,6 +73,11 @@
     "created": false,
     "rules": [
       {
+        "id": 269747,
+        "name": "enable gzip",
+        "phase": "response"
+      },
+      {
         "id": 269748,
         "name": "Apply Common Configuration for All Requests",
         "phase": "request"


### PR DESCRIPTION
This pull request includes a change to the `azion/production/azion.json` file, adding a new rule to the rules engine configuration.

Configuration Update:

* [`azion/production/azion.json`](diffhunk://#diff-833eec6e5fc3266bdc84658afe15142471143bc31f5f7d60ad5f29668b94fadbR75-R79): Added a new rule with ID 269747 to enable gzip during the response phase.