### PR TITLE
[UXE-6731] fix: add domain names to more details drawer in waf tuning

### DIFF
--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -13,7 +13,6 @@
           @change="filterTuning"
           class="w-full sm:max-w-xs"
         />
-
         <MultiSelect
           data-testid="waf-tuning-list__domains-field"
           appendTo="body"
@@ -139,6 +138,7 @@
   <MoreDetailsDrawer
     v-if="showDetailsOfAttack"
     :wafRuleId="wafRuleId"
+    :domainNames="parsedDomainsNames"
     v-model:visible="showDetailsOfAttack"
     :listService="props.listWafRulesTuningAttacksService"
     :tuningObject="tuningSelected"
@@ -241,6 +241,7 @@
   })
   const selectedEvents = ref([])
   const totalRecordsFound = ref(0)
+  const selectedDomainsNames = ref([])
   const isLoadingAllowed = ref(null)
   const showDialogAllowRule = ref(false)
   const showDetailsOfAttack = ref(false)
@@ -260,6 +261,10 @@
 
   const recordsFoundLabel = computed(() => {
     return `${totalRecordsFound.value} records found`
+  })
+
+  const parsedDomainsNames = computed(() => {
+    return selectedDomainsNames.value.join(', ')
   })
 
   const timeName = computed(
@@ -433,6 +438,9 @@
   }
 
   const setDomainsSelectedOptions = () => {
+    selectedDomainsNames.value = domainsOptions.value.options
+      .filter((item) => selectedDomainIds.value.includes(item.id))
+      .map((domain) => domain.name)
     selectedFilter.value.domains = selectedDomainIds.value || []
     filterTuning()
   }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
add domain names to more details in waf tuning details drawer
![image](https://github.com/user-attachments/assets/b9c7c38e-aa3f-423a-bf7a-f0335eaa3aed)

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
