### PR TITLE
[ENG-35342] fix: warn toggle menu-profile

### DIFF
--- a/src/layout/components/menu-profile/index.vue
+++ b/src/layout/components/menu-profile/index.vue
@@ -222,7 +222,8 @@
       >
         {{ item.label }}
       </router-link>
-      <span v-else
+      <span
+        v-else
         v-bind="props.action"
       >
         {{ item.label }}

--- a/src/templates/sign-in-block/forgot-password.vue
+++ b/src/templates/sign-in-block/forgot-password.vue
@@ -103,7 +103,6 @@
   import { useForm } from 'vee-validate'
   import { ref } from 'vue'
   import { useToast } from 'primevue/usetoast'
-  
 
   const SUBMIT_TIMER = 60
 


### PR DESCRIPTION
Reopening: https://github.com/aziontech/azion-console-kit/pull/2850

## Fix: Conditional router-link rendering for menu items

### Why was this reverted?

The `v-if="item.to"` condition is necessary to handle menu items that trigger actions instead of navigation. Specifically, the "Switch Account" button opens a dialog rather than linking to a page.

In the initial implementation, when the "Switch Account" option was hidden for Marketing accounts, it caused unexpected behavior because the router-link was still being rendered for items without a `to` property.

### The fix

- Added `v-if="item.to"` validation to the `router-link` component to ensure it only renders for items with a valid route
- This prevents router-link from wrapping action-based menu items (like dialogs)
- Resolves the issue where non-navigational items were incorrectly treated as links

### Testing

- ✅ Navigation items work correctly
- ✅ "Switch Account" button opens dialog without routing issues
- ✅ Hidden items don't cause rendering problems