### PR TITLE
chore: rename Edge Storage type to Object Storage in edge connectors

### DIFF
--- a/src/services/v2/edge-connectors/edge-connectors-adapter.js
+++ b/src/services/v2/edge-connectors/edge-connectors-adapter.js
@@ -174,7 +174,7 @@ const typeBuildersLoadRequest = {
 
 const edgeConnectorsTypes = {
   http: 'HTTP',
-  storage: 'Edge Storage',
+  storage: 'Object Storage',
   live_ingest: 'Live Ingest'
 }
 


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

rename Edge Storage type to Object Storage in edge connectors

### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
rename Edge Storage type to Object Storage in edge connectors

<img width="1653" height="838" alt="image" src="https://github.com/user-attachments/assets/b5920ef2-3121-41eb-9fc3-b441269e9295" />


<hr />

