### PR TITLE
[ENG-36113] fix: add validation and improve GitHub integration error messages

### DIFF
--- a/src/services/v2/vcs/vcs-service.js
+++ b/src/services/v2/vcs/vcs-service.js
@@ -34,6 +34,9 @@ export class VcsService extends BaseService {
   }
 
   postCallbackUrl = async (path, body) => {
+    if (!path) {
+      throw new Error('the integration callback URL was not received. Please try connecting again')
+    }
     const { data } = await this.http.request({
       method: 'POST',
       url: `${this.baseURL}${path}`,

--- a/src/templates/template-engine-block/index.vue
+++ b/src/templates/template-engine-block/index.vue
@@ -349,7 +349,10 @@
     try {
       await vcsService.postCallbackUrl(callbackUrl.value, integration.data)
     } catch (error) {
-      error.showErrors(toast)
+      error.showWithOptions(toast, (error) => ({
+        summary: `GitHub integration failed: ${error.detail}`,
+        severity: 'error'
+      }))
     } finally {
       await listIntegrations()
     }

--- a/src/views/AccountSettings/FormFields/FormFieldsAccountSettings.vue
+++ b/src/views/AccountSettings/FormFields/FormFieldsAccountSettings.vue
@@ -93,7 +93,7 @@
       showToast('GitHub integration connected successfully', 'success')
     } catch (error) {
       error.showWithOptions(toast, (error) => ({
-        summary: `Save failed ${error.detail}`,
+        summary: `GitHub integration failed: ${error.detail}`,
         severity: 'error'
       }))
     } finally {

--- a/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
+++ b/src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue
@@ -63,7 +63,7 @@
       await loadListIntegrations()
     } catch (error) {
       error.showWithOptions(toast, (error) => ({
-        summary: `Save failed ${error.detail}`,
+        summary: `GitHub integration failed: ${error.detail}`,
         severity: 'error'
       }))
     } finally {


### PR DESCRIPTION
# Bug fix

## Explain what was fixed and the correct behavior.

### What was fixed:
This PR fixes the GitHub integration error handling by:

1. **Added validation in `postCallbackUrl` method**: Previously, the method would attempt to make API requests even when the callback URL path was missing (`null`, `undefined`, or empty string), resulting in invalid HTTP requests to the API endpoint without a proper path.

2. **Improved error messages**: Changed generic error messages from `"Save failed ${error.detail}"` to more contextual `"GitHub integration failed: ${error.detail}"` across all GitHub integration components.

3. **Standardized error handling**: The `template-engine-block/index.vue` component was using `error.showErrors(toast)` without customization, while other components were using `error.showWithOptions`. This has been standardized to use `error.showWithOptions` consistently across all files.

### Correct behavior:
- **Validation**: The `postCallbackUrl` method now validates the `path` parameter before making the HTTP request. If the path is `null`, `undefined`, or empty string, it throws a clear error message: _"the integration callback URL was not received. Please try connecting again"_
- **Clear error messages**: Users now see specific error messages like _"GitHub integration failed: [details]"_ instead of generic _"Save failed [details]"_
- **Consistent UX**: All GitHub integration points (Import GitHub, Account Settings, Template Engine) now provide the same quality of error feedback

### Files changed:
- `src/services/v2/vcs/vcs-service.js` - Added path validation
- `src/templates/template-engine-block/index.vue` - Improved error handling
- `src/views/AccountSettings/FormFields/FormFieldsAccountSettings.vue` - Improved error message
- `src/views/ImportGitHub/FormFields/FormFieldsImportGithub.vue` - Improved error message

## Does this PR introduce UI changes? Add a video or screenshots here.

**No visual UI changes.** This PR only affects error messages displayed to users when GitHub integration fails. The error toast messages will now show:

**Before:**
```
Save failed the integration callback URL was not received. Please try connecting again
```

**After:**
```
GitHub integration failed: the integration callback URL was not received. Please try connecting again
```

<hr />

## Checklist

### Make sure your pull request fits the checklist below (when applicable):

- [x] The issue title follows the format: [ISSUE_CODE] bug: TITLE
- [x] Commits are tagged with the right word (feat, test, refactor, etc)
- [x] Application responsiveness was tested to different screen sizes *(N/A - no UI changes)*
- [ ] New tests are added to prevent the same issue from happening again
- [x] UI changes are validated by a team designer *(N/A - only error message changes)*
- [x] Code is formatted and linted
- [ ] Tags are added to the PR

### These changes were tested on the following browsers:

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari
- [ ] Brave