### PR TITLE
[UXE-4467] fix: display an appropriate message for users with blocked accounts

### DIFF
--- a/src/views/Billing/components/notification-payment.vue
+++ b/src/views/Billing/components/notification-payment.vue
@@ -12,7 +12,7 @@
       </div>
 
       <div class="flex flex-col">
-        <h4 class="text-lg font-bold">The Free Trial credit balance is running</h4>
+        <h4 class="text-lg font-bold">{{ title }}</h4>
         <p class="text-color-secondary w-full max-w-screen-lg sm:max-w-6xl text-sm">
           <slot
             name="textNotification"
@@ -53,7 +53,7 @@
   import Avatar from 'primevue/avatar'
   import PrimeButton from 'primevue/button'
   import { useAccountStore } from '@/stores/account'
-  import { ref } from 'vue'
+  import { ref, computed } from 'vue'
 
   defineOptions({
     name: 'notification-payment'
@@ -80,4 +80,11 @@
     .replace(/^Welcome to your trial period\. |<[^>]*>[^<]*<\/[^>]*>./g, '')
     .replace(/\bpayment method\b/i, '')
     .trim()
+
+  const title = computed(() => {
+    if (user.status === 'BLOCKED') {
+      return 'Account blocked due to some issues'
+    }
+    return 'The Free Trial credit balance is running'
+  })
 </script>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
[UXE-4467] fix: display an appropriate message for users with blocked accounts
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1432" alt="Captura de Tela 2025-04-03 às 15 46 31" src="https://github.com/user-attachments/assets/cf33f1db-6fb3-44ad-a960-f32ce0441f45" />

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
