### PR TITLE
[UXE-7572] refactor: cache settings payload structure based in api

### DIFF
--- a/src/services/v2/adapters/edge-app-cache-settings-adapter.js
+++ b/src/services/v2/adapters/edge-app-cache-settings-adapter.js
@@ -11,89 +11,147 @@ const parseTextToArray = (text) => text?.split('\n') ?? []
 const parseDeviceGroups = (ids) => ids?.map((id) => ({ id })) ?? []
 const parseDeviceGroup = (group) => group?.map(({ id }) => id) ?? []
 
-function resolveTieredCacheRegion(payload) {
-  if (!payload.tieredCache) {
-    return undefined
-  }
-
-  return payload.tieredCacheRegion ?? 'na-united-states'
-}
-
 export const CacheSettingsAdapter = {
   requestPayload(payload) {
-    return {
+    const result = {
       name: payload.name,
+      browser_cache: {
+        behavior: payload.browserCacheSettings || 'honor',
+        max_age: payload.browserCacheSettingsMaximumTtl || 0
+      },
       modules: {
-        browser_cache: {
-          behavior: payload.browserCacheSettings,
-          max_age: payload.browserCacheSettingsMaximumTtl
-        },
         edge_cache: {
-          behavior: payload.cdnCacheSettings,
-          max_age: payload.cdnCacheSettingsMaximumTtl,
-          caching_for_post_enabled: payload.enableCachingForPost,
-          caching_for_options_enabled: payload.enableCachingForOptions,
-          stale_cache_enabled: payload.enableStaleCache,
-          tiered_cache_enabled: payload.tieredCache,
-          tiered_cache_region: resolveTieredCacheRegion(payload)
-        },
-        application_controls: {
-          cache_by_query_string: payload.cacheByQueryString,
-          query_string_fields: parseTextToArray(payload.queryStringFields),
-          query_string_sort_enabled: payload.enableQueryStringSort,
-          cache_by_cookies: payload.cacheByCookies,
-          cookie_names: parseTextToArray(payload.cookieNames),
-          adaptive_delivery_action: payload.adaptiveDeliveryAction,
-          device_group: parseDeviceGroup(payload.deviceGroup)
-        },
-        slice_controls: {
-          slice_configuration_enabled: payload.sliceConfigurationEnabled,
-          slice_edge_caching_enabled: payload.isSliceEdgeCachingEnabled,
-          slice_tiered_caching_enabled: payload.isSliceTieredCache,
-          slice_configuration_range: payload.sliceConfigurationRange
+          behavior: payload.cdnCacheSettings || 'honor',
+          max_age: payload.cdnCacheSettingsMaximumTtl || 60,
+          stale_cache: {
+            enabled: payload.enableStaleCache || false
+          },
+          large_file_cache: {
+            enabled: payload.enableLargeFileCache || false,
+            offset: payload.largeFileCacheOffset || 1024
+          }
         }
       }
     }
+
+    // Add tiered_cache module if enabled
+    if (payload.tieredCache) {
+      result.modules.tiered_cache = {
+        behavior: 'override', // readonly according to docs
+        max_age: 31536000, // readonly according to docs
+        topology: payload.tieredCacheRegion || 'near-edge'
+      }
+    }
+
+    // Add application_accelerator module if any of its features are used
+    const hasAppAccelerator =
+      payload.enableCachingForPost ||
+      payload.enableCachingForOptions ||
+      payload.cacheByQueryString !== 'ignore' ||
+      payload.cacheByCookies !== 'ignore' ||
+      payload.adaptiveDeliveryAction !== 'ignore'
+
+    if (hasAppAccelerator) {
+      const appAccelerator = {}
+
+      // Cache vary by method
+      const cacheVaryByMethod = []
+      if (payload.enableCachingForOptions) cacheVaryByMethod.push('options')
+      if (payload.enableCachingForPost) cacheVaryByMethod.push('post')
+      if (cacheVaryByMethod.length > 0) {
+        appAccelerator.cache_vary_by_method = cacheVaryByMethod
+      }
+
+      // Cache vary by querystring
+      if (payload.cacheByQueryString && payload.cacheByQueryString !== 'ignore') {
+        appAccelerator.cache_vary_by_querystring = {
+          behavior: payload.cacheByQueryString,
+          fields: parseTextToArray(payload.queryStringFields) || [],
+          sort_enabled: payload.enableQueryStringSort !== false
+        }
+      }
+
+      // Cache vary by cookies
+      if (payload.cacheByCookies && payload.cacheByCookies !== 'ignore') {
+        appAccelerator.cache_vary_by_cookies = {
+          behavior: payload.cacheByCookies,
+          cookie_names: parseTextToArray(payload.cookieNames) || []
+        }
+      }
+
+      // Cache vary by devices
+      if (payload.adaptiveDeliveryAction && payload.adaptiveDeliveryAction !== 'ignore') {
+        appAccelerator.cache_vary_by_devices = {
+          behavior: payload.adaptiveDeliveryAction,
+          device_group: parseDeviceGroup(payload.deviceGroup) || []
+        }
+      }
+
+      if (Object.keys(appAccelerator).length > 0) {
+        result.modules.application_accelerator = appAccelerator
+      }
+    }
+
+    return result
   },
 
   transformListCacheSetting(data) {
     return data.map((item) => ({
       id: String(item.id),
       name: item.name,
-      browserCache: formatCacheBehavior(item.modules.browser_cache.behavior),
-      cdnCache: formatCacheBehavior(item.modules.edge_cache.behavior)
+      browserCache: formatCacheBehavior(item.browser_cache?.behavior || 'honor'),
+      cdnCache: formatCacheBehavior(item.modules?.edge_cache?.behavior || 'honor')
     }))
   },
 
   transformLoadCacheSetting({ data }) {
-    const controls = data.modules.application_controls
-    const edge = data.modules.edge_cache
-    const slice = data.modules.slice_controls
-    const browserCache = data.modules.browser_cache
+    const edge = data.modules?.edge_cache || {}
+    const tieredCache = data.modules?.tiered_cache
+    const appAccelerator = data.modules?.application_accelerator || {}
+    const browserCache = data.browser_cache || {}
+
+    // Extract cache vary by method settings
+    const cacheVaryByMethod = appAccelerator.cache_vary_by_method || []
+    const enableCachingForPost = cacheVaryByMethod.includes('post')
+    const enableCachingForOptions = cacheVaryByMethod.includes('options')
+
+    // Extract cache vary by querystring settings
+    const cacheVaryByQuerystring = appAccelerator.cache_vary_by_querystring || {}
+    const cacheByQueryString = cacheVaryByQuerystring.behavior || 'ignore'
+    const queryStringFields = parseContentToTextArea(cacheVaryByQuerystring.fields || [])
+    const enableQueryStringSort = cacheVaryByQuerystring.sort_enabled !== false
+
+    // Extract cache vary by cookies settings
+    const cacheVaryByCookies = appAccelerator.cache_vary_by_cookies || {}
+    const cacheByCookies = cacheVaryByCookies.behavior || 'ignore'
+    const cookieNames = parseContentToTextArea(cacheVaryByCookies.cookie_names || [])
+
+    // Extract cache vary by devices settings
+    const cacheVaryByDevices = appAccelerator.cache_vary_by_devices || {}
+    const adaptiveDeliveryAction = cacheVaryByDevices.behavior || 'ignore'
+    const deviceGroup = parseDeviceGroups(cacheVaryByDevices.device_group || [])
 
     return {
       id: data.id,
       name: data.name,
-      browserCacheSettings: browserCache.behavior,
-      browserCacheSettingsMaximumTtl: browserCache.max_age,
-      cdnCacheSettings: edge.behavior,
-      cdnCacheSettingsMaximumTtl: edge.max_age,
-      enableCachingForPost: edge.caching_for_post_enabled,
-      enableCachingForOptions: edge.caching_for_options_enabled,
-      enableStaleCache: edge.stale_cache_enabled,
-      tieredCache: edge.tiered_cache_enabled,
-      tieredCacheRegion: edge.tiered_cache_region,
-      cacheByQueryString: controls.cache_by_query_string,
-      queryStringFields: parseContentToTextArea(controls.query_string_fields),
-      enableQueryStringSort: controls.query_string_sort_enabled,
-      cacheByCookies: controls.cache_by_cookies,
-      cookieNames: parseContentToTextArea(controls.cookie_names),
-      adaptiveDeliveryAction: controls.adaptive_delivery_action,
-      deviceGroup: parseDeviceGroups(controls.device_group),
-      sliceConfigurationEnabled: slice.slice_configuration_enabled,
-      sliceConfigurationRange: slice.slice_configuration_range,
-      isSliceEdgeCachingEnabled: slice.slice_edge_caching_enabled,
-      isSliceTieredCache: slice.slice_tiered_caching_enabled
+      browserCacheSettings: browserCache.behavior || 'honor',
+      browserCacheSettingsMaximumTtl: browserCache.max_age || 0,
+      cdnCacheSettings: edge.behavior || 'honor',
+      cdnCacheSettingsMaximumTtl: edge.max_age || 60,
+      enableCachingForPost,
+      enableCachingForOptions,
+      enableStaleCache: edge.stale_cache?.enabled || false,
+      enableLargeFileCache: edge.large_file_cache?.enabled || false,
+      largeFileCacheOffset: edge.large_file_cache?.offset || 1024,
+      tieredCache: !!tieredCache,
+      tieredCacheRegion: tieredCache?.topology || 'near-edge',
+      cacheByQueryString,
+      queryStringFields,
+      enableQueryStringSort,
+      cacheByCookies,
+      cookieNames,
+      adaptiveDeliveryAction,
+      deviceGroup
     }
   }
 }

--- a/src/views/EdgeApplicationsCacheSettings/Drawer/index.vue
+++ b/src/views/EdgeApplicationsCacheSettings/Drawer/index.vue
@@ -70,7 +70,7 @@
     adaptiveDeliveryAction: 'ignore',
     deviceGroup: [],
     tieredCache: false,
-    isSliceTieredCacheEnabled: false,
+    isSliceTieredCache: false,
     isSliceEdgeCachingEnabled: false
   })
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

the new payload:
```
{
  "name": "string",							//required
  "browser_cache": {
    "behavior": "no-cache|honor|override",			//default: honor
    "max_age": 0							//default: 0
  },

  "modules": {
    "edge_cache": {							//Object with defaults
      "behavior": "honor|override",  				//default: honor
      "max_age": 60,						//default: 60
      "stale_cache": {
        "enabled": true						//default: false
      },	
      "large_file_cache": {
        "enabled": true,						//default false
        "offset": 1024						//default: 1024 (1-1048575)
      }
    },
    "tiered_cache": {					//null or Object //default: null
      "behavior": "override",					//readonly
      "max_age": 31536000,						//readonly
      "topology": "near-edge|br-east-1|us-east-1",		//default: near-edge
    },
    "application_accelerator": {				//null or Object //default: null
       "cache_vary_by_method": ["options","post"],		//default: []
       "cache_vary_by_querystring: {
         "behavior": "ignore|all|allowlist|denylist",		//default: ignore
         "fields": [],						//default: []
         "sort_enabled": true,					//default: true
       },
       "cache_vary_by_cookies: {
         "behavior": "ignore|all|allowlist|denylist",		//default: ignore
         "cookie_names": [],					//default: []
       },
       "cache_vary_by_devices: {
         "behavior": "ignore|allowlist",		       //default: ignore
         "device_group": []					//default: []	
       }
    }
  }
}

```
### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
no

### Does it have a link on Figma?
no

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
