### PR TITLE
[NO-ISSUE] chore: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 # precedence. If 2 or more squads are responsible for the same app
 # they both can be added in the same line.
 
-* @aziontech/uxe-engineering @aziontech/qa
+* @vinigfer @HerbertJulio @aloisio-m-bastian


### PR DESCRIPTION
This pull request includes a change to the `CODEOWNERS` file, updating the ownership assignments.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bL15-R15): Updated the ownership from `@aziontech/uxe-engineering @aziontech/qa` to `@vinigfer @HerbertJulio @aloisio-m-bastian`.