### PR TITLE
[UXE-6131] fix: show correct message when returning status other than 200 

### DIFF
--- a/src/services/data-stream-services/load-data-stream-service.js
+++ b/src/services/data-stream-services/load-data-stream-service.js
@@ -1,6 +1,7 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeDataStreamBaseUrl } from './make-data-stream-base-url'
 import { makeDataStreamDomainsBaseUrl } from './make-data-stream-domains-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadDataStreamService = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -13,6 +14,10 @@ export const loadDataStreamService = async ({ id }) => {
 }
 
 const adapt = async (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const payload = httpResponse.body.results
   const domains = await getDomainsOnDataStream(payload.id)
 

--- a/src/services/domains-services/load-domain-service.js
+++ b/src/services/domains-services/load-domain-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeDomainsBaseUrl } from './make-domains-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadDomainService = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -13,6 +14,10 @@ export const loadDomainService = async ({ id }) => {
 }
 
 const adapt = (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const body = httpResponse.body?.results
 
   const parsedVariable = {

--- a/src/services/edge-application-origins-services/load-origin-service.js
+++ b/src/services/edge-application-origins-services/load-origin-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '@/services/axios/AxiosHttpClientAdapter'
 import { makeEdgeApplicationBaseUrl } from '../edge-application-services/make-edge-application-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadOriginService = async ({ edgeApplicationId, id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -12,6 +13,10 @@ export const loadOriginService = async ({ edgeApplicationId, id }) => {
 }
 
 const adapt = (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const origin = httpResponse.body?.results
   if (origin.origin_type === 'live_ingest') {
     return {

--- a/src/services/edge-node-service-services/load-service-edge-node-service.js
+++ b/src/services/edge-node-service-services/load-service-edge-node-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeEdgeNodeBaseUrl } from '../edge-node-services/make-edge-node-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadServiceEdgeNodeService = async ({ id, edgeNodeId }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -11,6 +12,10 @@ export const loadServiceEdgeNodeService = async ({ id, edgeNodeId }) => {
 }
 
 const adapt = (httpResponse, id) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   let variables = ''
 
   if (httpResponse.body.variables?.length) {

--- a/src/services/edge-node-services/load-edge-node-service.js
+++ b/src/services/edge-node-services/load-edge-node-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeEdgeNodeBaseUrl } from './make-edge-node-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadEdgeNodeService = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -12,6 +13,10 @@ export const loadEdgeNodeService = async ({ id }) => {
 }
 
 const adapt = (httpResponse, id) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const edgeNode = {
     name: httpResponse.body.name,
     id: id,

--- a/src/services/edge-service-services/load-edge-service-services.js
+++ b/src/services/edge-service-services/load-edge-service-services.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeEdgeServiceBaseUrl } from './make-edge-service-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadEdgeServiceServices = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -16,6 +17,10 @@ const convertVariablesToString = (variables) => {
 }
 
 const adapt = (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const { id, name, active, variables } = httpResponse.body
   const parsedBody = {
     id,

--- a/src/services/users-services/load-user-service.js
+++ b/src/services/users-services/load-user-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeUserBaseUrl } from './make-user-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadUserService = async () => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -12,6 +13,9 @@ export const loadUserService = async () => {
 }
 
 const adapt = (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
   const responseData = httpResponse.body.data
   const parsedUser = {
     id: responseData.id,

--- a/src/services/variables-services/load-variable-service.js
+++ b/src/services/variables-services/load-variable-service.js
@@ -1,5 +1,6 @@
 import { AxiosHttpClientAdapter, parseHttpResponse } from '../axios/AxiosHttpClientAdapter'
 import { makeVariablesBaseUrl } from './make-variables-base-url'
+import { extractApiError } from '@/helpers/extract-api-error'
 
 export const loadVariableService = async ({ id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -12,6 +13,10 @@ export const loadVariableService = async ({ id }) => {
 }
 
 const adapt = (httpResponse) => {
+  if (httpResponse.statusCode !== 200) {
+    throw new Error(extractApiError({ body: httpResponse.body })).message
+  }
+
   const parsedVariable = {
     id: httpResponse.body.uuid,
     key: httpResponse.body.key,

--- a/src/tests/services/domains-services/load-domain-service.test.js
+++ b/src/tests/services/domains-services/load-domain-service.test.js
@@ -109,4 +109,15 @@ describe('DomainServices', () => {
       environment: fixtures.domainMock.environment
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut({ id: 'invalid-id' })).rejects.toThrow('Bad Request')
+  })
 })

--- a/src/tests/services/edge-application-origins-services/load-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/load-origin-service.test.js
@@ -86,4 +86,15 @@ describe('EdgeApplicationOriginsServices', () => {
       hmacSecretKey: fixtures.originMock.hmac_secret_key
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut(123123, 'invalid-id')).rejects.toThrow('Bad Request')
+  })
 })

--- a/src/tests/services/edge-node-service-services/load-service-edge-node-service.test.js
+++ b/src/tests/services/edge-node-service-services/load-service-edge-node-service.test.js
@@ -59,4 +59,15 @@ describe('EdgeNodeServices', () => {
       variables: 'var1=value1'
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut(fixtures.mockIds)).rejects.toThrow('Bad Request')
+  })
 })

--- a/src/tests/services/edge-node-services/load-edge-node-service.test.js
+++ b/src/tests/services/edge-node-services/load-edge-node-service.test.js
@@ -54,4 +54,15 @@ describe('EdgeNodeServices', () => {
       hasServices: fixtures.mock.has_services
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut({ id: fixtures.mock.id })).rejects.toThrow('Bad Request')
+  })
 })

--- a/src/tests/services/edge-service-services/load-edge-service-services.test.js
+++ b/src/tests/services/edge-service-services/load-edge-service-services.test.js
@@ -41,6 +41,17 @@ describe('EdgeServiceServices', () => {
     })
   })
 
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut({ id: fixtures.mock.id })).rejects.toThrow('Bad Request')
+  })
+
   it('should parsed correctly the returned edge service', async () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,

--- a/src/tests/services/users-services/load-user-service.test.js
+++ b/src/tests/services/users-services/load-user-service.test.js
@@ -80,4 +80,15 @@ describe('UsersServices', () => {
       teams: fixtures.userMock.teams
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut({ id: fixtures.userMock.id })).rejects.toThrow('Bad Request')
+  })
 })

--- a/src/tests/services/variables-services/load-variable-service.test.js
+++ b/src/tests/services/variables-services/load-variable-service.test.js
@@ -59,4 +59,15 @@ describe('VariablesService', () => {
       secret: fixtures.variableMock.secret
     })
   })
+
+  it('should return an error when the request fails with status 400', async () => {
+    vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
+      statusCode: 400,
+      body: { detail: 'Bad Request' }
+    })
+
+    const { sut } = makeSut()
+
+    await expect(sut({ id: fixtures.variableMock.uuid })).rejects.toThrow('Bad Request')
+  })
 })


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-6131] fix: show correct message when returning status other than 200 
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/8f4ec9ee-3daf-4767-b62f-54a2067c37fd


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave


[UXE-6131]: https://aziontech.atlassian.net/browse/UXE-6131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ