### PR TITLE
[UXE-6834] chore: remove config max-age in azsid

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -25,7 +25,7 @@ const addStageSuffixToCookies = (cookieName) => {
   return environment === 'stage' ? `${cookieName}_stg` : cookieName
 }
 
-const createCookieRewriteRule = (cookieName, description, prefix = '') => {
+const createCookieRewriteRule = ({ cookieName, description, prefix = '', hasConfigMaxAge }) => {
   const formattedCookieName = prefix + addStageSuffixToCookies(cookieName)
 
   const domains = [
@@ -56,27 +56,31 @@ const createCookieRewriteRule = (cookieName, description, prefix = '') => {
         captured: `${cookieName}_arr`,
         subject: `upstream_cookie_${formattedCookieName}`
       },
-      setCookie: `${formattedCookieName}=%{${cookieName}_arr[0]}; Max-Age=1209600; Path=/; SameSite=Lax; Secure; Domain=${domain}`,
-      filterCookie: formattedCookieName
+      setCookie: `${formattedCookieName}=%{${cookieName}_arr[0]}; ${hasConfigMaxAge ? 'Max-Age=1209600;' : ''} Path=/; SameSite=Lax; Secure; Domain=${domain}`,
+      ...(hasConfigMaxAge ? { filterCookie: formattedCookieName } : {})
     }
   }))
 }
 
 const cookieRewriteRules = [
-  ...createCookieRewriteRule(
-    'azrt',
-    'Captures and rewrites the _azrt cookie from upstream responses, setting it with specific domain, path, and security settings.',
-    '_'
-  ),
-  ...createCookieRewriteRule(
-    'azsid',
-    'Captures and rewrites the azsid cookie from upstream responses, applying new domain, expiration, and secure attributes.'
-  ),
-  ...createCookieRewriteRule(
-    'azat',
-    'Captures and rewrites the _azat cookie from upstream responses, setting secure, domain-specific settings for enhanced security.',
-    '_'
-  )
+  ...createCookieRewriteRule({
+    cookieName: 'azrt',
+    description: 'Captures and rewrites the _azrt cookie from upstream responses, setting it with specific domain, path, and security settings.',
+    prefix: '_',
+    hasConfigMaxAge: true
+  }),
+  ...createCookieRewriteRule({
+    cookieName: 'azsid',
+    description: 'Captures and rewrites the azsid cookie from upstream responses, applying new domain, expiration, and secure attributes.',
+    prefix: '',
+    hasConfigMaxAge: false
+  }),
+  ...createCookieRewriteRule({
+    cookieName: 'azat',
+    description: 'Captures and rewrites the _azat cookie from upstream responses, setting secure, domain-specific settings for enhanced security.',
+    prefix: '_',
+    hasConfigMaxAge: true
+  })
 ]
 
 const config = {


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
This pull request focuses on enhancing the `createCookieRewriteRule` function in the `azion.config.mjs` file to support an optional `hasConfigMaxAge` parameter and refactors the way cookie rewrite rules are created.

Enhancements and refactoring:

* Modified `createCookieRewriteRule` function to accept an object parameter, including a new optional `hasConfigMaxAge` property.
* Updated the `setCookie` and `filterCookie` properties within `createCookieRewriteRule` to conditionally include `Max-Age` and `filterCookie` based on the `hasConfigMaxAge` property.
* Refactored the creation of cookie rewrite rules to use the new object parameter format, including specifying the `hasConfigMaxAge` property for each rule.

### Does this PR introduce breaking changes?

- [ ] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
