### PR TITLE
[NO-ISSUE] chore: stage sync new iac rules

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -208,8 +208,8 @@
         "phase": "response"
       },
       {
-        "id": 467685,
-        "name": "Secure Headers - General",
+        "id": 488886,
+        "name": "Cache Controll to index.html",
         "phase": "response"
       }
     ]


### PR DESCRIPTION
## stage sync new iac rules
Syncing the id created rules in the stage environment to grant the name during deploy will not conflict with the existent rule.

## NOTE
If deploy success we will update the `azion/production/azion.json`