### PR TITLE
[NO-ISSUE] refactor: enhance stage environment handling for origin cities

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -1,17 +1,22 @@
 import { defineConfig } from 'azion'
 import process from 'node:process'
 
-const { CROSS_EDGE_SECRET, VITE_ENVIRONMENT } = process.env;
+const { CROSS_EDGE_SECRET, VITE_ENVIRONMENT } = process.env
 
 const environment = VITE_ENVIRONMENT || 'production'
 
 const addStagePrefix = (origin) => {
   if (environment === 'stage') {
-    return origin?.map((origin) => ({
-      ...origin,
-      hostHeader: `stage-${origin.hostHeader}`,
-      addresses: origin.addresses?.map((addr) => `stage-${addr}`)
-    }))
+    return origin?.map(({ hostHeader, addresses, ...rest }) => {
+      const isCitiesDomain = hostHeader === 'cities.azion.com'
+      const transform = (addr) => `stage-${isCitiesDomain ? addr.replace('.com', '.net') : addr}`
+
+      return {
+        ...rest,
+        hostHeader: transform(hostHeader),
+        addresses: addresses?.map(transform)
+      }
+    })
   }
   return origin
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ import istanbul from 'vite-plugin-istanbul'
 const getConfig = () => {
   const env = loadEnv('development', process.cwd())
   const URLStartPrefix = env.VITE_ENVIRONMENT === 'production' ? 'https://' : 'https://stage-'
+  const DomainSuffix = env.VITE_ENVIRONMENT === 'production' ? 'com' : 'net'
 
   return {
     plugins: [
@@ -45,7 +46,7 @@ const getConfig = () => {
           rewrite: (path) => path.replace(/^\/api\/vcs/, '/vcs/api')
         },
         '/graphql/cities': {
-          target: `${URLStartPrefix}cities.azion.com`,
+          target: `${URLStartPrefix}cities.azion.${DomainSuffix}`,
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/graphql\/cities/, '/graphql')
         },


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request includes changes to improve the handling of environment-specific configurations and domain transformations in the project. The most important changes include modifying the `azion.config.mjs` file to handle stage-specific domain transformations more effectively and updating the `vite.config.js` file to dynamically set domain suffixes based on the environment.

Improvements to environment-specific configurations:

* [`azion.config.mjs`](diffhunk://#diff-ebc6e887876c44245c813b133d1625750c81b15fa29591b239a6c220aefc35c7L4-R19): Enhanced the `addStagePrefix` function to handle stage-specific domain transformations, including a special case for the 'cities.azion.com' domain.

Updates to domain handling in configuration:

* [`vite.config.js`](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26R12): Added `DomainSuffix` to dynamically set the domain suffix based on the environment (`production` or `stage`).
* [`vite.config.js`](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L48-R49): Updated the target URL for the `/graphql/cities` proxy to use the new `DomainSuffix` variable for environment-specific domain handling.

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
NO

### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
