### PR TITLE
[UXE-9204] [DEV TOOLS WARN] fix: dev mode warn __VUE_PROD_HYDRATION_MISMATCH_DETAILS__

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,6 +38,9 @@ const getConfig = () => {
     build: {
       sourcemap: IS_SENTRY_UPLOAD ? 'hidden' : 'inline'
     },
+    define: {
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false
+    },
     plugins: [
       vue(),
       vueJsx(),


### PR DESCRIPTION
## Overview
This PR defines the `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` feature flag to eliminate excessive Vue development warnings that clutter the console during development.

## Problem
Currently, opening the browser dev tools triggers persistent hydration mismatch warnings because this variable is not explicitly defined in the ESM bundle.

### Warning Example
<img width="998" height="122" alt="Screenshot 2025-10-08 at 11 20 19 AM" src="https://github.com/user-attachments/assets/01552650-a243-484d-afa3-a987a61f8d13" />

## How to Reproduce
1. Run `yarn dev`
2. Open the Console on the Home page
3. Observe the hydration mismatch warnings

## Solution
Explicitly define the `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` feature flag in the build configuration to suppress these warnings in development mode.

## References
- [Vue.js Bundler Build Feature Flags](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags)