### PR TITLE
[NO-ISSUE] chore: Reduce Real Time Events limits (Http Requests)

### DIFF
--- a/src/services/real-time-events-service/http-request/list-http-request.js
+++ b/src/services/real-time-events-service/http-request/list-http-request.js
@@ -26,7 +26,7 @@ export const listHttpRequest = async (filter) => {
 const adapt = (filter) => {
   const table = {
     dataset: 'httpEvents',
-    limit: 10000,
+    limit: 1000,
     fields: [
       'configurationId',
       'host',

--- a/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
+++ b/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
@@ -45,7 +45,7 @@ describe('HttpRequestServices', () => {
       `\t$tsRange_end: DateTime!`,
       `) {`,
       `\t${datasetName} (`,
-      `\t\tlimit: 10000`,
+      `\t\tlimit: 1000`,
       `\t\torderBy: [ts_DESC]`,
       `\t\tfilter: {`,
       `\t\t\ttsRange: { begin: $tsRange_begin, end: $tsRange_end }`,


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Most of the time, Errors on GraphQL events API  occours because timeout or size of the response in list of http events.
There is no need to fetch 10.000 lines with no filter and show in a UI. No user will search manually through 100 pages of 100 records.
So If there is no good argument for this limit be 10k, let's reduce it to 1k. That means: 100 pages of 10 records or 10  pages of 100. If the user need to find something specific, he will use filters.

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
No

### Does it have a link on Figma?
No

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
