### PR TITLE
[UXE-6718] fix: behavior not contains in Real Time Events

### DIFF
--- a/src/helpers/convert-gql.js
+++ b/src/helpers/convert-gql.js
@@ -299,7 +299,7 @@ const formatFilter = (filters) => {
     if (filter.toLocaleLowerCase().includes('ilike')) {
       const parts = filter.split(':')
       if (parts.length) {
-        const operator = parts[0].toLocaleLowerCase().replace('ilike', '')
+        const operator = parts[0].replace(/ilike/i, '')
         const value = parts[1].trim()
         return `not: { ${operator}Like: ${value} }`
       }

--- a/src/helpers/convert-gql.js
+++ b/src/helpers/convert-gql.js
@@ -220,14 +220,6 @@ const mergeFieldsIntoFilter = (fields, filter) => {
   fields.forEach(({ operator, valueField, value }) => {
     const filterKey = operator === 'In' ? 'in' : 'and'
 
-    // if (operator === 'Ilike') {
-    //   filter[filterKey] = {
-    //     ...filter[filterKey],
-    //     [`${valueField}Like`]: value
-    //   }
-    //   return
-    // }
-
     filter[filterKey] = {
       ...filter[filterKey],
       [`${valueField}${operator}`]: value

--- a/src/helpers/convert-gql.js
+++ b/src/helpers/convert-gql.js
@@ -150,7 +150,7 @@ const convertGQL = (filter, table) => {
     dataset: table.dataset,
     limit: table.limit,
     orderBy: table.orderBy,
-    filterQuery,
+    filterQuery: formatFilter(filterQuery),
     fields: fieldsFormat
   }
 
@@ -219,6 +219,14 @@ const separateFieldsByType = (fields) => {
 const mergeFieldsIntoFilter = (fields, filter) => {
   fields.forEach(({ operator, valueField, value }) => {
     const filterKey = operator === 'In' ? 'in' : 'and'
+
+    // if (operator === 'Ilike') {
+    //   filter[filterKey] = {
+    //     ...filter[filterKey],
+    //     [`${valueField}Like`]: value
+    //   }
+    //   return
+    // }
 
     filter[filterKey] = {
       ...filter[filterKey],
@@ -291,6 +299,20 @@ const formatFilterParameter = (variables, fields) => {
     }
 
     return `\t$${key}: ${type}!`
+  })
+}
+
+const formatFilter = (filters) => {
+  return filters.map(filter => {
+    if (filter.toLocaleLowerCase().includes('ilike')) {
+      const parts = filter.split(':')
+      if (parts.length) {
+        const operator = parts[0].toLocaleLowerCase().replace('ilike', '')
+        const value = parts[1].trim()
+        return `not: { ${operator}Like: ${value} }`;
+      }
+    }
+    return filter
   })
 }
 

--- a/src/helpers/convert-gql.js
+++ b/src/helpers/convert-gql.js
@@ -303,13 +303,13 @@ const formatFilterParameter = (variables, fields) => {
 }
 
 const formatFilter = (filters) => {
-  return filters.map(filter => {
+  return filters.map((filter) => {
     if (filter.toLocaleLowerCase().includes('ilike')) {
       const parts = filter.split(':')
       if (parts.length) {
         const operator = parts[0].toLocaleLowerCase().replace('ilike', '')
         const value = parts[1].trim()
-        return `not: { ${operator}Like: ${value} }`;
+        return `not: { ${operator}Like: ${value} }`
       }
     }
     return filter

--- a/src/views/RealTimeEvents/Blocks/azion-query-language.js
+++ b/src/views/RealTimeEvents/Blocks/azion-query-language.js
@@ -248,8 +248,9 @@ export default class Aql {
 
   queryValidationForCompoundFields(queryText) {
     let erros = []
-    const operadores = ['=', '<>', '<', '>', '<=', '>=', 'like', 'ilike', 'between', 'in']
+    const operadores = ['=', '<>', '<', '>', '<=', '>=', 'ilike', 'like', 'between', 'in']
     if (!queryText) return []
+
     if (queryText.toLowerCase().includes('and')) {
       const expressions = queryText.split(/\s+and\s+/i)
       expressions.forEach((expression) => {


### PR DESCRIPTION
## Bug fix
the behavior of the not contains operator was working the same as contains

### Explain what was fixed and the correct behavior.

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="275" alt="image" src="https://github.com/user-attachments/assets/82c2d453-ab1a-4da7-8388-c17fa609a6a2" />

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
