### PR TITLE
[UXE-6742] revert: domains filter back to API v3 in WAF Tuning

### DIFF
--- a/src/router/routes/waf-rules-routes/index.js
+++ b/src/router/routes/waf-rules-routes/index.js
@@ -1,7 +1,7 @@
 import * as Helpers from '@/helpers'
 import * as WafRulesService from '@/services/waf-rules-services'
 import * as WafRulesServiceV4 from '@/services/waf-rules-services/v4'
-import * as DomainsServiceV4 from '@/services/domains-services/v4'
+import * as DomainsService from '@/services/domains-services'
 
 import { listCountriesService } from '@/services/network-lists-services'
 
@@ -75,8 +75,8 @@ export const wafRulesRoutes = {
           listWafRulesDomainsService: WafRulesService.listWafRulesDomainsService,
           createWafRulesAllowedTuningService: WafRulesService.createWafRulesAllowedTuningService,
           listWafRulesTuningAttacksService: WafRulesService.listWafRulesTuningAttacksService,
-          listDomainsService: DomainsServiceV4.listDomainsService,
-          loadDomainService: DomainsServiceV4.loadDomainService,
+          listDomainsService: DomainsService.listDomainsService,
+          loadDomainService: DomainsService.loadDomainService,
           loadNetworkListService: WafRulesServiceV4.loadNetworkListService
         }
       },

--- a/src/router/routes/waf-rules-routes/index.js
+++ b/src/router/routes/waf-rules-routes/index.js
@@ -75,7 +75,7 @@ export const wafRulesRoutes = {
           listWafRulesDomainsService: WafRulesService.listWafRulesDomainsService,
           createWafRulesAllowedTuningService: WafRulesService.createWafRulesAllowedTuningService,
           listWafRulesTuningAttacksService: WafRulesService.listWafRulesTuningAttacksService,
-          listDomainsService: DomainsService.listDomainsService,
+          listDomainsService: WafRulesService.listWafRulesDomainsService,
           loadDomainService: DomainsService.loadDomainService,
           loadNetworkListService: WafRulesServiceV4.loadNetworkListService
         }

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -24,7 +24,7 @@
           v-model="selectedDomainIds"
           @change="setDomainsSelectedOptions"
           class="w-full sm:max-w-xs"
-           placeholder="Select domain"
+          placeholder="Select domain"
           filter
           display="chip"
           scrollHeight="250px"
@@ -168,7 +168,7 @@
   import DialogAllowRule from './Dialog'
   import MoreDetailsDrawer from './Drawer'
   import FieldDropdownLazyLoader from '@/templates/form-fields-inputs/fieldDropdownLazyLoader'
- 
+
   import ListTableBlock from '@templates/list-table-block/with-selection-behavior'
   import PrimeButton from 'primevue/button'
   import Dropdown from 'primevue/dropdown'
@@ -433,8 +433,8 @@
   }
 
   const setDomainsSelectedOptions = () => {
-    selectedFilter.value.domains = selectedDomainIds.value || [];
-    filterTuning();
+    selectedFilter.value.domains = selectedDomainIds.value || []
+    filterTuning()
   }
 
   const downloadCSV = () => {
@@ -566,37 +566,20 @@
     }
   }
 
-  const setDomainsOptions = async () => {
+  const listDomainsOptions = async () => {
     try {
-   
-      domainsOptions.value.done = false;
-      
-      const params = { fields: 'id,name,active' };
-      const response = await props.listDomainsService(params);
+      domainsOptions.value.done = false
 
-      
-      if (Array.isArray(response)) {
-        domainsOptions.value.options = response;
-      } else if (response && response.results && Array.isArray(response.results)) {
-        domainsOptions.value.options = response.results;
-      } else {
-        domainsOptions.value.options = [];
-      }
-      
+      const domains = await props.listDomainsService({ wafId: wafRuleId })
 
-    } catch (error) {
-
-      domainsOptions.value.options = [];
+      domainsOptions.value.options = domains
     } finally {
-      domainsOptions.value.done = true;
+      domainsOptions.value.done = true
     }
   }
 
   onMounted(async () => {
-    await setNetWorkListOptions();
-    await setDomainsOptions();
-
+    await setNetWorkListOptions()
+    await listDomainsOptions()
   })
-
-
 </script>

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -570,7 +570,7 @@
     try {
       domainsOptions.value.done = false
 
-      const domains = await props.listDomainsService({ wafId: wafRuleId })
+      const domains = await props.listDomainsService({ wafId: wafRuleId.value })
 
       domainsOptions.value.options = domains
     } finally {


### PR DESCRIPTION
- Replace FieldMultiselectLazyLoader with MultiSelect component for domains filter
- Use WAF Rules domain service (v3) instead of Domains service (v4)
- Add comments about future migration back to v4 API
- Keep v4 implementation commented for future reference

## Pull Request

### What is the new behavior introduced by this PR?

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
