### PR TITLE
[ENG-35345] [DEV TOOLS WARN]  fix: breadcrumb and menu-production vue-router warning deprecation

### DIFF
--- a/src/layout/components/menu-production/index.vue
+++ b/src/layout/components/menu-production/index.vue
@@ -43,14 +43,14 @@
       @focus="scrollToFocusedItem"
     >
       <template #item="{ item, label, props }">
-        <a
-          class="flex h-9 focus:outline-none"
-          v-bind="props.action"
+        <router-link
+          :to="item.to"
           @click.prevent="redirectToRoute(item)"
           @click.middle="windowOpen(item.to)"
-          :href="item.to"
           :data-testid="`sidebar-block__menu-item__${item.id}`"
           v-if="hasClientFlag(item)"
+          v-bind="props.action"
+          class="flex h-9 focus:outline-none"
         >
           <span v-bind="props.icon" />
           <span v-bind="props.label">{{ label }}</span>
@@ -60,7 +60,7 @@
             :value="item.tag"
             class="ml-2"
           />
-        </a>
+        </router-link>
       </template>
     </PrimeMenu>
   </Sidebar>

--- a/src/templates/page-heading-block/index.vue
+++ b/src/templates/page-heading-block/index.vue
@@ -3,7 +3,7 @@
   import Breadcrumb from 'primevue/breadcrumb'
   import PrimeTag from 'primevue/tag'
   import { computed, useSlots } from 'vue'
-  import { useRouter, RouterLink } from 'vue-router'
+  import { useRouter } from 'vue-router'
 
   defineOptions({
     name: 'PageHeadingBlock'


### PR DESCRIPTION
## breadcrumb  and menu-production vue-router warning deprecation

The same case of [pull request](https://github.com/aziontech/azion-console-kit/pull/2850) but with the Breadcrumb component.