### PR TITLE
fix: reactivate gzip to static assets, css, js (not use gzip to index…

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -167,9 +167,9 @@ const config = {
         post: false,
         options: false
       },
-      browser: {
-        maxAgeSeconds: 0
-      },
+      // browser: {
+      //   maxAgeSeconds: 0
+      // }, // comented to not rewrite to 0 due not support to honor browser cache option
       edge: {
         maxAgeSeconds: 60 * 60 * 24 * 3 // 3 days
       }


### PR DESCRIPTION
## Enale GZIP Static assets
Fixing the activation of GZIP. 

https://ru4jw0d688.map.azionedge.net/

<img width="2552" height="1034" alt="Screenshot 2025-11-10 at 9 45 26 PM" src="https://github.com/user-attachments/assets/565ec8e7-12ce-4a2d-b38b-8a772ad6981b" />

In the image we can see the assets with gzip encoding and the root doc without gzip.
It is the behavior expected.

## Impact
Enable GZIP to the main index.html make week the etag hash not working the http 304.

When GZIP enabled the hash has the W prefix, note the main doc without gzip without the W prefix.
Weakness is the meaning of W .