### PR TITLE
[UXE-6469] fix: allow users without WAF or NL permissions to edit Rule in EF

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -55,6 +55,7 @@
             v-model="search"
             placeholder="Search"
             class="w-full rounded-r-none"
+            :disabled="!hasServiceAccess"
             ref="focusSearch"
             :data-testid="customTestId.search"
           />
@@ -172,6 +173,7 @@
   const SEARCH_MAX_WAIT = 1000
   const NUMBER_OF_CHARACTERS_MIN_FOR_SEARCH = 3
   const NUMBER_OF_CHARACTERS_TO_RESET_SEARCH = 0
+  const hasServiceAccess = ref(true)
 
   const name = toRef(props, 'name')
   const slots = useSlots()
@@ -311,6 +313,13 @@
         return
       }
       emitChange()
+    } catch {
+      const newOption = {
+        [props.optionLabel]: id,
+        [props.optionValue]: id
+      }
+      data.value = [newOption, ...data.value]
+      hasServiceAccess.value = false
     } finally {
       loading.value = false
     }

--- a/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
+++ b/src/views/EdgeFirewallRulesEngine/Drawer/index.vue
@@ -63,7 +63,6 @@
   const DEBOUNCE_TIME_IN_MS = 300
   const selectedRulesEngineToEdit = ref('')
   const edgeFirewallFunctionsOptions = ref([])
-  const wafRulesOptions = ref([])
 
   const showCreateDrawer = refDebounced(showCreateRulesEngineDrawer, DEBOUNCE_TIME_IN_MS)
   const showEditDrawer = refDebounced(showEditRulesEngineDrawer, DEBOUNCE_TIME_IN_MS)
@@ -217,19 +216,6 @@
     }
   }
 
-  const listWafRulesOptions = async () => {
-    try {
-      const result = await props.listWafRulesService()
-      wafRulesOptions.value = result
-    } catch (error) {
-      toast.add({
-        closable: true,
-        severity: 'error',
-        summary: error
-      })
-    }
-  }
-
   const createEdgeFirewallRulesEngineServiceWithDecorator = async (payload) => {
     return await props.createService({
       edgeFirewallId: props.edgeFirewallId,
@@ -250,7 +236,7 @@
     })
   }
   onMounted(async () => {
-    await Promise.all([listEdgeFirewallFunctionsOptions(), listWafRulesOptions()])
+    await Promise.all([listEdgeFirewallFunctionsOptions()])
   })
 
   defineExpose({
@@ -274,7 +260,7 @@
       <FormFieldsEdgeFirewallRulesEngine
         :enabledModules="edgeFirewallModules"
         :edgeFirewallFunctionsOptions="edgeFirewallFunctionsOptions"
-        :wafRulesOptions="wafRulesOptions"
+        :listWafRulesService="listWafRulesService"
         :listNetworkListService="listNetworkListService"
         :loadNetworkListService="loadNetworkListService"
       />
@@ -296,7 +282,7 @@
       <FormFieldsEdgeFirewallRulesEngine
         :enabledModules="edgeFirewallModules"
         :edgeFirewallFunctionsOptions="edgeFirewallFunctionsOptions"
-        :wafRulesOptions="wafRulesOptions"
+        :listWafRulesService="listWafRulesService"
         :listNetworkListService="listNetworkListService"
         :loadNetworkListService="loadNetworkListService"
       />


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Allow users without waf permissions to edit a rule that has a set waf rule behavior
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
