### PR TITLE
[UXE-6657] fix: close waf tuning drawer when esc is pressed

### DIFF
--- a/src/templates/empty-drawer/index.vue
+++ b/src/templates/empty-drawer/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { computed, ref, onMounted, onUnmounted } from 'vue'
+  import { computed, ref } from 'vue'
   import Sidebar from 'primevue/sidebar'
   import PrimeButton from 'primevue/button'
   import ConsoleFeedback from '@/layout/components/navbar/feedback'
@@ -44,20 +44,6 @@
   const toggleDrawerVisibility = (isVisible) => {
     emit('update:visible', isVisible)
   }
-
-  const handleKeydown = (event) => {
-    if (event.key === 'Escape' && visibleDrawer.value) {
-      toggleDrawerVisibility(false)
-    }
-  }
-
-  onMounted(() => {
-    document.addEventListener('keydown', handleKeydown)
-  })
-
-  onUnmounted(() => {
-    document.removeEventListener('keydown', handleKeydown)
-  })
 </script>
 
 <template>
@@ -66,6 +52,7 @@
       v-model:visible="visibleDrawer"
       :update:visible="toggleDrawerVisibility"
       position="right"
+      tabindex="0"
       :pt="{
         root: {
           class: [

--- a/src/templates/empty-drawer/index.vue
+++ b/src/templates/empty-drawer/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { computed, ref } from 'vue'
+  import { computed, ref, onMounted, onUnmounted } from 'vue'
   import Sidebar from 'primevue/sidebar'
   import PrimeButton from 'primevue/button'
   import ConsoleFeedback from '@/layout/components/navbar/feedback'
@@ -44,6 +44,20 @@
   const toggleDrawerVisibility = (isVisible) => {
     emit('update:visible', isVisible)
   }
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape' && visibleDrawer.value) {
+      toggleDrawerVisibility(false)
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('keydown', handleKeydown)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('keydown', handleKeydown)
+  })
 </script>
 
 <template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
close waf tuning drawer when esc is pressed
### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
