### PR TITLE
[UXE-6093] fix: adjust origin_id handling in error responses service

### DIFF
--- a/src/services/edge-application-error-responses-services/edit-error-responses-service.js
+++ b/src/services/edge-application-error-responses-services/edit-error-responses-service.js
@@ -33,8 +33,9 @@ const adapt = (payload) => {
       })
     }
   })
+  
   return {
-    origin_id: payload.originId,
+    origin_id: errorResponses.length === 1 ? null : payload.originId,
     error_responses: errorResponses
   }
 }

--- a/src/tests/services/edge-application-error-responses/edit-error-responses-services.test.js
+++ b/src/tests/services/edge-application-error-responses/edit-error-responses-services.test.js
@@ -63,7 +63,7 @@ describe('EdgeApplicationErrorResponsesServices', () => {
             uri: errorResponse.uri
           }
         ],
-        origin_id: fixtures.errorResponsePayload.originId
+        origin_id: null
       }
     })
   })
@@ -90,7 +90,7 @@ describe('EdgeApplicationErrorResponsesServices', () => {
             uri: null
           }
         ],
-        origin_id: fixtures.errorResponsePayload.originId
+        origin_id: null
       }
     })
   })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -33,7 +33,8 @@ export default mergeConfig(
           'src/views/**',
           'src/helpers/**',
           'src/plugins/**',
-          'src/modules/**'
+          'src/modules/**',
+          '!src/modules/azion-ai-chat/**'
         ],
         statements: 91,
         branches: 91,


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request includes changes to the error response handling in the `EdgeApplicationErrorResponsesServices` and updates to the test cases and configuration files. The most important changes include modifying the `adapt` function to handle cases with a single error response, updating test cases to reflect this change, and excluding a specific module from the coverage configuration.

Changes to error response handling:

* [`src/services/edge-application-error-responses-services/edit-error-responses-service.js`](diffhunk://#diff-7cedd672c270b2dd3f0253abe4fb57c76fa58c0142773f625e7f4ef1d312b300R36-R38): Modified the `adapt` function to set `origin_id` to `null` if there is only one error response.

Updates to test cases:

* [`src/tests/services/edge-application-error-responses/edit-error-responses-services.test.js`](diffhunk://#diff-2a70e5e4dc6de7c4b257fa8360668f8d5571652da234ae9215ecf3387da0b3a0L66-R66): Updated test cases to expect `origin_id` to be `null`. [[1]](diffhunk://#diff-2a70e5e4dc6de7c4b257fa8360668f8d5571652da234ae9215ecf3387da0b3a0L66-R66) [[2]](diffhunk://#diff-2a70e5e4dc6de7c4b257fa8360668f8d5571652da234ae9215ecf3387da0b3a0L93-R93)


### Does this PR introduce breaking changes?

- [ ] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [ ] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
