### PR TITLE
[UXE-7893] fix: replace incorrect clone icon with the proper one

### DIFF
--- a/src/views/EdgeFirewall/ListView.vue
+++ b/src/views/EdgeFirewall/ListView.vue
@@ -35,7 +35,7 @@
     {
       type: 'dialog',
       label: 'Clone',
-      icon: 'pi pi-fw pi-copy',
+      icon: 'pi pi-fw pi-clone',
       dialog: {
         component: CloneBlock,
         body: (item) => ({


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
[UXE-7893] fix: replace incorrect clone icon with the proper one
### Does this PR introduce breaking changes?

- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [x] Brave


[UXE-7893]: https://aziontech.atlassian.net/browse/UXE-7893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ