### PR TITLE
[ENG-35907] fix: prevent drawer from showing "Go Back" and return to list after save

### DIFF
--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -329,7 +329,6 @@
     :editService="editService"
     :schema="validationSchema"
     @onSuccess="handleTrackEdit"
-    :showBarGoBack="false"
     @onError="handleFailedEditOrigin"
     title="Edit Origin"
   >


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
When editing an Origin through the drawer, after saving, the drawer stayed in a pseudo "completed edit" state and did not return to the listing. This prevented the user from performing another edit or saving again.

The fix was to remove the `showGoBack` prop to the drawer, ensuring that after saving, the flow correctly returns to the Origins list and the user can continue editing as expected.

### Does this PR introduce UI changes? Add a video or screenshots here.
N/A

---

### Checklist

- [x] The issue title follows the format: `[ISSUE_CODE] bug: TITLE`
- [x] Commits are tagged with the correct type (`fix`)
- [x] Application responsiveness was tested (no UI impact)
- [ ] New tests are added  
- [x] UI changes validated by a team designer  
- [x] Code is formatted and linted
- [x] Tags are added to the PR

#### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
