### PR TITLE
[NO-ISSUE] fix: rename cache setting column header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.47.27",
+  "version": "1.47.28",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/views/EdgeApplicationsCacheSettings/ListView.vue
+++ b/src/views/EdgeApplicationsCacheSettings/ListView.vue
@@ -85,7 +85,7 @@
       },
       {
         field: 'name',
-        header: 'Origin Name'
+        header: 'Name'
       },
       {
         field: 'browserCache',


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
Coluna de Name em cache setting com header de `Origin Name`
### Does this PR introduce UI changes? Add a video or screenshots here.

Console Produção:
<img width="854" height="351" alt="image" src="https://github.com/user-attachments/assets/db30f46c-ab87-4cb8-9084-f05cfb7ee4da" />
Corrigido:

<img width="1379" height="316" alt="image" src="https://github.com/user-attachments/assets/1fb4a039-3e20-4b90-8394-7c39fb2d0b82" />

