### PR TITLE
[UXE-6406] fix: add watch for browser cache settings to reset maximum TTL value

### DIFF
--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -284,7 +284,7 @@
     description="Define how the edge should handle TTL values sent by the origin as well as how long your content should remain cached at the edge."
     :isDrawer="true"
   >
-  <template #inputs>
+    <template #inputs>
       <FieldGroupRadio
         label="Browser Cache Settings"
         nameField="browserCacheSettings"

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/FormFieldsEdgeApplicationCacheSettings.vue
@@ -253,6 +253,10 @@
       isSliceL2CachingEnabled.value = false
     }
   })
+
+  watch(browserCacheSettings, (cacheSettings) => {
+    if (cacheSettings === 'no-cache') browserCacheSettingsMaximumTtl.value = 0
+  })
 </script>
 
 <template>
@@ -280,7 +284,7 @@
     description="Define how the edge should handle TTL values sent by the origin as well as how long your content should remain cached at the edge."
     :isDrawer="true"
   >
-    <template #inputs>
+  <template #inputs>
       <FieldGroupRadio
         label="Browser Cache Settings"
         nameField="browserCacheSettings"


### PR DESCRIPTION
## Bug fix
fix: add watch for browser cache settings to reset maximum TTL value

### Explain what was fixed and the correct behavior.
must enter the correct values ​​when selecting No Cache

### Does this PR introduce UI changes? Add a video or screenshots here.
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
