### PR TITLE
[NO-ISSUE] fix: menu icon when domains and removed preview tag

### DIFF
--- a/src/services/sidebar-menus-services/menus.js
+++ b/src/services/sidebar-menus-services/menus.js
@@ -25,12 +25,7 @@ function createDomainsItem() {
     label: handleTextDomainWorkload.pluralTitle,
     icon: hasFlagBlockApiV4() ? 'pi pi-globe' : 'ai ai-workloads',
     to: `/${handleTextDomainWorkload.pluralLabel}`,
-    id: 'domains',
-    tag: 'Preview'
-  }
-
-  if (hasFlagBlockApiV4()) {
-    delete menuOption.tag
+    id: 'domains'
   }
 
   return menuOption

--- a/src/services/sidebar-menus-services/menus.js
+++ b/src/services/sidebar-menus-services/menus.js
@@ -23,7 +23,7 @@ function createDomainsItem() {
   const handleTextDomainWorkload = TEXT_DOMAIN_WORKLOAD()
   const menuOption = {
     label: handleTextDomainWorkload.pluralTitle,
-    icon: 'ai ai-workloads',
+    icon: hasFlagBlockApiV4() ? 'pi pi-globe' : 'ai ai-workloads',
     to: `/${handleTextDomainWorkload.pluralLabel}`,
     id: 'domains',
     tag: 'Preview'

--- a/src/services/sidebar-menus-services/menus.js
+++ b/src/services/sidebar-menus-services/menus.js
@@ -60,7 +60,6 @@ function createSecureItems() {
       to: '/edge-connectors',
       icon: 'ai ai-edge-connectors',
       id: 'edge-connectors',
-      tag: 'Preview',
       visible: !hasFlagBlockApiV4()
     },
     {
@@ -143,7 +142,6 @@ function createEdgeLibrariesItems() {
       label: 'Custom Pages',
       to: '/custom-pages',
       icon: 'ai ai-custom-pages',
-      tag: 'Preview',
       id: 'custom-pages',
       visible: !hasFlagBlockApiV4()
     },


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

Removed "Preview" tag from Custom Pages, Edge Connectors and Workloads from Menu, and fix the icon when flag is on, domains = globe icon, workloads = workloads icon.

### Does this PR introduce breaking changes?

- [X] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

<img width="664" height="1594" alt="image" src="https://github.com/user-attachments/assets/27666e03-eef2-4cea-970b-57202d94df76" />

<img width="642" height="1568" alt="image" src="https://github.com/user-attachments/assets/0a789bc6-ec64-47db-a20a-be08f4b632a6" />

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
