### PR TITLE
[UXE-9039] fix: upstream status charts does not consider M and K correctly for ordering

### DIFF
--- a/src/modules/real-time-metrics/reports/convert-beholder-to-chart.js
+++ b/src/modules/real-time-metrics/reports/convert-beholder-to-chart.js
@@ -481,7 +481,8 @@ const formatListChart = ({ report, data }) => {
   // Formata os valores da agregação para exibição
   const formattedData = dataset.map((item) => ({
     ...item,
-    [aggregationKey]: formatDataUnit(item[aggregationKey], report)?.value
+    [aggregationKey]: formatDataUnit(item[aggregationKey], report)?.value,
+    [`${aggregationKey}_raw`]: item[aggregationKey]
   }))
 
   fieldsHandle.push(aggregationKey)
@@ -489,7 +490,8 @@ const formatListChart = ({ report, data }) => {
   // Define as colunas com os nomes corretos
   const columns = fieldsHandle.map((field) => ({
     field,
-    header: CHART_RULES.COLUMN_NAMES_FIELD[field] || camelToTitle(field)
+    header: CHART_RULES.COLUMN_NAMES_FIELD[field] || camelToTitle(field),
+    sortField: field === aggregationKey ? `${field}_raw` : field
   }))
 
   return [{ data: formattedData, columns }]


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
upstream status charts does not consider M and K correctly for ordering

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave
