### PR TITLE
[UXE-9094] fix: asterisks as subdomain in workloads

### DIFF
--- a/src/services/v2/utils/adapter/domainAdapter.js
+++ b/src/services/v2/utils/adapter/domainAdapter.js
@@ -1,14 +1,46 @@
 import psl from 'psl'
 
+function parseWildcardDomain(urlOrHostname) {
+  if (!urlOrHostname || typeof urlOrHostname !== 'string') {
+    return { hasWildcard: false, cleanDomain: urlOrHostname, wildcardPrefix: '' }
+  }
+
+  const trimmed = urlOrHostname.trim()
+
+  if (trimmed.startsWith('*.')) {
+    return {
+      hasWildcard: true,
+      cleanDomain: trimmed.substring(2),
+      wildcardPrefix: '*'
+    }
+  }
+
+  return {
+    hasWildcard: false,
+    cleanDomain: trimmed,
+    wildcardPrefix: ''
+  }
+}
+
 export function getPrimaryDomain(urlOrHostname) {
   if (!urlOrHostname || typeof urlOrHostname !== 'string') {
     return { domain: '', subdomain: '' }
   }
 
-  const parsed = psl.parse(urlOrHostname)
+  const wildcardInfo = parseWildcardDomain(urlOrHostname)
+
+  const parsed = psl.parse(wildcardInfo.cleanDomain)
 
   if (parsed && parsed.domain) {
+    if (wildcardInfo.hasWildcard) {
+      return {
+        ...parsed,
+        subdomain: wildcardInfo.wildcardPrefix,
+        isWildcard: true
+      }
+    }
     return parsed
   }
+
   return { domain: '', subdomain: '' }
 }


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
fix load workload when has asterics in subdomain
### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [ ] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [ ] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
