### PR TITLE
[ENG-36137] fix: prevent popup display when last editor or modified date are empty or invalid

### DIFF
--- a/src/composables/useDataTable.js
+++ b/src/composables/useDataTable.js
@@ -447,8 +447,11 @@ export function useDataTable(props, emit) {
         lastEditor: rowData.last_editor || rowData.lastEditor,
         lastModified: rowData.last_modified || rowData.lastModified
       }
-
-      showPopup.value = true
+      showPopup.value =
+        (rowData.last_editor && rowData.last_editor !== '-') ||
+        (rowData.lastModified && rowData.lastModified !== '-') ||
+        (rowData.last_editor && rowData.last_editor !== '-') ||
+        (rowData.lastModified && rowData.lastModified !== '-')
     }, 1000)
   }
 

--- a/src/helpers/convert-date.js
+++ b/src/helpers/convert-date.js
@@ -243,6 +243,7 @@ function getRemainingDays(dateStr) {
 }
 
 const convertToRelativeTime = (date) => {
+  if (!date) return '-'
   const now = new Date()
   const targetDate = new Date(date)
   const diffMs = now.getTime() - targetDate.getTime()


### PR DESCRIPTION
## Bugfix
### Problema
Problema estava que em quando a API retornava `null` no campo de Last Modified a função de conversão de data gerava `56 years`
<img width="1917" height="912" alt="image" src="https://github.com/user-attachments/assets/aee3819b-16a0-4427-b736-95dce313bb38" />

### Solução
- Adicionado uma verificação na função de conversão para que quando retornado `null` seja convertido para `-` 
- Adicionado uma verificação para mostrar o popup apenas se estiver valor de last modified