### PR TITLE
[UXE-7498] feat: restrict Origins and Error Responses tabs visibility based on API v4 flag

### DIFF
--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -238,7 +238,7 @@
     {
       header: 'Origins',
       component: EdgeApplicationsOriginsListView,
-      condition: true,
+      condition: hasFlagBlockApiV4(),
       show: showTabs.origins,
       props: () => ({
         ...props.originsServices,
@@ -260,7 +260,7 @@
     {
       header: 'Error Responses',
       component: EdgeApplicationsErrorResponseEditView,
-      condition: true,
+      condition: hasFlagBlockApiV4(),
       show: showTabs.errorResponses,
       props: () => ({
         ...props.errorResponsesServices,


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-7498](https://aziontech.atlassian.net/browse/UXE-7498) in edge aplication, restrict Origins and Error Responses tabs visibility based on API v4 flag
### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/a7100637-a181-4af0-9813-791a46c7f50d


### Does it have a link on Figma?
https://www.figma.com/design/m1ZkbEPzLlbA2bb5G0erZX/Prototypes-War-Room--Jun-Jul-?node-id=9-8548&t=l0iCvPFAvSCKwmdQ-1
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [] Brave


[UXE-7498]: https://aziontech.atlassian.net/browse/UXE-7498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ