### PR TITLE
[UXE-9090] fix: emit event when change relative time

### DIFF
--- a/src/components/base/dataTimeRange/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange/inputDateRange/index.vue
@@ -384,6 +384,7 @@
       hasChanges.value = false
       tempInputValue.value = ''
       model.value.label = ''
+      emit('select', model.value)
     }
   }
 


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
- Mudar o filtro relativo não dispara evento para carregar os dados
Antes:

https://github.com/user-attachments/assets/3acf3cd8-df17-401d-9953-99a9eb4b0cb1

Depois:

https://github.com/user-attachments/assets/f1f0b0d5-6765-443f-aa72-de4b0a36a1fd



### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [] Application responsiveness was tested to different screen sizes
- [ ] New tests are added to prevent the same issue from happening again
- [ ] UI changes are validated by a team designer
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
