### PR TITLE
[ENG-36291] fix: adjust page heading block layout and spacing

### DIFF
--- a/src/templates/page-heading-block/index.vue
+++ b/src/templates/page-heading-block/index.vue
@@ -49,7 +49,7 @@
 </script>
 
 <template>
-  <div class="w-full md:h-16 flex md:flex-row flex-col gap-4 md:justify-between items-center">
+  <div class="w-full md:min-h-16 flex md:flex-row flex-col gap-4 md:justify-between items-center">
     <div class="w-full md:w-auto flex flex-col">
       <Breadcrumb
         :model="breadcrumbs.items"
@@ -89,7 +89,7 @@
         </template>
       </Breadcrumb>
       <span
-        class="text-[var(--text-color-secondary)] text-sm font-normal leading-7 px-0.5"
+        class="text-[var(--text-color-secondary)] text-sm font-normal leading-5 px-0.5"
         v-if="props.description"
       >
         {{ props.description }}
@@ -97,7 +97,7 @@
     </div>
     <div
       v-if="hasDefaultSlot"
-      class="flex items-center gap-3 w-full md:w-auto justify-between md:justify-end flex-shrink-0"
+      class="flex items-center gap-3 w-full md:w-auto justify-end flex-shrink-0"
     >
       <slot name="default"></slot>
     </div>


### PR DESCRIPTION
## Bug fix

### What was the problem?
Quando reduzimos o tamanho de tela, o espaçamento das linhas esta empurrando para o title para cima na página
<img width="783" height="166" alt="image" src="https://github.com/user-attachments/assets/ef54942f-67fb-4c0e-a836-1ed799595fc6" />

### Expected behavior
Deve manter a mesma posição, sem empurrar o title para cima
<img width="802" height="218" alt="image" src="https://github.com/user-attachments/assets/650553c0-f9a1-4fc6-a9a8-1176a17cdca6" />

### How was it solved
- Ajustado o css

### How to test
Alterar a resolução da tela e verificar o page title
