### PR TITLE
[NO-ISSUE] fix: remove object view on domains edge application dropdown

### DIFF
--- a/src/services/edge-application-services/v4/list-edge-applications-service.js
+++ b/src/services/edge-application-services/v4/list-edge-applications-service.js
@@ -8,16 +8,24 @@ export const listEdgeApplicationsService = async ({
   search = '',
   ordering = '',
   page = 1,
-  pageSize = 10
+  pageSize = 10,
+  isDropdown = false
 }) => {
-  const searchParams = makeListServiceQueryParams({ fields, ordering, page, pageSize, search })
+  const searchParams = makeListServiceQueryParams({
+    fields,
+    ordering,
+    page,
+    pageSize,
+    search,
+    isDropdown
+  })
 
   let httpResponse = await AxiosHttpClientAdapter.request({
     url: `${makeEdgeApplicationV4BaseUrl()}?${searchParams.toString()}`,
     method: 'GET'
   })
 
-  httpResponse = adapt(httpResponse)
+  httpResponse = adapt(httpResponse, isDropdown)
 
   return parseHttpResponse(httpResponse)
 }
@@ -37,11 +45,11 @@ const parseName = (edgeApplication) => {
   return nameProps
 }
 
-const adapt = (httpResponse) => {
+const adapt = (httpResponse, isDropdown) => {
   const parsedEdgeApplications = httpResponse.body.results?.map((edgeApplication) => {
     return {
       id: edgeApplication.id,
-      name: parseName(edgeApplication),
+      name: isDropdown ? edgeApplication.name : parseName(edgeApplication),
       disableEditClick: edgeApplication.product_version === LOCKED_VALUE,
       lastEditor: edgeApplication.last_editor,
       lastModify: dateFormat(edgeApplication.last_modified),

--- a/src/services/edge-application-services/v4/list-edge-applications-service.js
+++ b/src/services/edge-application-services/v4/list-edge-applications-service.js
@@ -16,8 +16,7 @@ export const listEdgeApplicationsService = async ({
     ordering,
     page,
     pageSize,
-    search,
-    isDropdown
+    search
   })
 
   let httpResponse = await AxiosHttpClientAdapter.request({

--- a/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsCreateDomains.vue
@@ -93,6 +93,13 @@
     emit('edgeApplicationCreated')
   }
 
+  const listEdgeApplicationsDecorator = async (queryParams) => {
+    return await props.listEdgeApplicationsService({
+      ...queryParams,
+      isDropdown: true
+    })
+  }
+
   const handleEdgeFirewallCreated = (id) => {
     edgeFirewall.value = id
   }
@@ -208,7 +215,7 @@
           required
           data-testid="domains-form__edge-application-field"
           name="edgeApplication"
-          :service="listEdgeApplicationsService"
+          :service="listEdgeApplicationsDecorator"
           :loadService="loadEdgeApplicationsService"
           optionLabel="name"
           optionValue="value"

--- a/src/views/Domains/FormFields/FormFieldsEditDomains.vue
+++ b/src/views/Domains/FormFields/FormFieldsEditDomains.vue
@@ -76,6 +76,13 @@
     emit('edgeFirewallCreated')
   }
 
+  const listEdgeApplicationsDecorator = async (queryParams) => {
+    return await props.listEdgeApplicationsService({
+      ...queryParams,
+      isDropdown: true
+    })
+  }
+
   const handleEdgeFirewallAccessDenied = () => {
     hasEdgeFirewallAccess.value = false
   }
@@ -272,7 +279,7 @@
           required
           data-testid="domains-form__edge-application-field"
           name="edgeApplication"
-          :service="listEdgeApplicationsService"
+          :service="listEdgeApplicationsDecorator"
           :loadService="loadEdgeApplicationsService"
           optionLabel="name"
           optionValue="value"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
In domains create or edit form, on the edge application selector, when you open the options is showing an js object instead of the name of the options, this pr fix this problem and parse object correctly to show only the name on dropdown
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
