### PR TITLE
[NO-ISSUE] hotfix: fix click to edit rule in waf tunning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.48.13",
+  "version": "1.48.14",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/templates/list-table-block/with-selection-behavior.vue
+++ b/src/templates/list-table-block/with-selection-behavior.vue
@@ -78,7 +78,7 @@
         <template #body="{ data: rowData }">
           <template v-if="col.type !== 'component'">
             <div
-              @click="editItemSelected(rowData)"
+              @click="!disableEditOnClick && editItemSelected($event, rowData)"
               :data-testid="`list-table-block__column__${col.field}__row`"
             >
               {{ rowData[col.field] }}
@@ -86,7 +86,7 @@
           </template>
           <template v-else>
             <component
-              @click="editItemSelected(rowData)"
+              @click="!disableEditOnClick && editItemSelected($event, rowData)"
               :is="col.component(extractFieldValue(rowData, col.field))"
               :data-testid="`list-table-block__column__${col.field}__row`"
             />
@@ -156,6 +156,10 @@
   const props = defineProps({
     disabledList: {
       type: Boolean
+    },
+    disableEditOnClick: {
+      type: Boolean,
+      default: false
     },
     hiddenHeader: {
       type: Boolean

--- a/src/views/WafRules/Drawer/index.vue
+++ b/src/views/WafRules/Drawer/index.vue
@@ -445,6 +445,8 @@
                 v-model:selectedItensData="selectedAttack"
                 :columns="tableColumns"
                 :listService="listAttacks"
+                disabledList
+                disableEditOnClick
                 :hasListService="true"
                 hiddenHeader
               />


### PR DESCRIPTION
## HOTFIX
Ao clicar para abrir um item em Waf Rules -> Tunnig ocorre um erro no console e não abre o drawer

<img width="1664" height="870" alt="image" src="https://github.com/user-attachments/assets/abf9f52f-ca39-4ba7-bf73-677a13f2e3bb" />

Corrigido:
É possivel visualizar o drawer e editar regra

<img width="1918" height="901" alt="image" src="https://github.com/user-attachments/assets/17ffd8d4-3cea-43f5-aa3b-13393e6a32f2" />
