### PR TITLE
[ENG-35673] fix: pluralize firewall route in bredcrumb

### DIFF
--- a/src/router/routes/firewall-routes/index.js
+++ b/src/router/routes/firewall-routes/index.js
@@ -63,7 +63,7 @@ export const edgeFirewallRoutes = {
         breadCrumbs: [
           {
             label: 'Firewall',
-            to: '/firewall'
+            to: '/firewalls'
           },
           {
             label: 'Edit Firewall'


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
<img width="299" height="106" alt="image" src="https://github.com/user-attachments/assets/6a6a580c-693d-47d1-baa1-e5b178127dfb" />

when editing a firewall and click at "Firewall" item in the breadcrumb is redirecting to not found page

### Solution

Pluralize firewall route in the breadcrumb 
