### PR TITLE
[NO-ISSUE] fix: ensure new style of page heading block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/templates/page-heading-block/index.vue
+++ b/src/templates/page-heading-block/index.vue
@@ -88,32 +88,12 @@
           </span>
         </template>
       </Breadcrumb>
-
-      <div
-        class="flex flex-col justify-start gap-3 px-0.5"
-        v-if="props.pageTitle || props.description"
+      <span
+        class="text-[var(--text-color-secondary)] text-sm font-normal leading-7 max-md:text-base"
+        v-if="props.description"
       >
-        <div
-          :data-testid="`page_title_${props.pageTitle}`"
-          class="text-[var(--text-color)] text-3xl font-medium leading-9 max-md:text-2xl whitespace-pre-wrap"
-          v-if="props.pageTitle"
-          :class="{ 'flex gap-3 align-items-center': props.tag }"
-        >
-          {{ props.pageTitle
-          }}<PrimeTag
-            v-if="props.tag"
-            class="h-max"
-            v-bind="props.tag"
-            v-tooltip.bottom="props.tag?.tooltip"
-          />
-        </div>
-        <div
-          class="text-[var(--text-color-secondary)] text-lg font-normal leading-7 max-md:text-base"
-          v-if="props.description"
-        >
-          {{ props.description }}
-        </div>
-      </div>
+        {{ props.description }}
+      </span>
     </div>
     <div
       v-if="hasDefaultSlot"


### PR DESCRIPTION
## Bug fix

### Explain what was fixed and the correct behavior.
O estilo do page heading block estava com os dois modelos apos o merge das tabelas
<img width="1364" height="246" alt="image" src="https://github.com/user-attachments/assets/2c9f06cd-7877-4d9b-8fef-14c99e2e3d57" />

Apos a correção deve ficar dessa maneira
<img width="1327" height="296" alt="image" src="https://github.com/user-attachments/assets/e0829096-a4a6-4d5a-841c-c5fb9f1b3620" />
