### PR TITLE
[UXE-7843] feat: share block on Edit Function Instance

### DIFF
--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -44,7 +44,7 @@
   import Button from 'primevue/button'
   import InputText from 'primevue/inputtext'
   import OverlayPanel from 'primevue/overlaypanel'
-  
+
   const overlayPanel = ref()
   const copyButton = ref()
   const tooltipMessage = ref('')

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -44,11 +44,12 @@
   import Button from 'primevue/button'
   import InputText from 'primevue/inputtext'
   import OverlayPanel from 'primevue/overlaypanel'
-
+  
   const overlayPanel = ref()
   const copyButton = ref()
   const tooltipMessage = ref('')
   const showTooltip = ref(false)
+  const delay = 2000
   const url = computed(() => window.location.href)
 
   const tooltipConfig = computed(() => {
@@ -58,7 +59,7 @@
     return {
       value: tooltipMessage.value,
       showDelay: 0,
-      hideDelay: 2000,
+      hideDelay: delay,
       disabled: false
     }
   })
@@ -96,7 +97,7 @@
         const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
         buttonEl.dispatchEvent(mouseLeaveEvent)
         showTooltip.value = false
-      }, 2000)
+      }, delay)
     }
   }
 </script>

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -1,0 +1,57 @@
+<template>
+  <Button
+    type="button"
+    icon="pi pi-share-alt"
+    size="small"
+    label=""
+    @click="toggle"
+    outlined
+  />
+
+  <OverlayPanel ref="overlayPanel">
+    <div class="flex flex-column gap-4 w-25rem">
+      <div class="flex flex-column gap-4">
+        <p class="text-sm text-900 block mb-2">
+          Share this link to provide direct access to this drawer. It allows users to quickly
+          navigate to the specific configuration.
+        </p>
+
+        <div class="w-full">
+          <strong class="text-color text-sm text-900 block mb-2"> Direct link </strong>
+          <InputText
+            readonly
+            :value="url"
+            class="w-full"
+          />
+        </div>
+        <div>
+          <Button
+            outlined
+            icon="pi pi-copy"
+            size="small"
+            label="Copy link"
+            @click="copyToClipboard"
+          />
+        </div>
+      </div>
+    </div>
+  </OverlayPanel>
+</template>
+
+<script setup>
+  import { ref, computed } from 'vue'
+  import Button from 'primevue/button'
+  import InputText from 'primevue/inputtext'
+  import OverlayPanel from 'primevue/overlaypanel'
+
+  const overlayPanel = ref()
+  const url = computed(() => window.location.href)
+
+  const toggle = (event) => {
+    overlayPanel.value.toggle(event)
+  }
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(url.value)
+  }
+</script>

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -3,7 +3,6 @@
     type="button"
     icon="pi pi-share-alt"
     size="small"
-    label=""
     @click="toggle"
     outlined
   />
@@ -26,8 +25,10 @@
         </div>
         <div>
           <Button
+            ref="copyButton"
+            v-tooltip="tooltipConfig"
             outlined
-            icon="pi pi-copy"
+            icon="pi pi-copy" 
             size="small"
             label="Copy link"
             @click="copyToClipboard"
@@ -39,19 +40,69 @@
 </template>
 
 <script setup>
-  import { ref, computed } from 'vue'
+  import { ref, computed, nextTick } from 'vue'
   import Button from 'primevue/button'
   import InputText from 'primevue/inputtext'
   import OverlayPanel from 'primevue/overlaypanel'
 
   const overlayPanel = ref()
+  const copyButton = ref()
+  const tooltipMessage = ref('')
+  const showTooltip = ref(false)
   const url = computed(() => window.location.href)
+
+  const tooltipConfig = computed(() => {
+    if (!showTooltip.value) {
+      return { disabled: true }
+    }
+    return {
+      value: tooltipMessage.value,
+      showDelay: 0,
+      hideDelay: 2000,
+      disabled: false
+    }
+  })
 
   const toggle = (event) => {
     overlayPanel.value.toggle(event)
   }
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(url.value)
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(url.value)
+      tooltipMessage.value = 'Copied'
+      showTooltip.value = true
+      
+      await nextTick()
+      
+      const buttonEl = copyButton.value?.$el || copyButton.value
+      if (buttonEl) {
+        const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
+        buttonEl.dispatchEvent(mouseEnterEvent)
+        
+        setTimeout(() => {
+          const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
+          buttonEl.dispatchEvent(mouseLeaveEvent)
+          showTooltip.value = false
+        }, 2000)
+      }
+    } catch (err) {
+      tooltipMessage.value = 'Failed to copy'
+      showTooltip.value = true
+      
+      await nextTick()
+      
+      const buttonEl = copyButton.value?.$el || copyButton.value
+      if (buttonEl) {
+        const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
+        buttonEl.dispatchEvent(mouseEnterEvent)
+        
+        setTimeout(() => {
+          const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
+          buttonEl.dispatchEvent(mouseLeaveEvent)
+          showTooltip.value = false
+        }, 2000)
+      }
+    }
   }
 </script>

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -28,7 +28,7 @@
             ref="copyButton"
             v-tooltip="tooltipConfig"
             outlined
-            icon="pi pi-copy" 
+            icon="pi pi-copy"
             size="small"
             label="Copy link"
             @click="copyToClipboard"
@@ -67,36 +67,36 @@
     overlayPanel.value.toggle(event)
   }
 
-const copyToClipboard = async () => {
-  try {
-    await navigator.clipboard.writeText(url.value)
-    tooltipMessage.value = 'Copied'
-    showTooltip.value = true
-    
-    await showTooltipOnButton()
-  } catch (err) {
-    console.error('Failed to copy to clipboard:', err) // eslint-disable-line
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(url.value)
+      tooltipMessage.value = 'Copied'
+      showTooltip.value = true
 
-    tooltipMessage.value = 'Failed to copy'
-    showTooltip.value = true
-    
-    await showTooltipOnButton()
-  }
-}
+      await showTooltipOnButton()
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err) // eslint-disable-line
 
-const showTooltipOnButton = async () => {
-  await nextTick()
-  
-  const buttonEl = copyButton.value?.$el || copyButton.value
-  if (buttonEl) {
-    const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
-    buttonEl.dispatchEvent(mouseEnterEvent)
-    
-    setTimeout(() => {
-      const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
-      buttonEl.dispatchEvent(mouseLeaveEvent)
-      showTooltip.value = false
-    }, 2000)
+      tooltipMessage.value = 'Failed to copy'
+      showTooltip.value = true
+
+      await showTooltipOnButton()
+    }
   }
-}
+
+  const showTooltipOnButton = async () => {
+    await nextTick()
+
+    const buttonEl = copyButton.value?.$el || copyButton.value
+    if (buttonEl) {
+      const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
+      buttonEl.dispatchEvent(mouseEnterEvent)
+
+      setTimeout(() => {
+        const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
+        buttonEl.dispatchEvent(mouseLeaveEvent)
+        showTooltip.value = false
+      }, 2000)
+    }
+  }
 </script>

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -67,42 +67,35 @@
     overlayPanel.value.toggle(event)
   }
 
-  const copyToClipboard = async () => {
-    try {
-      await navigator.clipboard.writeText(url.value)
-      tooltipMessage.value = 'Copied'
-      showTooltip.value = true
-      
-      await nextTick()
-      
-      const buttonEl = copyButton.value?.$el || copyButton.value
-      if (buttonEl) {
-        const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
-        buttonEl.dispatchEvent(mouseEnterEvent)
-        
-        setTimeout(() => {
-          const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
-          buttonEl.dispatchEvent(mouseLeaveEvent)
-          showTooltip.value = false
-        }, 2000)
-      }
-    } catch (err) {
-      tooltipMessage.value = 'Failed to copy'
-      showTooltip.value = true
-      
-      await nextTick()
-      
-      const buttonEl = copyButton.value?.$el || copyButton.value
-      if (buttonEl) {
-        const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
-        buttonEl.dispatchEvent(mouseEnterEvent)
-        
-        setTimeout(() => {
-          const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
-          buttonEl.dispatchEvent(mouseLeaveEvent)
-          showTooltip.value = false
-        }, 2000)
-      }
-    }
+const copyToClipboard = async () => {
+  try {
+    await navigator.clipboard.writeText(url.value)
+    tooltipMessage.value = 'Copied'
+    showTooltip.value = true
+    
+    await showTooltipOnButton()
+  } catch (err) {
+    tooltipMessage.value = 'Failed to copy'
+    showTooltip.value = true
+    
+    await showTooltipOnButton()
+  }
+}
+
+const showTooltipOnButton = async () => {
+  await nextTick()
+  
+  const buttonEl = copyButton.value?.$el || copyButton.value
+  if (buttonEl) {
+    const mouseEnterEvent = new MouseEvent('mouseenter', { bubbles: true })
+    buttonEl.dispatchEvent(mouseEnterEvent)
+    
+    setTimeout(() => {
+      const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true })
+      buttonEl.dispatchEvent(mouseLeaveEvent)
+      showTooltip.value = false
+    }, 2000)
+  }
+}
   }
 </script>

--- a/src/layout/components/navbar/share-url.vue
+++ b/src/layout/components/navbar/share-url.vue
@@ -75,6 +75,8 @@ const copyToClipboard = async () => {
     
     await showTooltipOnButton()
   } catch (err) {
+    console.error('Failed to copy to clipboard:', err) // eslint-disable-line
+
     tooltipMessage.value = 'Failed to copy'
     showTooltip.value = true
     
@@ -97,5 +99,4 @@ const showTooltipOnButton = async () => {
     }, 2000)
   }
 }
-  }
 </script>

--- a/src/templates/edit-drawer-block/index.vue
+++ b/src/templates/edit-drawer-block/index.vue
@@ -2,10 +2,11 @@
   import { computed, onBeforeMount, ref, provide } from 'vue'
   import { useForm, useIsFormDirty } from 'vee-validate'
   import { useToast } from 'primevue/usetoast'
+  import Sidebar from 'primevue/sidebar'
+  import ShareUrl from '@/layout/components/navbar/share-url'
+  import ConsoleFeedback from '@/layout/components/navbar/feedback'
   import ActionBarBlock from '@/templates/action-bar-block'
   import GoBack from '@/templates/action-bar-block/go-back'
-  import Sidebar from 'primevue/sidebar'
-  import ConsoleFeedback from '@/layout/components/navbar/feedback'
   import DialogUnsavedBlock from '@/templates/dialog-unsaved-block'
   import { useScrollToError } from '@/composables/useScrollToError'
   import { capitalizeFirstLetter } from '@/helpers'
@@ -49,6 +50,10 @@
       default: false
     },
     showBarGoBack: {
+      type: Boolean,
+      default: false
+    },
+    showShareUrl: {
       type: Boolean,
       default: false
     }
@@ -195,7 +200,10 @@
     >
       <template #header>
         <h2>{{ title }}</h2>
-        <ConsoleFeedback />
+        <div class="flex gap-2">
+          <ConsoleFeedback />
+          <ShareUrl v-if="showShareUrl" />
+        </div>
       </template>
       <div class="pb-16 w-full space-y-8">
         <form

--- a/src/views/EdgeApplicationsFunctions/Drawer/index.vue
+++ b/src/views/EdgeApplicationsFunctions/Drawer/index.vue
@@ -23,6 +23,7 @@
     :isOverlapped="isOverlapped"
     :editService="editService"
     :schema="validationSchema"
+    :showShareUrl="true"
     @onSuccess="handleSuccessEdit"
     @onError="handleFailedToEdit"
     title="Edit Instance"

--- a/src/views/EdgeFirewallFunctions/Drawer/index.vue
+++ b/src/views/EdgeFirewallFunctions/Drawer/index.vue
@@ -27,8 +27,9 @@
     :isOverlapped="isOverlapped"
     :editService="editService"
     :schema="validationSchema"
-    @onSuccess="handleSuccessEdit"
     :showBarGoBack="true"
+    :showShareUrl="true"
+    @onSuccess="handleSuccessEdit"
     @onError="handleFailedToEdit"
     title="Edit Instance"
   >


### PR DESCRIPTION
## Share Url

**Issue:**
https://aziontech.atlassian.net/browse/UXE-7843

**Figma:**
https://www.figma.com/design/0TY2pcUTBsndMlrs0ZUvQf/Console-UI--Migration-06-2024---06-2025-?node-id=18998-322760&t=vZWgoYP2M7FKU0no-0


Implemented the possibility to visual copy the current url with the query string params.

<img width="1697" height="1043" alt="Screenshot 2025-09-18 at 3 45 29 PM" src="https://github.com/user-attachments/assets/22dec245-67e8-48d6-a6eb-5ba1bec301a8" />

Tooltip on click

<img width="846" height="371" alt="Screenshot 2025-09-18 at 4 29 51 PM" src="https://github.com/user-attachments/assets/d3f67be1-c676-412d-b0e3-8f404550be05" />


### Objective

- Facilitate the share url with a visual indicator


### Added

- new file layout/navibar/share-url.vue
- added showShareUrl param to edit-drawer-block
