### PR TITLE
[ENG-36014] chore: cicd nodejs update -- node:18-alpine3.18 --> node:22-alpine

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -14,7 +14,7 @@ jobs:
       group: deploy-console
       cancel-in-progress: false
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,7 +14,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -17,7 +17,7 @@ jobs:
   package-audit:
     runs-on: ubuntu-latest
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/post-deploy-purge-production.yml
+++ b/.github/workflows/post-deploy-purge-production.yml
@@ -21,7 +21,7 @@ jobs:
       group: deploy-console
       cancel-in-progress: false
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/post-deploy-purge-stage.yml
+++ b/.github/workflows/post-deploy-purge-stage.yml
@@ -21,7 +21,7 @@ jobs:
       group: deploy-console
       cancel-in-progress: false
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -16,7 +16,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/security-linter.yaml
+++ b/.github/workflows/security-linter.yaml
@@ -18,7 +18,7 @@ jobs:
   security-linter:
     runs-on: ubuntu-latest
     container:
-      image: node:18-alpine3.18
+      image: node:22-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
o nosso lock tem uns path para npm, regerei para ficar tudo apontando para yarn.
porém, com isso um cicd falhou pq precisa que node >=20 e um dos nossos cicd está 18na volta do almoço vou ver para atualizarmos tbm o nodejs usado nos nossos cicd



--



https://github.com/aziontech/azion-console-kit/actions/runs/19707657389/job/56459370969?pr=2986 

```
error wait-on@9.0.3: The engine "node" is incompatible with this module. Expected version ">=20.0.0". Got "18.20.3"
```

