### PR TITLE
[UXE-7498] feat: conditionally show Origins and Error Responses tabs

### DIFF
--- a/cypress/e2mock/edge-application/tabs-visibility.cy.js
+++ b/cypress/e2mock/edge-application/tabs-visibility.cy.js
@@ -17,9 +17,7 @@ describe('Edge Application Tabs Visibility - Mock Test', { tags: ['@dev2'] }, ()
 
       cy.wait('@edgeApplicationsListApi', { timeout: 30000 })
 
-      cy.get('[data-testid="edge-applications-list-table-block"] [data-pc-section="bodyrow"]')
-        .first()
-        .click()
+      cy.get(selectors.edgeApplication.edgeApplicationTable).first().click()
 
       cy.intercept('GET', '/v4/edge_application/applications/*', {
         fixture: '/edge-application/edge-application-item-v4.json'
@@ -70,9 +68,7 @@ describe('Edge Application Tabs Visibility - Mock Test', { tags: ['@dev2'] }, ()
       cy.openProduct('Edge Application')
       cy.wait('@edgeApplicationsListApi', { timeout: 30000 })
 
-      cy.get('[data-testid="edge-applications-list-table-block"] [data-pc-section="bodyrow"]')
-        .first()
-        .click()
+      cy.get(selectors.edgeApplication.edgeApplicationTable).first().click()
 
       cy.intercept('GET', '/api/v3/edge_applications/*', {
         fixture: '/edge-application/edge-application-item-v3.json'

--- a/cypress/e2mock/edge-application/tabs-visibility.cy.js
+++ b/cypress/e2mock/edge-application/tabs-visibility.cy.js
@@ -1,0 +1,111 @@
+import selectors from '../../support/selectors'
+describe('Edge Application Tabs Visibility - Mock Test', { tags: ['@dev2'] }, () => {
+  context('When api v4 is enabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/account/info', {
+        fixture: '/account/info/workload_flags.json'
+      }).as('accountInfo')
+
+      cy.login()
+      cy.wait('@accountInfo', { timeout: 30000 })
+
+      cy.intercept('GET', '/v4/edge_application/applications*', {
+        fixture: '/edge-application/edge-applications.json'
+      }).as('edgeApplicationsListApi')
+
+      cy.openProduct('Edge Application')
+
+      cy.wait('@edgeApplicationsListApi', { timeout: 30000 })
+
+      cy.get('[data-testid="edge-applications-list-table-block"] [data-pc-section="bodyrow"]')
+        .first()
+        .click()
+
+      cy.intercept('GET', '/v4/edge_application/applications/*', {
+        fixture: '/edge-application/edge-application-item-v4.json'
+      }).as('edgeApplicationItemApi')
+
+      cy.wait('@edgeApplicationItemApi', { timeout: 30000 })
+    })
+
+    it('it should not show origins and error responses tabs', () => {
+      cy.get(selectors.edgeApplication.tabs('Main Settings')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Origins')).should('not.exist')
+      cy.get(selectors.edgeApplication.tabs('Device Groups')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Error Responses')).should('not.exist')
+      cy.get(selectors.edgeApplication.tabs('Cache Settings')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Functions Instances')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Rules Engine')).should('be.visible')
+    })
+
+    it('should navigate between tabs correctly', () => {
+      const tabs = {
+        'Main Settings': 'main-settings',
+        'Device Groups': 'device-groups',
+        'Cache Settings': 'cache-settings',
+        'Functions Instances': 'functions',
+        'Rules Engine': 'rules-engine'
+      }
+
+      Object.entries(tabs).forEach(([tabName, tabUrl]) => {
+        cy.get(selectors.edgeApplication.tabs(tabName)).click()
+        cy.url().should('include', `/${tabUrl}`)
+      })
+    })
+  })
+
+  context('When api v4 is disabled', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/account/info', {
+        fixture: '/account/info/domain_flags.json'
+      }).as('accountInfo')
+
+      cy.login()
+      cy.wait('@accountInfo', { timeout: 30000 })
+
+      cy.intercept('GET', '/v4/edge_application/applications*', {
+        fixture: '/edge-application/edge-applications.json'
+      }).as('edgeApplicationsListApi')
+
+      cy.openProduct('Edge Application')
+      cy.wait('@edgeApplicationsListApi', { timeout: 30000 })
+
+      cy.get('[data-testid="edge-applications-list-table-block"] [data-pc-section="bodyrow"]')
+        .first()
+        .click()
+
+      cy.intercept('GET', '/api/v3/edge_applications/*', {
+        fixture: '/edge-application/edge-application-item-v3.json'
+      }).as('edgeApplicationItemApi')
+
+      cy.wait('@edgeApplicationItemApi', { timeout: 30000 })
+    })
+
+    it('should not show origins and error responses tabs', () => {
+      cy.get(selectors.edgeApplication.tabs('Main Settings')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Origins')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Device Groups')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Error Responses')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Cache Settings')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Functions Instances')).should('be.visible')
+      cy.get(selectors.edgeApplication.tabs('Rules Engine')).should('be.visible')
+    })
+
+    it('should navigate between tabs correctly', () => {
+      const tabs = {
+        'Main Settings': 'main-settings',
+        Origins: 'origins',
+        'Device Groups': 'device-groups',
+        'Error Responses': 'error-responses',
+        'Cache Settings': 'cache-settings',
+        'Functions Instances': 'functions',
+        'Rules Engine': 'rules-engine'
+      }
+
+      Object.entries(tabs).forEach(([tabName, tabUrl]) => {
+        cy.get(selectors.edgeApplication.tabs(tabName)).click()
+        cy.url().should('include', `/${tabUrl}`)
+      })
+    })
+  })
+})

--- a/cypress/fixtures/account/info/workload_flags.json
+++ b/cypress/fixtures/account/info/workload_flags.json
@@ -1,0 +1,24 @@
+{
+  "id": 22692,
+  "name": "Vinicius",
+  "company_name": "Azion",
+  "full_name": "Paulo Ferreira",
+  "city": "Porto Alegre",
+  "region": "Rio Grande do Sul",
+  "country": "Brazil",
+  "kind": "client",
+  "client_flags": [
+    "allow_console",
+    "enable_ipv6",
+    "federated_auth",
+    "waf_mode",
+    "block_apiv3_access"
+  ],
+  "address": "Santa Terezinha 609",
+  "complement": "",
+  "postal_code": "90040-180",
+  "first_login": false,
+  "is_client_only": true,
+  "disclaimer": "Welcome to your trial period. You have USD 300.00 to use in 312 days. To use Azion with no service interruptions at the end of your trial, add a payment method <a href='/billing-subscriptions/payment-methods/add' target='_top'>right here</a>.",
+  "status": "ONLINE"
+}

--- a/cypress/fixtures/edge-application/edge-application-item-v3.json
+++ b/cypress/fixtures/edge-application/edge-application-item-v3.json
@@ -1,0 +1,26 @@
+{
+  "results": {
+    "id": 1755712388,
+    "name": "teste",
+    "delivery_protocol": "http",
+    "http_port": [80],
+    "https_port": [443],
+    "minimum_tls_version": "",
+    "active": true,
+    "debug_rules": false,
+    "http3": false,
+    "websocket": false,
+    "supported_ciphers": "all",
+    "application_acceleration": true,
+    "caching": true,
+    "device_detection": true,
+    "edge_firewall": false,
+    "edge_functions": true,
+    "image_optimization": true,
+    "l2_caching": true,
+    "load_balancer": true,
+    "raw_logs": false,
+    "web_application_firewall": false
+  },
+  "schema_version": 3
+}

--- a/cypress/fixtures/edge-application/edge-application-item-v4.json
+++ b/cypress/fixtures/edge-application/edge-application-item-v4.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "id": 1727808946,
+    "name": "foo1",
+    "last_editor": "foo1@foo.com",
+    "last_modified": "2025-08-29T15:58:32.195505Z",
+    "modules": {
+      "edge_cache": {
+        "enabled": true
+      },
+      "edge_functions": {
+        "enabled": true
+      },
+      "application_accelerator": {
+        "enabled": true
+      },
+      "image_processor": {
+        "enabled": true
+      },
+      "tiered_cache": {
+        "enabled": true
+      }
+    },
+    "application_acceleration": true,
+    "caching": true,
+    "debug_rules": true,
+    "delivery_protocol": "http",
+    "device_detection": true,
+    "edge_firewall": true,
+    "edgeFunctions": true,
+    "http3": true,
+    "http_port": [80],
+    "https_port": [443],
+    "image_optimization": true,
+    "l2_caching": true,
+    "load_balancer": true,
+    "active": true,
+    "debug": true,
+    "product_version": "3.0"
+  },
+  "schema_version": 3
+}

--- a/cypress/support/selectors/product-selectors/edge-application.js
+++ b/cypress/support/selectors/product-selectors/edge-application.js
@@ -1,5 +1,7 @@
 export default {
   tabs: (tabName) => `[data-testid="edge-application-details-tab-panel__${tabName}__tab"] a`,
+  edgeApplicationTable:
+    '[data-testid="edge-applications-list-table-block"] [data-pc-section="bodyrow"]',
   mainSettings: {
     createButton: '[data-testid="create_Edge Application_button"]',
     nameInput: '[data-testid="form-horizontal-general-name__input"]',
@@ -9,8 +11,8 @@ export default {
       `[data-testid="form-horizontal-modules-default-switch__switch-${moduleName}__switch"] > .p-inputswitch-slider`,
     l2CachingSwitch:
       '[data-testid="form-horizontal-modules-subscription-switch__switch-l2Caching__switch"] > .p-inputswitch-slider',
-    tieredCacheEnabled: '[data-testid="form-horizontal-modules-subscription-switch__switch-tieredCacheEnabled"]'
-
+    tieredCacheEnabled:
+      '[data-testid="form-horizontal-modules-subscription-switch__switch-tieredCacheEnabled"]'
   },
   accordionStepEdgeConnector: {
     createEdgeConnector: '[data-testid="create-edge-connector-accordion"]',
@@ -19,11 +21,13 @@ export default {
   },
   accordionStepCache: {
     createCache: '[data-testid="create-cache-accordion"]',
-    browserCacheSettings: '[data-testid="form-horizontal-cache-expiration-policies-browser-cache-settings__radio__browserCacheSettings-radio-0"]',
-    cdnCacheSettings: '[data-testid="form-horizontal-cache-expiration-policies-edge-cache-settings__radio__cdnCacheSettings-radio-0"]'
+    browserCacheSettings:
+      '[data-testid="form-horizontal-cache-expiration-policies-browser-cache-settings__radio__browserCacheSettings-radio-0"]',
+    cdnCacheSettings:
+      '[data-testid="form-horizontal-cache-expiration-policies-edge-cache-settings__radio__cdnCacheSettings-radio-0"]'
   },
   accordionStepDomain: {
-    createDomain: '[data-testid="create-domain-accordion"]',
+    createDomain: '[data-testid="create-domain-accordion"]'
   },
   deviceGroups: {
     createButton: '[data-testid="create-device-group-button"]',
@@ -32,7 +36,7 @@ export default {
   },
   rulesEngine: {
     createButton: '[data-testid="rules-engine-create-button"]',
-    
+
     ruleNameInput: '[data-testid="rule-form-general-name__input"]',
     createCachePolicyButton:
       '[data-testid="edge-applications-rules-engine-form__create-cache-policy-button"]',
@@ -86,7 +90,8 @@ export default {
     reviewChanges: '[data-testid="rules-engine-save-order-button"] > .p-button-label',
     reviewChangesModal: '[data-testid="review-changes-dialog-warning-message-details"]',
     saveReorder: '[data-testid="review-changes-dialog-footer-delete-button"] > .p-button-label',
-    edgeConnectorsDropdown: '[data-testid="edge-application-rule-form__edge-connector-item[0]__dropdown"]',
+    edgeConnectorsDropdown:
+      '[data-testid="edge-application-rule-form__edge-connector-item[0]__dropdown"]',
     edgeConnectorsDropdownItem: '#behaviors\\[0\\]\\.edgeConnectorId_0'
   },
   origins: {

--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -37,17 +37,18 @@
     edgeFunctionsServices: { type: Object, required: true }
   })
 
-  const defaultTabs = {
+  const defaultTabs = ref({
     'main-settings': 0,
-    origins: 1,
-    'device-groups': 2,
-    'error-responses': 3,
-    'cache-settings': 4,
-    functions: 5,
-    'rules-engine': 6
-  }
-
-  const mapTabs = ref({ ...defaultTabs })
+    origins: !hasFlagBlockApiV4() ? null : 1,
+    'device-groups': !hasFlagBlockApiV4() ? 1 : 2,
+    'error-responses': !hasFlagBlockApiV4() ? null : 3,
+    'cache-settings': !hasFlagBlockApiV4() ? 2 : 4,
+    functions: !hasFlagBlockApiV4() ? 3 : 5,
+    'rules-engine': !hasFlagBlockApiV4() ? 4 : 6
+  })
+  const mapTabs = ref({
+    ...defaultTabs.value
+  })
 
   const toast = useToast()
   const route = useRoute()
@@ -112,7 +113,7 @@
       reindexMapTabs()
       return
     }
-    mapTabs.value = { ...defaultTabs }
+    mapTabs.value = { ...defaultTabs.value }
   }
 
   const renderTabByCurrentRouter = async () => {
@@ -238,7 +239,7 @@
     {
       header: 'Origins',
       component: EdgeApplicationsOriginsListView,
-      condition: true,
+      condition: hasFlagBlockApiV4(),
       show: showTabs.origins,
       props: () => ({
         ...props.originsServices,
@@ -260,7 +261,7 @@
     {
       header: 'Error Responses',
       component: EdgeApplicationsErrorResponseEditView,
-      condition: true,
+      condition: hasFlagBlockApiV4(),
       show: showTabs.errorResponses,
       props: () => ({
         ...props.errorResponsesServices,


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
- on Edge Application, conditionally show Origins and Error Responses tabs 
- add tests e2mock for validation
### Does this PR introduce breaking changes?

- [ ] No
- [X] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
