### PR TITLE
[UXE-7726] fix: Digital Certificates - correct placeholder text for private key field

### DIFF
--- a/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
+++ b/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
@@ -177,7 +177,7 @@
             label="Private Key"
             name="privateKey"
             :value="privateKey"
-            placeholder="For security purposes, the current private key isn't exhibited, but it was correctly registered. Paste a new certificate in this field to update it."
+            placeholder="For security purposes, the current private key isn't exhibited, but it was correctly registered. Paste a new private key in this field to update it."
           />
         </div>
       </template>


### PR DESCRIPTION

## Bug fix

### Explain what was fixed and the correct behavior.
Alterado o texto do placeholder do campo
### Does this PR introduce UI changes? Add a video or screenshots here.
<img width="584" height="185" alt="image" src="https://github.com/user-attachments/assets/20a50a1f-12f8-41ad-a4d4-35774d826f10" />

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
