### PR TITLE
fix: ^/billing/invoices because has index.html in the interface

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -298,7 +298,7 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^/billing'
+            inputValue: '^/billing/invoices'
           },
           {
             variable: '${uri}',
@@ -539,7 +539,7 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^/billing'
+            inputValue: '^/billing/invoices'
           },
           {
             variable: '${uri}',


### PR DESCRIPTION
## hotfix: ^/billing/invoices because has index.html in the interface

Colateral of issue html main cache due billing/envoice used to route of pdf download, we can not block all /billing