### PR TITLE
[NO-ISSUE] fix: rename edge sql route name

### DIFF
--- a/src/router/routes/edge-sql-routes/index.js
+++ b/src/router/routes/edge-sql-routes/index.js
@@ -35,7 +35,7 @@ export const edgeSQLRoutes = {
     },
     {
       path: 'database/:id/:tab?',
-      name: 'sql-database',
+      name: 'database-sql-database',
       component: () => import('@views/EdgeSQL/DatabaseView.vue'),
       meta: {
         breadCrumbs: [


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
in edge sql has 2 route with the same name and this is causing error on vue-router
<img width="530" height="172" alt="image" src="https://github.com/user-attachments/assets/394295a5-6d67-4f40-afcf-c401030dd9ea" />

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [] Commits are tagged with the right word (feat, test, refactor, etc)
- [] Application responsiveness was tested to different screen sizes
- [] New tests are added to prevent the same issue from happening again
- [] UI changes are validated by a team designer
- [ ] Code is formatted and linted
- [ ] Tags are added to the PR

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
