### PR TITLE
[UXE-6492] fix: Edge Firewall Rules Engine - Network Lists no loading

### DIFF
--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -185,7 +185,7 @@
   const focusSearch = ref(null)
   const disableEmitInit = ref(props.disableEmitFirstRender)
 
-  onMounted(async () => {
+  onMounted(() => {
     loadSelectedValue(props.value)
   })
 
@@ -384,7 +384,8 @@
 
       data.value = results
       totalCount.value = newValue.count
-    }
+    },
+    { immediate: true }
   )
 
   watchDebounced(

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -582,10 +582,8 @@
             />
           </div>
 
-          <div
-            class="flex items-top gap-x-2 items-top mt-2 mb-4 flex-col gap-2 sm:flex-row items-end"
-          >
-            <div class="flex flex-col h-fit sm:max-w-lg w-full gap-2">
+          <div class="flex items-top gap-x-2 items-top mt-2 mb-4 flex-col gap-2 sm:flex-row">
+            <div class="flex flex-col h-fit sm:max-w-lg w-full">
               <FieldDropdownIcon
                 :data-testid="`edge-firewall-rules-form__variable[${criteriaInnerRowIndex}]`"
                 :value="criteria[criteriaIndex].value[criteriaInnerRowIndex].variable"


### PR DESCRIPTION
## Bug fix
the network list dropdown is not loading as soon as it is enabled

### Explain what was fixed and the correct behavior.
It should load the network list dropdown as soon as it is enabled.

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
