### PR TITLE
[ISSUE-35687] fix: rename script runner to get logs - fix of 503

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -107,8 +107,8 @@ const config = {
       {
         name: 'origin-script-runner',
         type: 'single_origin',
-        hostHeader: `script-runner.azion.com`,
-        addresses: [`script-runner.azion.com`]
+        hostHeader: `script-runner.azion.net`,
+        addresses: [`script-runner.azion.net`]
       },
       {
         name: 'origin-template-engine',


### PR DESCRIPTION
## Script runner status 503

https://aziontech.atlassian.net/jira/software/c/projects/ENG/boards/1524?assignee=5b30eea62106432d8401134c&selectedIssue=ENG-35687

o get de logs no script runner está causando 503 na tela de deploy do console,
congelando a interface com eterno loading.

