### PR TITLE
[UXE-6793] fix: correct double encoding of domain IDs in WAF request

### DIFF
--- a/src/views/WafRules/Drawer/index.vue
+++ b/src/views/WafRules/Drawer/index.vue
@@ -231,7 +231,7 @@
     } else {
       query = params.filters
     }
-    query.domains = encodeURIComponent(props.domains.join(','))
+    query.domains = props.domains.join(',')
     const response = await props.listService({
       wafId: props.wafRuleId,
       tuningId: props.tuningObject.id,


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Fixed double encoding of domain IDs in WAF requests by removing manual encodeURIComponent() call. Previously, domain IDs were encoded twice (manually and by URLSearchParams), causing 400 errors. Now only URLSearchParams handles encoding, resulting in properly formatted API requests.

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
