### PR TITLE
[UXE-6874] fix: edge firewall rule with network lists criteria not loading correctly

### DIFF
--- a/cypress/e2mock/edge-firewall/rules-engine/network-in-list.cy.js
+++ b/cypress/e2mock/edge-firewall/rules-engine/network-in-list.cy.js
@@ -1,0 +1,163 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import selectors from '../../../support/selectors'
+
+describe('Edge Firewall Rules Engine with Network List', () => {
+  const MOCK_EDGE_FIREWALL_ID = '1234'
+  const MOCK_RULE_ID = '5678'
+  const MOCK_NETWORK_LIST_ID = '9012'
+  const MOCK_NETWORK_LIST_NAME = 'Special Network List'
+
+  beforeEach(() => {
+    cy.login()
+
+    cy.intercept('GET', '/api/v4/edge_firewall/firewalls*', {
+      statusCode: 200,
+      body: {
+        count: 1,
+        total_pages: 1,
+        schema_version: 3,
+        links: {
+          previous: null,
+          next: null
+        },
+        results: [
+          {
+            id: MOCK_EDGE_FIREWALL_ID,
+            name: 'Test Edge Firewall',
+            is_active: true,
+            last_editor: 'user@example.com',
+            last_modified: '2023-01-01T00:00:00Z',
+            edge_functions: true,
+            network_protection: true,
+            waf: true,
+            debug_rules: true
+          }
+        ]
+      }
+    }).as('listEdgeFirewalls')
+    cy.openProduct('Edge Firewall')
+    cy.wait('@listEdgeFirewalls')
+
+    cy.intercept('GET', `/api/v4/edge_firewall/firewalls/${MOCK_EDGE_FIREWALL_ID}`, {
+      statusCode: 200,
+      body: {
+        data: {
+          id: MOCK_EDGE_FIREWALL_ID,
+          name: 'Test Edge Firewall',
+          active: true,
+          last_editor: 'user@example.com',
+          last_modified: '2023-01-01T00:00:00Z',
+          debug_rules: true,
+          modules: {
+            edge_functions_enabled: true,
+            network_protection_enabled: true,
+            waf_enabled: true
+          },
+          domains: ['example.com']
+        }
+      }
+    }).as('loadEdgeFirewall')
+
+    cy.intercept('GET', `/api/v3/edge_firewall/${MOCK_EDGE_FIREWALL_ID}/functions_instances*`, {
+      statusCode: 200,
+      body: {
+        count: 0,
+        total_pages: 1,
+        schema_version: 3,
+        links: {
+          previous: null,
+          next: null
+        },
+        results: []
+      }
+    }).as('listEdgeFirewallFunctions')
+
+    cy.intercept('GET', `/api/v4/edge_firewall/firewalls/${MOCK_EDGE_FIREWALL_ID}/rules*`, {
+      statusCode: 200,
+      body: {
+        count: 1,
+        results: [
+          {
+            id: MOCK_RULE_ID,
+            name: 'teste',
+            last_editor: 'cypress_email_stage+prod2@zohomail.com',
+            last_modified: '2025-04-07T16:51:21.922062Z',
+            active: true,
+            description: ''
+          }
+        ]
+      }
+    }).as('listRules')
+
+    cy.intercept(
+      'GET',
+      `/api/v4/edge_firewall/firewalls/${MOCK_EDGE_FIREWALL_ID}/rules/${MOCK_RULE_ID}`,
+      {
+        statusCode: 200,
+        body: {
+          data: {
+            id: MOCK_RULE_ID,
+            name: 'teste',
+            last_editor: 'cypress_email_stage+prod2@zohomail.com',
+            last_modified: '2025-04-07T16:51:21.922062Z',
+            active: true,
+            behaviors: [
+              {
+                name: 'deny',
+                argument: null
+              }
+            ],
+            criteria: [
+              [
+                {
+                  argument: MOCK_NETWORK_LIST_ID,
+                  variable: '${network}',
+                  conditional: 'if',
+                  operator: 'is_not_in_list'
+                }
+              ]
+            ],
+            description: '',
+            order: 0
+          }
+        }
+      }
+    ).as('loadRule')
+    cy.get(selectors.edgeFirewall.nameRow).first().click()
+    cy.wait('@loadEdgeFirewall')
+
+    cy.get(selectors.edgeFirewall.rulesEngineTab).click()
+    cy.wait('@listRules')
+    cy.wait('@listEdgeFirewallFunctions')
+  })
+
+  it('should load a rule with network list criteria and verify the network list name is displayed', () => {
+    cy.intercept('GET', '/api/v4/workspace/network_lists*', {
+      statusCode: 200,
+      body: {
+        count: 0,
+        results: []
+      }
+    }).as('listNetworkLists')
+    cy.intercept('GET', `/api/v4/workspace/network_lists/${MOCK_NETWORK_LIST_ID}`, {
+      statusCode: 200,
+      body: {
+        data: {
+          id: parseInt(MOCK_NETWORK_LIST_ID),
+          name: MOCK_NETWORK_LIST_NAME,
+          type: 'ip_cidr',
+          items: ['192.168.1.1/32'],
+          last_editor: 'user@example.com',
+          last_modified: '2023-01-01T00:00:00Z'
+        }
+      }
+    }).as('loadNetworkList')
+
+    cy.get(selectors.edgeFirewall.rulesTableColumnName).first().click({ force: true })
+    cy.wait('@loadRule')
+    cy.wait('@listNetworkLists')
+    cy.wait('@loadNetworkList')
+
+    cy.contains(MOCK_NETWORK_LIST_NAME).should('exist')
+  })
+})

--- a/cypress/e2mock/edge-firewall/rules-engine/network-in-list.cy.js
+++ b/cypress/e2mock/edge-firewall/rules-engine/network-in-list.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 import selectors from '../../../support/selectors'
 
-describe('Edge Firewall Rules Engine with Network List', () => {
+describe('Edge Firewall Rules Engine with Network List', { tags: ['@dev6'] }, () => {
   const MOCK_EDGE_FIREWALL_ID = '1234'
   const MOCK_RULE_ID = '5678'
   const MOCK_NETWORK_LIST_ID = '9012'

--- a/cypress/support/selectors/product-selectors/edge-firewall.js
+++ b/cypress/support/selectors/product-selectors/edge-firewall.js
@@ -42,6 +42,8 @@ export default {
   ruleCriteriaInput: '[data-testid="edge-firewall-rules-form__argument[0][0]__input"]',
   ruleCriteriaNetworkListDropdown:
     '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown"]',
+  ruleCriteriaNetworkListDropdownValue:
+    '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown__value"]',
   ruleCriteriaNetworkListFilter:
     '[data-testid="edge-firewall-rules-form__network-list[0]__dropdown-search"]',
   ruleBehaviorDropdown: '[data-testid="edge-firewall-rules-form__behaviors[0]-dropdown__dropdown"]',
@@ -78,7 +80,8 @@ export default {
   behaviorLimitByFirstOption: '#behaviors\\[0\\]\\.limit_by_0',
 
   createRulesEngine: '[data-testid="rules-engine-create-button"] > .p-button-label',
-  inputNumberFirstPosition: '#row-0 > :nth-child(1) > .gap-4 > [data-testid="data-table-input-position"] > .p-inputtext',
+  inputNumberFirstPosition:
+    '#row-0 > :nth-child(1) > .gap-4 > [data-testid="data-table-input-position"] > .p-inputtext',
   reviewChanges: '[data-testid="rules-engine-save-order-button"] > .p-button-label',
   reviewChangesModal: '[data-testid="review-changes-dialog-warning-message-details"]',
   saveReorder: '[data-testid="review-changes-dialog-footer-delete-button"] > .p-button-label'

--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -390,7 +390,6 @@
         }
       })
 
-      // Preserve any selected value that might exist in data.value
       const selectedItem = data.value?.find((item) => item[props.optionValue] === props.value)
       data.value = selectedItem ? [selectedItem, ...results] : results || []
       totalCount.value = (newValue && newValue.count) || 0

--- a/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
+++ b/src/templates/form-fields-inputs/fieldDropdownLazyLoaderDinaminc.vue
@@ -368,7 +368,15 @@
   watch(
     () => props.initalData,
     (newValue) => {
-      let results = newValue.body?.map((item) => {
+      if (!newValue?.body) {
+        if (!props.value) {
+          data.value = []
+          totalCount.value = 0
+        }
+        return
+      }
+
+      let results = newValue.body.map((item) => {
         return {
           [props.optionLabel]: item.name,
           [props.optionValue]: item.id,
@@ -382,8 +390,10 @@
         }
       })
 
-      data.value = results
-      totalCount.value = newValue.count
+      // Preserve any selected value that might exist in data.value
+      const selectedItem = data.value?.find((item) => item[props.optionValue] === props.value)
+      data.value = selectedItem ? [selectedItem, ...results] : results || []
+      totalCount.value = (newValue && newValue.count) || 0
     },
     { immediate: true }
   )


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

### Does this PR introduce UI changes? Add a video or screenshots here.
fix error when loading an edge firewall rule that has a network lists criteria when getById request promise is resolved before the request to list all
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
