### PR TITLE
[NO-ISSUE] fix: hide footer when loading page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.47.17",
+  "version": "1.47.18",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -16,7 +16,7 @@
       :style="{ transition: 'margin-right 0.2s' }"
     >
       <router-view class="flex flex-1 flex-col" />
-      <AppFooter />
+      <AppFooter v-show="!showLoading" />
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Pull Request

### What is the new behavior introduced by this PR?

No PR #3039 foi removido o `v-if` do AppFooter para que não seja feito 2 request para `components.json`. Porem com isso fez com que o footer aparecesse no topo da página enquanto ela é carregada

https://github.com/user-attachments/assets/6ebada2d-201c-4e25-a9b1-7f2bc96db295



### Solução
Adicionado um `v-show` para que não mostre o componente mas já realiza o unico request para `components.json`


https://github.com/user-attachments/assets/86ab82d0-708d-4569-8827-30364bd0e765



