### PR TITLE
[UXE-6797] fix: timezone applied to Edge Firewall Rules Engine last modified column

### DIFF
--- a/src/services/edge-firewall-rules-engine-services/v4/list-edge-firewall-rules-engine-service.js
+++ b/src/services/edge-firewall-rules-engine-services/v4/list-edge-firewall-rules-engine-service.js
@@ -1,7 +1,7 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '@/services/axios/AxiosHttpClientAdapter'
 import { makeEdgeFirewallBaseUrl } from '../../edge-firewall-services/v4/make-edge-firewall-base-url'
 import { makeListServiceQueryParams } from '@/helpers/make-list-service-query-params'
-import { formatExhibitionDate } from '@/helpers/convert-date'
+import { getCurrentTimezone } from '@/helpers'
 
 export const listEdgeFirewallRulesEngineService = async ({ id, fields = '', search = '' }) => {
   let allData = []
@@ -53,7 +53,7 @@ const adapt = (results, statusCode) => {
       id: rules.id,
       name: rules.name,
       description: rules.description || '',
-      lastModified: formatExhibitionDate(rules.last_modified, 'long', 'short'),
+      lastModified: getCurrentTimezone(rules.last_modified),
       lastEditor: rules.last_editor,
       status: STATUS_AS_TAG[rules.active],
       position: {

--- a/src/tests/services/edge-firewall-rules-engine-services/v4/list-edge-firewall-rules-engine-service.test.js
+++ b/src/tests/services/edge-firewall-rules-engine-services/v4/list-edge-firewall-rules-engine-service.test.js
@@ -72,7 +72,7 @@ describe('EdgeFirewallRulesEngineServices', () => {
           id: fixtures.edgeFirewallRulesEngineMock.id,
           name: fixtures.edgeFirewallRulesEngineMock.name,
           description: fixtures.edgeFirewallRulesEngineMock.description,
-          lastModified: 'November 10, 2023 at 12:00 AM',
+          lastModified: 'November 10, 2023 at 12:00:00 AM',
           lastEditor: fixtures.edgeFirewallRulesEngineMock.last_editor,
           status: {
             content: 'Active',
@@ -108,7 +108,7 @@ describe('EdgeFirewallRulesEngineServices', () => {
           id: fixtures.edgeFirewallRulesEngineInactiveMock.id,
           name: fixtures.edgeFirewallRulesEngineInactiveMock.name,
           description: fixtures.edgeFirewallRulesEngineInactiveMock.description,
-          lastModified: 'November 11, 2023 at 12:00 AM',
+          lastModified: 'November 11, 2023 at 12:00:00 AM',
           lastEditor: fixtures.edgeFirewallRulesEngineInactiveMock.last_editor,
           status: {
             content: 'Inactive',


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-6797] Fix: timezone applied to the last modified column
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1440" alt="Captura de Tela 2025-03-21 às 13 35 51" src="https://github.com/user-attachments/assets/93655b5f-5a3e-4dd9-b2fe-973b5e584dc2" />

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave


[UXE-6797]: https://aziontech.atlassian.net/browse/UXE-6797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ