### PR TITLE
fix: remove edge in edge-connector creation path

### DIFF
--- a/src/views/EdgeConnectors/ListView.vue
+++ b/src/views/EdgeConnectors/ListView.vue
@@ -27,7 +27,7 @@
         title="No Connectors have been created"
         description="Click the button below to create your first Connectors."
         createButtonLabel="Connectors"
-        createPagePath="edge-connectors/create"
+        createPagePath="connectors/create"
         :documentationService="documentationService"
       >
         <template #illustration>


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
should open the creation screen when we do not have any registered connectors

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
