### PR TITLE
[UXE-7724] fix: correct certificate status display when actual status is "failed"

### DIFF
--- a/src/helpers/format-strings.js
+++ b/src/helpers/format-strings.js
@@ -1,0 +1,24 @@
+/**
+ * Formats a given string by capitalizing the first letter of each word and removing underscores.
+ *
+ * @param {string} inputString - The string to be formatted.
+ * @returns {string} The formatted string example: "edge_certificate" -> "Edge Certificate".
+ */
+export const formatString = (inputString) => {
+  if (typeof inputString !== 'string' || inputString.trim() === '') {
+    return ''
+  }
+
+  const formattedString = inputString
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map((word) => {
+      if (word.length === 0) {
+        return ''
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    })
+    .join(' ')
+
+  return formattedString
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -52,6 +52,7 @@ import INFORMATION_TEXTS from './azion-information-texts'
 import { getCurrentTimezone } from './account-timezone'
 import TEXT_DOMAIN_WORKLOAD from './handle-text-workload-domain-flag'
 import { adaptServiceDataResponse } from '../services/v2/utils/adaptServiceDataResponse'
+import { formatString } from './format-strings'
 import {
   HTTP_PORT_LIST_OPTIONS,
   HTTP3_PORT_LIST_OPTIONS,
@@ -126,5 +127,6 @@ export {
   getExpiredDate,
   getRemainingDays,
   getCurrentDateTimeIntl,
-  contactSalesEdgeApplicationService
+  contactSalesEdgeApplicationService,
+  formatString
 }

--- a/src/services/v2/adapters/digital-certificates-adapter.js
+++ b/src/services/v2/adapters/digital-certificates-adapter.js
@@ -1,5 +1,5 @@
 import { getCurrentTimezone, checkIfFieldExist, getCurrentDateTimeIntl } from '@/helpers'
-import { parseStatusData } from '@/services/v2/utils/adapter/parse-status-utils'
+import { parseStatusString } from '@/services/v2/utils/adapter/parse-status-utils'
 
 const EDGE_CERTIFICATE = 'TLS Certificate'
 const TRUSTED_CA_CERTIFICATE = 'Trusted CA Certificate'
@@ -64,7 +64,7 @@ export const DigitalCertificatesAdapter = {
         type: checkIfFieldExist(typeMap[item?.type]),
         validity: item?.validity ? getCurrentTimezone(item.validity) : '-',
         status: {
-          status: parseStatusData(item.status),
+          status: parseStatusString(item.status),
           statusDetail: item?.status_detail
         }
       }

--- a/src/services/v2/utils/adapter/parse-status-utils.js
+++ b/src/services/v2/utils/adapter/parse-status-utils.js
@@ -1,3 +1,5 @@
+import { formatString } from '@/helpers'
+
 export const parseStatusData = (status) => {
   const parsedStatus = status
     ? {
@@ -22,6 +24,21 @@ export const parseDefaultData = (status) => {
         content: 'No',
         severity: 'danger'
       }
+
+  return parsedStatus
+}
+
+export const parseStatusString = (status) => {
+  const parsedStatus =
+    status.toUpperCase() === 'ACTIVE'
+      ? {
+          content: formatString(status),
+          severity: 'success'
+        }
+      : {
+          content: formatString(status),
+          severity: 'danger'
+        }
 
   return parsedStatus
 }


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-7724] fix: correct certificate status display when actual status is "failed"
### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="1430" height="851" alt="Captura de Tela 2025-07-24 às 14 51 29" src="https://github.com/user-attachments/assets/3490a281-835c-41c8-a1ba-6983bc0a9fce" />

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave


[UXE-7724]: https://aziontech.atlassian.net/browse/UXE-7724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ