### PR TITLE
[NO-ISSUE] fix: load bucket list without waiting for metrics response

### DIFF
--- a/src/views/EdgeStorage/components/BucketListTable.vue
+++ b/src/views/EdgeStorage/components/BucketListTable.vue
@@ -107,17 +107,31 @@
       isLoading.value = true
       let bucketCount = 0
       if (!buckets.value.length || bucketTableNeedRefresh.value) {
-        const [listBucketsResponse, metricsResponse] = await Promise.all([
-          edgeStorageService.listEdgeStorageBuckets(params),
-          edgeStorageService.getEdgeStorageMetrics()
-        ])
+        const listBucketsResponse = await edgeStorageService.listEdgeStorageBuckets(params)
 
         buckets.value = listBucketsResponse.body
         bucketCount = listBucketsResponse.count
+
         buckets.value.forEach((bucket) => {
-          const size = metricsResponse.find((metric) => metric.bucketName === bucket.name)?.storedGb
-          bucket.size = size ? `${size} GB` : '-'
+          bucket.size = '-'
         })
+
+        edgeStorageService
+          .getEdgeStorageMetrics()
+          .then((metricsResponse) => {
+            buckets.value.forEach((bucket) => {
+              const size = metricsResponse.find(
+                (metric) => metric.bucketName === bucket.name
+              )?.storedGb
+              bucket.size = size ? `${size} GB` : '-'
+            })
+          })
+          .catch(() => {
+            buckets.value.forEach((bucket) => {
+              bucket.size = '-'
+            })
+          })
+
         bucketTableNeedRefresh.value = false
         if (route.params?.id) {
           const bucketName = buckets.value.find((bucket) => bucket.name === route.params.id)


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?
Na listagem de buckets era feito 2 request
- listagem do bucket em si
- metricas do bucket
porem caso o request de metrics demora muito mais pra ser respondido bloqueando assim a tela.

Foi alterado para ele ser carregado em background e tornando ele não bloqueante para mostrar a listagem dos buckets

### Does this PR introduce breaking changes?

- [X] No
- [ ] Yes

### Does this PR introduce UI changes? Add a video or screenshots here.

https://github.com/user-attachments/assets/687d4ff4-6e90-432d-8795-03adc9594221


### Does it have a link on Figma?

<hr />

### Checklist

#### Make sure your pull request fits the checklist below (when applicable):

- [X] The issue title follows the format: [ISSUE_CODE] TYPE: TITLE
- [X] Commits are tagged with the right word (feat, test, refactor, etc)
- [ ] Application responsiveness was tested to different screen sizes
- [X] Code is formatted and linted
- [X] Tags are added to the PR

#### These changes were tested on the following browsers:

- [X] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave
