### PR TITLE
[NO-ISSUE] chore: remove GraphQL Billing and Accounting route configurations

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -123,11 +123,6 @@
         "phase": "request"
       },
       {
-        "id": 277559,
-        "name": "Route GraphQL Billing Queries to Manager Origin",
-        "phase": "request"
-      },
-      {
         "id": 277563,
         "name": "Secure Headers",
         "phase": "response"
@@ -140,11 +135,6 @@
       {
         "id": 312030,
         "name": "Route API Identity Providers",
-        "phase": "request"
-      },
-      {
-        "id": 317377,
-        "name": "Route GraphQL Accounting Queries to Manager Origin",
         "phase": "request"
       },
       {

--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -2,7 +2,6 @@
   "name": "console-kit-2024-08-21-stage",
   "bucket": "console-kit-2024-08-21-stage",
   "preset": "vue",
-  "mode": "deliver",
   "env": "production",
   "prefix": "20240821142547",
   "not-first-run": true,
@@ -177,6 +176,11 @@
         "id": 368018,
         "name": "Rewrite azat Cookie in azionedge.net",
         "phase": "response"
+      },
+      {
+        "id": 371432,
+        "name": "API Version 4 Routing",
+        "phase": "request"
       }
     ]
   },


### PR DESCRIPTION
This pull request includes several changes to the `azion/stage/azion.json` file, focusing on modifying routing rules and removing the `mode` property. The most important changes are summarized below:

Changes to routing rules:

* Removed the routing rule for "GraphQL Billing Queries to Manager Origin".
* Removed the routing rule for "GraphQL Accounting Queries to Manager Origin".
* Added a new routing rule for "API Version 4 Routing".

Other changes:

* Removed the `mode` property from the configuration.