### PR TITLE
[UXE-6093] fix: change the origin id to null when there is no error response

### DIFF
--- a/src/views/EdgeApplicationsErrorResponses/FormFields/FormFieldsErrorResponses.vue
+++ b/src/views/EdgeApplicationsErrorResponses/FormFields/FormFieldsErrorResponses.vue
@@ -145,6 +145,14 @@
   onMounted(async () => {
     await getOrigins()
   })
+
+  const removeErrosResponses = async (index) => {
+    await removeErrorResponse(index)
+
+    if (!disableOriginKey.value) {
+      originId.value = null
+    }
+  }
 </script>
 
 <template>
@@ -205,7 +213,7 @@
               Custom Error Response
             </Divider>
             <PrimeButton
-              @click="removeErrorResponse(index)"
+              @click="removeErrosResponses(index)"
               outlined
               icon="pi pi-trash"
             />


### PR DESCRIPTION
## Bug fix
fix: change the origin id to null when there is no error response

### Explain what was fixed and the correct behavior.
must change the origin id to null when there are no response errors

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
