### PR TITLE
[UXE-6725] fix: adding the description and weight values to the editing form

### DIFF
--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -15,6 +15,8 @@
   const { value: selectedPolicy } = useField('selectedPolicy')
   const { value: selectedRecordType } = useField('selectedRecordType')
   const { value: ttl } = useField('ttl')
+  const { value: weight } = useField('weight')
+  const { value: description } = useField('description')
 
   const edgeDNSStore = useEdgeDNSStore()
 
@@ -249,6 +251,7 @@
             description="Specify the weight for each record. Accepts integers between 0 and 255."
             placeholder="Weight"
             showButtons
+            :value="weight"
             :disabled="!enableTTLField"
             :min="0"
             :max="255"
@@ -265,6 +268,7 @@
         <FieldTextArea
           label="Description"
           required
+          :value="description"
           name="description"
           placeholder="add the description"
           description="Differentiate records with the same Name and Type by adding a description that identifies each one. Accepts up to 45 characters."


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

[UXE-6725] fix: adding the description and weight values to the editing form

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/a11cc1bc-56c9-4c1b-8966-2a99139b36f1


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave


[UXE-6725]: https://aziontech.atlassian.net/browse/UXE-6725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ