### PR TITLE
[NO-ISSUE] refactor: fix toast message when failure to upload file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.48.9",
+  "version": "1.48.11",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/composables/useEdgeStorage.js
+++ b/src/composables/useEdgeStorage.js
@@ -217,7 +217,7 @@ export const useEdgeStorage = () => {
             handleToast(
               'error',
               'Upload Failed',
-              `All ${failureCount} file${failureCount > 1 && 's'} failed to upload`
+              `All ${failureCount} file${failureCount > 1 ? 's' : ''} failed to upload`
             )
           }
         }


### PR DESCRIPTION
## Bug Fix
### Changes
- Refatoração na lógica do toast para exibir mensagem de erro de upload

antes:
<img width="443" height="213" alt="image" src="https://github.com/user-attachments/assets/8ad866b3-7a2f-4d85-822b-046a3164fbb0" />

depois:
<img width="421" height="147" alt="image" src="https://github.com/user-attachments/assets/28abada1-5441-4b7f-8486-2baef2850fd0" />
