### PR TITLE
[UXE-6467] fix: allow account settings access during payment review

### DIFF
--- a/src/router/hooks/guards/billingGuard.js
+++ b/src/router/hooks/guards/billingGuard.js
@@ -26,6 +26,9 @@ export async function billingGuard({ to, accountStore }) {
         return true
       }
     } else if (paymentReviewPending) {
+      if (to.name === 'account-settings') {
+        return true
+      }
       return BILLING_REDIRECT_OPTIONS
     }
   }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
This pull request includes a small change to the `billingGuard` function in the `src/router/hooks/guards/billingGuard.js` file. The change allows navigation to the 'account-settings' route even if a payment review is pending.

* [`src/router/hooks/guards/billingGuard.js`](diffhunk://#diff-a0954bd42eccb244c3dbac572b222e158217edfff9a88c9485befe7d4f41466dR29-R31): Added a condition to allow access to the 'account-settings' route when `paymentReviewPending` is true.

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
