### PR TITLE
[UXE-6887] fix: add 20 as the default value for ANAME

### DIFF
--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -18,4 +18,8 @@ describe('Constants Test', () => {
   it('TTL_DEFAULT should be 3600', () => {
     expect(constants.TTL_DEFAULT).toBe(3600)
   })
+
+  it('TTL_DEFAULT_ANAME should be 20', () => {
+    expect(constants.TTL_DEFAULT_ANAME).toBe(20)
+  })
 })

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,3 +2,4 @@ export const CDN_MAXIMUM_TTL_MAX_VALUE = 60
 export const CDN_MAXIMUM_TTL_MIN_VALUE = 3
 export const TTL_MAX_VALUE_RECORDS = 604800
 export const TTL_DEFAULT = 3600
+export const TTL_DEFAULT_ANAME = 20

--- a/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsRecords.vue
@@ -9,7 +9,7 @@
   import { documentationGuideProducts } from '@/helpers'
   import { useField } from 'vee-validate'
   import { computed, ref } from 'vue'
-  import { TTL_MAX_VALUE_RECORDS, TTL_DEFAULT } from '@/utils/constants'
+  import { TTL_MAX_VALUE_RECORDS, TTL_DEFAULT, TTL_DEFAULT_ANAME } from '@/utils/constants'
   import LabelBlock from '@/templates/label-block'
   const { value: name, errorMessage: errorName } = useField('name')
   const { value: selectedPolicy } = useField('selectedPolicy')
@@ -49,7 +49,7 @@
   })
 
   const setTtlByRecordType = () => {
-    if (!enableTTLField.value) ttl.value = TTL_DEFAULT
+    ttl.value = enableTTLField.value ? TTL_DEFAULT : TTL_DEFAULT_ANAME
   }
 
   const RECORD_TYPES_VALUE_FIELD_INFOS = {
@@ -193,7 +193,6 @@
             :max="TTL_MAX_VALUE_RECORDS"
             :value="ttl"
             showButtons
-            :disabled="!enableTTLField"
             :step="1"
             data-testid="edge-dns-records-form__settings__ttl-field"
           />


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-6887] fix: add 20 as the default value for ANAME
### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/851618db-4d8e-4f14-8918-8fbf75c802d8


<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
