### PR TITLE
[ENG-35875] fix: cache browser configuration http status 304 in the general index.html

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -520,7 +520,7 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^/api'
+            inputValue: '^/api' 
           },
           {
             variable: '${uri}',


### PR DESCRIPTION
# Ajuste de Cache do Browser para arquivos .html na raiz

## Contexto
O Console é um SPA (Single Page Application), portanto possui apenas uma regra de rewrite para entregar o `index.html`. Foi necessário separar a configuração de cache para o Set Origin, uma vez que este também precisa entregar arquivos `.html`, resolvendo assim o conflito de interesse entre as duas funcionalidades.

### Aplicação de Teste
**Link:** https://ru4jw0d688.map.azionedge.net/

> **Nota:** Este link pode expirar após validação e deploy.

## Alterações Realizadas

### Novas Configurações
- **Cache Settings criado:**
  - Browser Cache: 0 segundos
  - CDN Cache: 3 dias

> Nessa configuração browser deve ser honrada a origem e cdn sobreescrita

### Rules Engine
- Adicionada configuração de cache estático para `.html` na regra de rewrite que localiza o `index.html`
- Removida configuração de cache estático previamente aplicada no Set Origin do bucket
- Criadas regras para negar rotas de API:
  - Na configuração de rewrite
  - Na configuração de cache-control (Response Phase)

## Comportamento Esperado

Após o primeiro acesso (status 200), ao recarregar a página com **Enter** ou **Shift + R**, o browser enviará os headers `if-modified-since` e `if-none-match` para o servidor. Caso não haja modificações, o servidor retornará status **304 (Not Modified)**.

Com o status 304, há latência de rede, porém **sem transferência do body da resposta**.

### Métricas de Performance
Os tempos medidos estão alinhados com as configurações aplicadas:

- **~3ms** – Cache em disco
- **~600ms** – Resposta com status 304
- **~1.2s** – Resposta com status 200


## CUIDADO

Ativar gzip para .html irá enfraquecer a cifra usada no etag, sendo adicionado um prefixo W/ (Week).
Quando isso acontece pelo fato do hash ser atualizado on the fly o browser sempre irá entregar um 200 no lugar de um 304.

## MANUAL JOB

CLI + Bundler não tem suporte para configuração para honrar ou overwrite da configuração de cache, após o deploy validar a configuração `Statics - Cache .html`

- Browser deve Honrar Origin
- CDN fazer overwrite

Com isso o 304 irá ficar.

~**3ms** – Cache em disco
~**40/60ms** – Resposta com status 304