### PR TITLE
[NO-ISSUE] fix: update getTotalRecords service with baseURL configuration

### DIFF
--- a/src/services/real-time-events-service/get-total-records.js
+++ b/src/services/real-time-events-service/get-total-records.js
@@ -11,6 +11,7 @@ export const getTotalRecords = async ({ filter, dataset }) => {
   const decorator = new AxiosHttpClientSignalDecorator()
 
   const httpResponse = await decorator.request({
+    baseURL: '/',
     url: makeRealTimeEventsBaseUrl(),
     method: 'POST',
     body: payload

--- a/src/tests/services/real-time-events-service/get-total-records.test.js
+++ b/src/tests/services/real-time-events-service/get-total-records.test.js
@@ -56,6 +56,7 @@ describe('getTotalRecords', () => {
       url: 'v4/events/graphql',
       method: 'POST',
       signal: undefined,
+      baseURL: '/',
       body: {
         query,
         variables: {


### PR DESCRIPTION
This pull request includes updates to the `getTotalRecords` function and its corresponding test to add a `baseURL` parameter to the HTTP request configuration.

Changes include:

* [`src/services/real-time-events-service/get-total-records.js`](diffhunk://#diff-0527528c5005aa009de9b4ab881d3fe3282f7d72509876817f49a4310231e1f1R14): Added `baseURL: '/'` to the HTTP request configuration in the `getTotalRecords` function.
* [`src/tests/services/real-time-events-service/get-total-records.test.js`](diffhunk://#diff-b4f87b5372e7f3b3cb325b0ed6140ed35a889d4e533cfcb98500fb2c84d005d2R59): Added `baseURL: '/'` to the expected HTTP request configuration in the `getTotalRecords` test.