### PR TITLE
[ENG-35930] feat: conditionally include S3 secret key in data stream payload

### DIFF
--- a/src/services/v2/data-stream/data-stream-adapter.js
+++ b/src/services/v2/data-stream/data-stream-adapter.js
@@ -79,7 +79,7 @@ const parseByEndpointType = (payload) => {
         }
       }
     case 's3':
-      return {
+      const obj = {
         type: 's3',
         attributes: {
           access_key: payload.accessKey,
@@ -87,10 +87,13 @@ const parseByEndpointType = (payload) => {
           object_key_prefix: payload.objectKey,
           bucket_name: payload.bucket,
           content_type: payload.contentType,
-          host_url: payload.host,
-          secret_key: payload.secretKey
+          host_url: payload.host
         }
       }
+      if (payload.secretKey) {
+        obj.attributes.secret_key = payload.secretKey
+      }
+      return obj
     case 'big_query':
       return {
         type: 'big_query',


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.

- quando estamos editando um stream em DataStream, é enviado o secretKey mesmo vazio, sobrescrevendo a chave no lado da api.
- Foi adicionado uma verificação validando se secretKey no payload existe ou não

### Does this PR introduce UI changes? Add a video or screenshots here.

<hr />

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
