### PR TITLE
[NO-ISSUE] fix: edge dns form not showing values when edit

### DIFF
--- a/src/templates/form-fields-inputs/fieldTextIcon.vue
+++ b/src/templates/form-fields-inputs/fieldTextIcon.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { computed, toRef, ref } from 'vue'
+  import { computed, toRef, ref, watch } from 'vue'
   import { useField } from 'vee-validate'
   import InputText from 'primevue/inputtext'
   import LabelBlock from '@/templates/label-block'
@@ -62,6 +62,13 @@
     errorMessage.value = field.errorMessage
     handleBlur = field.handleBlur
     handleChange = field.handleChange
+  } else {
+    watch(
+      () => props.value,
+      (newValue) => {
+        inputValue.value = newValue
+      }
+    )
   }
 
   const iconPositionClass = computed(() => {

--- a/src/views/EdgeDNS/FormFields/FormFieldsEditEdgeDns.vue
+++ b/src/views/EdgeDNS/FormFields/FormFieldsEditEdgeDns.vue
@@ -80,6 +80,7 @@
         <FieldTextIcon
           label="Domain Name"
           name="domain"
+          :value="domain"
           placeholder="mydomain.com"
           data-testid="edge-dns-form__domain"
           disabled


### PR DESCRIPTION
## Bugfix

### Problem
Quando editamos um DNS em Edge DNS os campos `domain` e `dnssec` que são carregadados da API não estavam sendo mostrados na interface. 
Jam reproduzindo o problema: https://jam.dev/c/5eedf400-e999-48fd-b697-65e7f5296dd3

### Solução

- Add watch to update inputValue when value prop changes in fieldTextIcon component
- Bind domain value to FieldTextIcon component in EdgeDNS edit form

https://github.com/user-attachments/assets/ab336353-a512-46a8-9f97-125c95006be8

