### PR TITLE
[ENG-35876] fix: allow saving single origin changes in edge application

### DIFF
--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -135,11 +135,16 @@
             address: yup.string().label('Address').required(),
             weight: yup
               .number()
+              .nullable()
+              .min(1)
+              .max(10)
               .label('Weight')
-              .when('$originType', {
-                is: 'load_balancer',
-                then: (schema) => schema.required().min(1).max(10),
-                otherwise: (schema) => schema.optional().min(1).max(10)
+              .test('weight-required', 'Weight is a required field', function (value) {
+                const { originType } = this.from[1].value
+                if (originType === 'load_balancer') {
+                  return value != null
+                }
+                return true
               }),
             isActive: yup.boolean().default(true).label('Active')
           })


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Now users can save changes to single origin configurations in edge applications. Previously, the validation was incorrectly requiring the "weight" field for all origin types, blocking saves for single origins. The fix ensures that the weight field is only required when the origin type is "load_balancer", allowing single origins to be saved without validation errors.

### Does this PR introduce breaking changes?
- [x] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.
NO

### Does it have a link on Figma?
NO
<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
