### PR TITLE
[UXE-6702] fix: clear form fields after submission feedback

### DIFF
--- a/cypress/e2mock/feedback.cy.js
+++ b/cypress/e2mock/feedback.cy.js
@@ -1,0 +1,42 @@
+import selectors from '../support/selectors'
+
+describe('Feedback Form with Request Interception', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.intercept('POST', '/api/webhook/console_feedback', {
+      statusCode: 200,
+      body: { message: 'Feedback sent successfully' }
+    }).as('sendFeedback')
+  })
+
+  it('should send feedback successfully', () => {
+    // Arrange
+    cy.openFeedback()
+
+    // Act
+    cy.get(selectors.header.buttonFeedback.typeDropdown).click()
+    cy.get(selectors.header.buttonFeedback.typeDropdownOption('Other')).click()
+    cy.get(selectors.header.buttonFeedback.description).type('This is a test feedback.')
+    cy.get(selectors.header.buttonFeedback.submitFeedback).click()
+
+    // Assert
+    cy.wait('@sendFeedback')
+    cy.verifyToast('Success', 'Feedback sent successfully')
+  })
+
+  it('should reset the form fields on reopening', () => {
+    // Arrange
+    cy.openFeedback()
+
+    // Act
+    cy.get(selectors.header.buttonFeedback.typeDropdown).should('have.text', 'Issue')
+    cy.get(selectors.header.buttonFeedback.description).type('This is a test feedback.')
+    cy.get(selectors.header.buttonFeedback.closeFeedback).click()
+    cy.openFeedback()
+
+    // Assert
+    cy.get(selectors.header.buttonFeedback.typeDropdown).should('have.text', 'Issue')
+    cy.get(selectors.header.buttonFeedback.description).should('have.value', '')
+    cy.get(selectors.header.buttonFeedback.closeFeedback).click()
+  })
+})

--- a/cypress/e2mock/feedback.cy.js
+++ b/cypress/e2mock/feedback.cy.js
@@ -1,6 +1,6 @@
 import selectors from '../support/selectors'
 
-describe('Feedback Form with Request Interception', () => {
+describe('Feedback Form Spec', { tags: ['@dev2'] }, () => {
   beforeEach(() => {
     cy.login()
     cy.intercept('POST', '/api/webhook/console_feedback', {

--- a/cypress/e2mock/feedback.cy.js
+++ b/cypress/e2mock/feedback.cy.js
@@ -1,6 +1,6 @@
 import selectors from '../support/selectors'
 
-describe('Feedback Form Spec', { tags: ['@dev2'] }, () => {
+describe('Feedback Spec', { tags: ['@dev2'] }, () => {
   beforeEach(() => {
     cy.login()
     cy.intercept('POST', '/api/webhook/console_feedback', {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -98,6 +98,13 @@ Cypress.Commands.add('openProductThroughSidebar', (productName) => {
 })
 
 /**
+ * Opens the feedback dialog.
+ */
+Cypress.Commands.add('openFeedback', () => {
+  cy.get(selectors.header.buttonFeedback.openFeedback).click()
+})
+
+/**
  * Opens an item through the account menu.
  *
  * @param {string} menuAccountLabel - The label of the item in the account menu.

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -4,6 +4,7 @@ import FORM_FIELDS_SELECTORS from './selectors/block-selectors/form-fields-block
 import MENU_SIDEBAR_SELECTORS from './selectors/block-selectors/menu-sidebar.js'
 import MENU_ACCOUNT_SELECTORS from './selectors/block-selectors/menu-account.js'
 import TEAMS_BLOCK_SELECTORS from './selectors/block-selectors/teams-block.js'
+import HEADER_BLOCK_SELECTORS from './selectors/block-selectors/header-block.js'
 
 // Views
 import LOGIN_VIEW_SELECTORS from './selectors/view-selectors/login.js'
@@ -36,6 +37,7 @@ const selectors = {
   wafTuning: WAF_TUNING_PRODUCT_SELECTORS,
   form: FORM_FIELDS_SELECTORS,
   login: LOGIN_VIEW_SELECTORS,
+  header: HEADER_BLOCK_SELECTORS,
   menuSidebar: MENU_SIDEBAR_SELECTORS,
   menuAccount: MENU_ACCOUNT_SELECTORS,
   activityHistory: ACTIVITY_HISTORY_VIEW_SELECTORS,

--- a/cypress/support/selectors/block-selectors/header-block.js
+++ b/cypress/support/selectors/block-selectors/header-block.js
@@ -1,0 +1,10 @@
+export default {
+  buttonFeedback: {
+    openFeedback: '[data-testid="header-block__open-feedback-button"]',
+    typeDropdown: '[data-testid="feedback-dialog__dialog-body__button-type-dropdown"]',
+    typeDropdownOption: (option) => `li[aria-label="${option}"].p-dropdown-item`,
+    description: '[data-testid="feedback-dialog__dialog-body__textarea-description"]',
+    closeFeedback: '[data-testid="feedback-dialog__dialog-footer__cancel-button"]',
+    submitFeedback: '[data-testid="feedback-dialog__dialog-footer__confirm-button"]'
+  }
+}

--- a/src/layout/components/navbar/feedback.vue
+++ b/src/layout/components/navbar/feedback.vue
@@ -12,11 +12,13 @@
     :class="props.class"
     @click="visible = true"
     v-tooltip.bottom="{ value: 'Feedback', showDelay: 200 }"
+    data-testid="header-block__open-feedback-button"
   />
 
   <Dialog
     v-model:visible="visible"
     modal
+    @show="resetForm()"
     header="Report an issue"
     :style="{ width: '35rem' }"
   >
@@ -34,6 +36,7 @@
           optionValue="code"
           placeholder="Select one Type"
           class="max-w-[216px]"
+          data-testid="feedback-dialog__dialog-body__button-type-dropdown"
         />
       </div>
       <div class="flex flex-col gap-3">
@@ -46,6 +49,7 @@
           v-model="report"
           rows="5"
           cols="30"
+          data-testid="feedback-dialog__dialog-body__textarea-description"
         />
       </div>
     </div>
@@ -58,6 +62,7 @@
           size="small"
           class="w-20"
           @click="visible = false"
+          data-testid="feedback-dialog__dialog-footer__cancel-button"
         />
         <PrimeButton
           type="button"
@@ -68,6 +73,7 @@
           icon="pi pi-send"
           :loading="loading"
           @click="sendFeedback()"
+          data-testid="feedback-dialog__dialog-footer__confirm-button"
         />
       </div>
     </template>
@@ -114,6 +120,11 @@
     { name: 'Other', code: 'other' }
   ]
 
+  const resetForm = () => {
+    selectedIssueType.value = 'issue'
+    report.value = ''
+  }
+
   const sendFeedback = async () => {
     try {
       loading.value = true
@@ -132,6 +143,7 @@
         detail: 'Feedback sent successfully',
         life: 3000
       })
+      resetForm()
       visible.value = false
     } catch (error) {
       toast.add({


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
This PR includes two main improvements to the feedback functionality:

### Form Reset Enhancement
- Added automatic form field reset after successful feedback submission
- Fields affected: type dropdown and description textarea
- Improves user experience by ensuring clean state for next submission

### E2E Test Coverage
Added comprehensive E2E tests to ensure feedback form reliability:
- Test successful feedback submission flow
- Verify form reset functionality on dialog reopen
- Mock API responses for consistent test execution
- Follow best practices with fixtures and selectors

## Test Cases
```javascript
✓ should submit feedback successfully
✓ should reset form fields when reopening the dialog
```

## Type of Change
- [x] Bug fix (non-breaking change fixing form reset)
- [x] Test enhancement (non-breaking change adding tests)


### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
