### PR TITLE
[UXE-6870] hotfix: increase WAF rules page size to 2000 to fetch all rules

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Download Azion CLI
         run: |
-          wget https://github.com/aziontech/azion/releases/download/2.5.3/azion_2.5.3_linux_amd64.apk
-          apk add --allow-untrusted azion_2.5.3_linux_amd64.apk
+          wget https://github.com/aziontech/azion/releases/download/2.6.1/azion_2.6.1_linux_amd64.apk
+          apk add --allow-untrusted azion_2.6.1_linux_amd64.apk
 
       - name: Configure Azion CLI
         run: azion -t ${{ secrets.PLATFORM_KIT_TOKEN }}

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Download Azion CLI
         run: |
-          wget https://github.com/aziontech/azion/releases/download/2.5.3/azion_2.5.3_linux_amd64.apk
-          apk add --allow-untrusted azion_2.5.3_linux_amd64.apk
+          wget https://github.com/aziontech/azion/releases/download/2.6.1/azion_2.6.1_linux_amd64.apk
+          apk add --allow-untrusted azion_2.6.1_linux_amd64.apk
 
       - name: Configure Azion CLI
         run: azion -t ${{ secrets.PLATFORM_KIT_TOKEN }}

--- a/src/services/waf-rules-services/list-waf-rules-service.js
+++ b/src/services/waf-rules-services/list-waf-rules-service.js
@@ -3,7 +3,7 @@ import { makeWafRulesBaseUrl } from './make-waf-rules-base-url'
 
 export const listWafRulesService = async () => {
   let httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeWafRulesBaseUrl()}/?page=1&page_size=200`,
+    url: `${makeWafRulesBaseUrl()}/?page=1&page_size=2000`,
     method: 'GET'
   })
 

--- a/src/tests/services/waf-rules-services/list-waf-rules-service.test.js
+++ b/src/tests/services/waf-rules-services/list-waf-rules-service.test.js
@@ -78,7 +78,7 @@ describe('WafRulesServices', () => {
     await sut()
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: 'v3/waf/?page=1&page_size=200',
+      url: 'v3/waf/?page=1&page_size=2000',
       method: 'GET'
     })
   })


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
This pull request includes changes to the `listWafRulesService` function and its corresponding test to increase the page size parameter from 200 to 2000. This adjustment ensures that more data is retrieved in a single request, improving efficiency.

Changes to `listWafRulesService`:

* [`src/services/waf-rules-services/list-waf-rules-service.js`](diffhunk://#diff-92e22065074c85d7b862a4fe589cc53e0d86f31fa2f6c0640bd1153da483f365L6-R6): Updated the `url` parameter in the `AxiosHttpClientAdapter.request` call to use `page_size=2000` instead of `page_size=200`.

Corresponding test updates:

* [`src/tests/services/waf-rules-services/list-waf-rules-service.test.js`](diffhunk://#diff-7df7be7c97fa220a48bf6bee63b2e4cf0f02d0cad72c6c4e343798e2d1be8686L81-R81): Modified the expected `url` in the test to match the new `page_size=2000` parameter.

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
