### PR TITLE
[UXE-9029] fix: integration validation Form Builder blocking send request data

### DIFF
--- a/src/views/EdgeApplicationsFunctions/Drawer/index.vue
+++ b/src/views/EdgeApplicationsFunctions/Drawer/index.vue
@@ -17,7 +17,15 @@
         @additionalErrors="handleAdditionalErrors"
       />
     </template>
+    <template #actionBar="{ onSubmit, onCancel, loading }">
+      <ActionBarBlock
+        @onSubmit="formSubmit(onSubmit)"
+        @onCancel="onCancel"
+        :loading="isLoading || loading"
+      />
+    </template>
   </CreateDrawerBlock>
+
   <EditDrawerBlock
     v-if="loadEditFunctionDrawer"
     :id="selectedFunctionToEdit"

--- a/src/views/EdgeApplicationsFunctions/Drawer/index.vue
+++ b/src/views/EdgeApplicationsFunctions/Drawer/index.vue
@@ -98,8 +98,8 @@
       return
     }
 
-    isLoading.value = false
     await onSubmit()
+    isLoading.value = false
   }
 
   const handleSuccessEdit = () => {

--- a/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -16,7 +16,7 @@
   import indentJsonStringify from '@/utils/indentJsonStringify'
   import { edgeFunctionService } from '@/services/v2'
 
-  const emit = defineEmits(['toggleDrawer'])
+  const emit = defineEmits(['toggleDrawer', 'additionalErrors'])
 
   const renderers = markRaw([...vanillaRenderers])
 
@@ -31,6 +31,7 @@
   const azionFormArgsValue = ref('{}')
   const azionFormData = ref({})
   const azionFormError = ref(false)
+  const azionFormValidationErrors = ref([])
   const hasFormBuilder = ref(false)
   const showFormBuilder = ref(false)
   const selectPanelOptions = ['Form', 'JSON']
@@ -79,8 +80,11 @@
 
   const onChangeAzionForm = (event) => {
     azionFormData.value = event.data
+    azionFormValidationErrors.value = event.errors || []
     azionFormArgsValue.value = indentJsonStringify(event.data)
     args.value = indentJsonStringify(event.data)
+
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const selectPanelUpdateModelValue = (value) => {
@@ -120,6 +124,7 @@
     azionFormData.value = {}
     schemaAzionForm.value = {}
     schemaAzionFormString.value = '{}'
+    azionFormValidationErrors.value = []
     azionForm.value = schemaAzionFormString.value
   }
 
@@ -166,6 +171,7 @@
     azionFormData.value = argsJsonParser(args.value)
     schemaAzionFormString.value = azForm
     azionForm.value = schemaAzionFormString.value
+    azionFormValidationErrors.value = []
 
     setAzionFormSchema(argsJsonParser(azForm))
     setAzionFormEmptyState(argsJsonParser(azForm))
@@ -330,8 +336,8 @@
           class="flex flex-col gap-4"
         >
           <TitleDescriptionArea
-            :title="`Arguments`"
-            :description="`Configure the function arguments to customize its behavior.`"
+            title="Arguments"
+            description="Configure the function arguments to customize its behavior."
           />
           <div class="resize-y overflow-y-auto">
             <CodeEditor

--- a/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeApplicationsFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -124,8 +124,9 @@
     azionFormData.value = {}
     schemaAzionForm.value = {}
     schemaAzionFormString.value = '{}'
-    azionFormValidationErrors.value = []
     azionForm.value = schemaAzionFormString.value
+    azionFormValidationErrors.value = []
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const codeEditorFormBuilderUpdate = (value) => {

--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -19,7 +19,15 @@
         :loadEdgeFunctionService="edgeFunctionService.loadEdgeFunction"
       />
     </template>
+    <template #actionBar="{ onSubmit, onCancel, loading }">
+      <ActionBarBlock
+        @onSubmit="formSubmit(onSubmit)"
+        @onCancel="onCancel"
+        :loading="isLoading || loading"
+      />
+    </template>
   </CreateDrawerBlock>
+
   <EditDrawerBlock
     v-if="loadEditFunctionDrawer"
     :id="selectedFunctionToEdit"

--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -120,8 +120,8 @@
       return
     }
 
-    isLoading.value = false
     await onSubmit()
+    isLoading.value = false
   }
 
   const handleAdditionalErrors = (errors) => {

--- a/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -125,6 +125,7 @@
     schemaAzionFormString.value = '{}'
     azionFormValidationErrors.value = []
     azionForm.value = schemaAzionFormString.value
+    emit('additionalErrors', [])
   }
 
   const codeEditorFormBuilderUpdate = (value) => {

--- a/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
+++ b/src/views/EdgeFirewallFunctions/FormFields/FormFieldsEdgeApplicationsFunctions.vue
@@ -16,6 +16,8 @@
   import indentJsonStringify from '@/utils/indentJsonStringify'
   import { edgeFunctionService } from '@/services/v2'
 
+  const emit = defineEmits(['toggleDrawer', 'additionalErrors'])
+
   const { value: name } = useField('name')
   const { value: edgeFunctionID } = useField('edgeFunctionID')
   const { value: args, errorMessage: argsError } = useField('args')
@@ -27,13 +29,12 @@
   const azionFormArgsValue = ref('{}')
   const azionFormData = ref({})
   const azionFormError = ref(false)
+  const azionFormValidationErrors = ref([])
   const hasFormBuilder = ref(false)
   const showFormBuilder = ref(false)
   const selectPanelOptions = ['Form', 'JSON']
   const selectPanelValue = ref(selectPanelOptions[0])
   const renderers = markRaw([...vanillaRenderers])
-
-  const emit = defineEmits(['toggleDrawer'])
 
   const drawerRef = ref('')
   const openDrawer = () => {
@@ -78,8 +79,11 @@
 
   const onChangeAzionForm = (event) => {
     azionFormData.value = event.data
+    azionFormValidationErrors.value = event.errors || []
     azionFormArgsValue.value = indentJsonStringify(event.data)
     args.value = indentJsonStringify(event.data)
+
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const selectPanelUpdateModelValue = (value) => {
@@ -119,6 +123,7 @@
     azionFormData.value = {}
     schemaAzionForm.value = {}
     schemaAzionFormString.value = '{}'
+    azionFormValidationErrors.value = []
     azionForm.value = schemaAzionFormString.value
   }
 
@@ -165,6 +170,7 @@
     azionFormData.value = argsJsonParser(args.value)
     schemaAzionFormString.value = azForm
     azionForm.value = schemaAzionFormString.value
+    azionFormValidationErrors.value = []
 
     setAzionFormSchema(argsJsonParser(azForm))
     setAzionFormEmptyState(argsJsonParser(azForm))

--- a/src/views/EdgeFunctions/CreateView.vue
+++ b/src/views/EdgeFunctions/CreateView.vue
@@ -2,19 +2,14 @@
   import { ref, onMounted, inject } from 'vue'
   import { useRoute } from 'vue-router'
   import * as yup from 'yup'
-
   import ContentBlock from '@/templates/content-block'
   import CreateFormBlock from '@/templates/create-form-block'
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import PageHeadingBlock from '@/templates/page-heading-block'
-
   import FormFieldsCreateEdgeFunctions from './FormFields/FormFieldsCreateEdgeFunctions'
-
   import MobileCodePreview from './components/mobile-code-preview.vue'
-
   import HelloWorldSample from '@/helpers/edge-function-hello-world'
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
-
   import { useLoadingStore } from '@/stores/loading'
   import { edgeFunctionService } from '@/services/v2'
 
@@ -22,7 +17,6 @@
   const tracker = inject('tracker')
   const route = useRoute()
   const ARGS_INITIAL_STATE = '{}'
-
   const isLoading = ref(false)
   const additionalErrors = ref([])
 
@@ -46,14 +40,6 @@
       })
       .track()
   }
-
-  onMounted(() => {
-    const store = useLoadingStore()
-    store.startLoading()
-    if (document.readyState == 'complete') {
-      store.finishLoading()
-    }
-  })
 
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field'),
@@ -116,6 +102,14 @@
     await onSubmit()
     isLoading.value = false
   }
+
+  onMounted(() => {
+    const store = useLoadingStore()
+    store.startLoading()
+    if (document.readyState == 'complete') {
+      store.finishLoading()
+    }
+  })
 </script>
 
 <template>

--- a/src/views/EdgeFunctions/CreateView.vue
+++ b/src/views/EdgeFunctions/CreateView.vue
@@ -1,22 +1,27 @@
 <script setup>
+  import { ref, onMounted, inject } from 'vue'
+  import { useRoute } from 'vue-router'
   import * as yup from 'yup'
-  import HelloWorldSample from '@/helpers/edge-function-hello-world'
-  import FormFieldsCreateEdgeFunctions from './FormFields/FormFieldsCreateEdgeFunctions'
+
   import ContentBlock from '@/templates/content-block'
   import CreateFormBlock from '@/templates/create-form-block'
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import PageHeadingBlock from '@/templates/page-heading-block'
-  import { handleTrackerError } from '@/utils/errorHandlingTracker'
+  
+  import FormFieldsCreateEdgeFunctions from './FormFields/FormFieldsCreateEdgeFunctions'
+  
   import MobileCodePreview from './components/mobile-code-preview.vue'
-  import { ref, onMounted, inject } from 'vue'
+  
+  import HelloWorldSample from '@/helpers/edge-function-hello-world'
+  import { handleTrackerError } from '@/utils/errorHandlingTracker'
+  
   import { useLoadingStore } from '@/stores/loading'
-  import { useRoute } from 'vue-router'
   import { edgeFunctionService } from '@/services/v2'
 
-  const route = useRoute()
+  
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
-
+  const route = useRoute()
   const ARGS_INITIAL_STATE = '{}'
 
   const handleTrackCreation = (response) => {

--- a/src/views/EdgeFunctions/EditView.vue
+++ b/src/views/EdgeFunctions/EditView.vue
@@ -6,13 +6,13 @@
   import EditFormBlock from '@/templates/edit-form-block'
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import PageHeadingBlock from '@/templates/page-heading-block'
-  
+
   import FormFieldsEditEdgeFunctions from './FormFields/FormFieldsEditEdgeFunctions.vue'
   import MobileCodePreview from './components/mobile-code-preview.vue'
-  
+
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
   import { edgeFunctionService } from '@/services/v2'
-  
+
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
 
@@ -22,6 +22,9 @@
       required: true
     }
   })
+
+  const isLoading = ref(false)
+  const additionalErrors = ref([])
   const updateObject = ref({})
   const runtime = ref(null)
   const name = ref('')
@@ -61,6 +64,26 @@
     active: yup.boolean(),
     runtime: yup.string()
   })
+
+  const hasAdditionalErrors = () => {
+    return additionalErrors.value.length
+  }
+
+  const handleAdditionalErrors = (errors) => {
+    additionalErrors.value = errors
+  }
+
+  const formSubmit = async (onSubmit) => {
+    isLoading.value = true
+
+    if (hasAdditionalErrors()) {
+      isLoading.value = false
+      return
+    }
+
+    await onSubmit()
+    isLoading.value = false
+  }
 </script>
 
 <template>
@@ -87,13 +110,14 @@
             v-model:preview-data="updateObject"
             v-model:run="runtime"
             v-model:name="name"
+            @additionalErrors="handleAdditionalErrors"
           />
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading }">
           <ActionBarBlockWithTeleport
-            @onSubmit="onSubmit"
+            @onSubmit="formSubmit(onSubmit)"
             @onCancel="onCancel"
-            :loading="loading"
+            :loading="isLoading || loading"
           />
         </template>
       </EditFormBlock>

--- a/src/views/EdgeFunctions/EditView.vue
+++ b/src/views/EdgeFunctions/EditView.vue
@@ -1,16 +1,20 @@
 <script setup>
+  import { ref, inject } from 'vue'
   import * as yup from 'yup'
+
   import ContentBlock from '@/templates/content-block'
   import EditFormBlock from '@/templates/edit-form-block'
-  import FormFieldsEditEdgeFunctions from './FormFields/FormFieldsEditEdgeFunctions.vue'
-  import PageHeadingBlock from '@/templates/page-heading-block'
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
-  import { handleTrackerError } from '@/utils/errorHandlingTracker'
+  import PageHeadingBlock from '@/templates/page-heading-block'
+  
+  import FormFieldsEditEdgeFunctions from './FormFields/FormFieldsEditEdgeFunctions.vue'
   import MobileCodePreview from './components/mobile-code-preview.vue'
-  import { ref, inject } from 'vue'
+  
+  import { handleTrackerError } from '@/utils/errorHandlingTracker'
+  import { edgeFunctionService } from '@/services/v2'
+  
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
-  import { edgeFunctionService } from '@/services/v2'
 
   const props = defineProps({
     updatedRedirect: {

--- a/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
@@ -33,7 +33,7 @@
     }
   })
 
-  const emit = defineEmits(['update:previewData'])
+  const emit = defineEmits(['update:previewData', 'additionalErrors'])
 
   const SPLITTER_PROPS = {
     height: '50vh',
@@ -48,6 +48,7 @@
   const showFormBuilder = ref(false)
   const azionFormData = ref({})
   const azionFormError = ref(false)
+  const azionFormValidationErrors = ref([])
   const schemaAzionFormString = ref('{}')
   const emptySchemaAzionForm = ref(true)
   const selectPanelOptions = ['JSON', 'Form Builder']
@@ -132,8 +133,12 @@
   })
 
   const onChangeAzionForm = (event) => {
+    azionFormValidationErrors.value = event.errors || []
+    
     codeEditorArgsUpdate(indentJsonStringify(event.data))
     setAzionFormData(event.data)
+    
+    emit('additionalErrors', event.errors || [])
   }
 
   const setDefaultFormBuilder = () => {
@@ -148,6 +153,9 @@
     schemaAzionFormString.value = '{}'
     azionForm.value = {}
     emptySchemaAzionForm.value = true
+
+    azionFormValidationErrors.value = []
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const executionEnvironmentOptions = [

--- a/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
@@ -134,10 +134,10 @@
 
   const onChangeAzionForm = (event) => {
     azionFormValidationErrors.value = event.errors || []
-    
+
     codeEditorArgsUpdate(indentJsonStringify(event.data))
     setAzionFormData(event.data)
-    
+
     emit('additionalErrors', azionFormValidationErrors.value)
   }
 

--- a/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsCreateEdgeFunctions.vue
@@ -138,7 +138,7 @@
     codeEditorArgsUpdate(indentJsonStringify(event.data))
     setAzionFormData(event.data)
     
-    emit('additionalErrors', event.errors || [])
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const setDefaultFormBuilder = () => {
@@ -153,7 +153,6 @@
     schemaAzionFormString.value = '{}'
     azionForm.value = {}
     emptySchemaAzionForm.value = true
-
     azionFormValidationErrors.value = []
     emit('additionalErrors', azionFormValidationErrors.value)
   }

--- a/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
@@ -189,7 +189,7 @@
     azionForm.value = {}
     emptySchemaAzionForm.value = true
     azionFormValidationErrors.value = []
-    
+
     emit('additionalErrors', azionFormValidationErrors.value)
   }
 </script>

--- a/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
@@ -23,7 +23,7 @@
   import { defaultSchemaFormBuilder } from './Config'
 
   defineProps(['previewData', 'run'])
-  const emit = defineEmits(['update:previewData', 'update:run', 'update:name'])
+  const emit = defineEmits(['update:previewData', 'update:run', 'update:name', 'additionalErrors'])
 
   const SPLITTER_PROPS = {
     height: '50vh',
@@ -37,6 +37,7 @@
   const showFormBuilder = ref(false)
   const azionFormData = ref({})
   const azionFormError = ref(false)
+  const azionFormValidationErrors = ref([])
   const schemaAzionFormString = ref('{}')
   const emptySchemaAzionForm = ref(true)
   const selectPanelOptions = ['JSON', 'Form Builder']
@@ -167,8 +168,12 @@
   }
 
   const onChangeAzionForm = (event) => {
+    azionFormValidationErrors.value = event.errors || []
+
     codeEditorArgsUpdate(indentJsonStringify(event.data))
     setAzionFormData(event.data)
+
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 
   const setDefaultFormBuilder = () => {
@@ -183,6 +188,9 @@
     schemaAzionFormString.value = '{}'
     azionForm.value = {}
     emptySchemaAzionForm.value = true
+    azionFormValidationErrors.value = []
+    
+    emit('additionalErrors', azionFormValidationErrors.value)
   }
 </script>
 


### PR DESCRIPTION
## Form Builder Integration Validation Enhancement

Issue:
https://aziontech.atlassian.net/browse/UXE-9029

On this pull request it is to blocking request update function instance in the Application and Firewall instance functions.

<img width="1696" height="987" alt="Screenshot 2025-09-17 at 5 12 00 PM" src="https://github.com/user-attachments/assets/52c6157e-ac0f-4adb-93d9-a79e6e84cae4" />

### Objective:
Block request submission for Application and Firewall instance functions when form validation fails.
Current Implementation Analysis

### Problem
- Form submission is not being blocked when validation errors exist
- Application and Firewall functions can send invalid data to the server
- No proper feedback mechanism for validation states


