### PR TITLE
[ENG-36341] fix: fix upload files to edge storage

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -264,10 +264,9 @@ const config = {
       },
       {
         name: 'Set Cache for Static Assets',
-        description:
-          'Sets the cache for all requests using the default object storage.',
+        description: 'Sets the cache for all requests using the default object storage.',
         match:
-          '^(?!.*edge_storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$',
+          '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$',
         behavior: {
           enableGZIP: true,
           setCache: 'Statics - Cache'
@@ -289,7 +288,7 @@ const config = {
         description:
           'Sets the storage origin and deliver for all requests using the default object storage.',
         match:
-          '^(?!.*edge_storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml|html)$',
+          '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml|html)$',
         behavior: {
           setOrigin: {
             name: 'origin-storage-default',
@@ -337,7 +336,8 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^(?!.*edge_storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
+            inputValue:
+              '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
           }
         ],
         behavior: {
@@ -541,8 +541,7 @@ const config = {
       },
       {
         name: 'Cache Controll to index.html',
-        description:
-          'Applies Cache-Control header to index.html',
+        description: 'Applies Cache-Control header to index.html',
         criteria: [
           {
             variable: '${uri}',
@@ -554,7 +553,7 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^/api' 
+            inputValue: '^/api'
           },
           {
             variable: '${uri}',
@@ -578,13 +577,16 @@ const config = {
             variable: '${uri}',
             conditional: 'and',
             operator: 'does_not_match',
-            inputValue: '^(?!.*edge_storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
+            inputValue:
+              '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
           }
         ],
         behavior: {
-          setHeaders: ['Cache-Control: no-cache, must-revalidate, max-age=0, stale-while-revalidate=30']
+          setHeaders: [
+            'Cache-Control: no-cache, must-revalidate, max-age=0, stale-while-revalidate=30'
+          ]
         }
-      },
+      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.48.22",
+  "version": "1.48.23",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/composables/useEdgeStorage.js
+++ b/src/composables/useEdgeStorage.js
@@ -348,7 +348,7 @@ export const useEdgeStorage = () => {
 
   const getBucketSelected = () => {
     if (selectedBucket.value) {
-      return selectedBucket.value
+      return selectedBucket.value.name
     }
 
     const bucketName = route.params.id

--- a/src/router/routes/edge-storage/index.js
+++ b/src/router/routes/edge-storage/index.js
@@ -87,7 +87,6 @@ export const edgeStorageRoutes = {
           },
           {
             label: 'Buckets',
-            to: '/object-storage/:id',
             dynamic: true,
             routeParam: 'id'
           },

--- a/src/views/EdgeStorage/Drawer/index.vue
+++ b/src/views/EdgeStorage/Drawer/index.vue
@@ -22,7 +22,7 @@
 
   const initialValues = {
     name: '',
-    workloads_access: 'read_write',
+    workloads_access: 'read_only',
     bucket: [selectedBucket.value.name]
   }
 

--- a/src/views/EdgeStorage/FormFields/FormFieldsEdgeStorage.vue
+++ b/src/views/EdgeStorage/FormFields/FormFieldsEdgeStorage.vue
@@ -21,7 +21,7 @@
 
   const { value: name } = useField('name')
   const { value: workloads_access } = useField('workloads_access', undefined, {
-    initialValue: 'read_write'
+    initialValue: 'read_only'
   })
 
   const workloadsAccessOptions = [


### PR DESCRIPTION
## Bug fix

### What was the problem?
- Ao criar um bucket novo o campo `Workloads Access` esta vindo como default `Read and Write`. O correto deveria ser `Read Only`
- A listagem de credenciais dentro do bucket não esta sendo listada
- Uploads de arquivos para um bucket esta dando erro `501`

### Expected behavior
- Workloads Access deveria ter default `read_only`
- Listar as credentials do bucket corretamente
- Enviar arquivos sem erro 

### How was it solved
- Alterado o initial values
- Ajustado a função para passar corretamente o nome do bucket para api na listagem de credentials
- Alterado as regras de IAC alterando `edge_storage` para `workspace/storage`

### How to test
Acessar a tela de Object Storage e testar os pontos acima