### PR TITLE
[UXE-6468] feat: add banner for redirect Real-Time Manager 

### DIFF
--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -12,6 +12,9 @@
   import DialogOnboardingScheduling from '@/templates/dialogs-block/dialog-onboarding-scheduling.vue'
   import CreateFormBlock from '@/templates/create-form-block'
   import { useLayout } from '@/composables/use-layout'
+  import InlineMessage from 'primevue/inlinemessage'
+  import { getStaticUrlsByEnvironment } from '@/helpers'
+
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
 
@@ -39,7 +42,7 @@
   const router = useRouter()
   const route = useRoute()
   const dialog = useDialog()
-  const { accountData } = useAccountStore()
+  const { accountData, isBannerVisible } = useAccountStore()
   const user = accountData
 
   const teams = ref([])
@@ -113,6 +116,12 @@
     }
   }
 
+  const openRTM = async () => {
+    const urlEOL = getStaticUrlsByEnvironment('managerEOL')
+    await tracker.product.clickedTo({ target: 'RTM' }).track()
+    window.location.href = `${urlEOL}?disableRedirect=true`
+  }
+
   onMounted(async () => {
     teams.value = await props.listTeamsService()
     showOnboardingSchedulingDialog()
@@ -126,6 +135,25 @@
   <ContentBlock>
     <template #content>
       <section class="w-full flex flex-col gap-6 lg:gap-8">
+        <InlineMessage
+          v-if="isBannerVisible"
+          class="p-3 gap-1"
+          severity="info"
+          data-testid="message-deprecation"
+        >
+          Azion Console is now the primary way to access Azion's platform.
+          <PrimeButton
+            label="Real-Time Manager (RTM)"
+            @click="openRTM"
+            iconPos="right"
+            class="p-0"
+            size="small"
+            link
+          />
+          will be deprecated soon, and access will only be available for a limited time through this
+          link.
+        </InlineMessage>
+
         <div
           v-if="showExperimental"
           class="w-full p-3 surface-border border rounded-md flex flex-col gap-4 justify-between items-center sm:flex-row sm:p-8 lg:gap-10"


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request introduces changes to the `HomeView.vue` file, focusing on adding new imports, updating the state management, and implementing a new inline message component for user notifications.

### Key Changes:

#### New Imports:
* Added `InlineMessage` from `primevue/inlinemessage` and `getStaticUrlsByEnvironment` from `@/helpers`.

#### State Management:
* Updated the state management to include `isBannerVisible` from `useAccountStore`.

#### New Function:
* Implemented `openRTM` function to handle redirection to a specific URL with tracking.

#### UI Enhancements:
* Added an `InlineMessage` component to display a deprecation notice for the Real-Time Manager (RTM) with a button to access it.

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
