### PR TITLE
[NO-ISSUE] fix: add value prop to runtime field in edge functions form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.13",
+  "version": "1.49.14",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
+++ b/src/views/EdgeFunctions/FormFields/FormFieldsEditEdgeFunctions.vue
@@ -248,6 +248,7 @@
             <FieldTextIcon
               label="Runtime"
               name="runtimeFormat.content"
+              :value="runtimeFormat?.content"
               icon="pi pi-lock"
               disabled
               description="Runtime isn't an editable field."


### PR DESCRIPTION
## Bug fix

### What was the problem?
Não mostra runtime na edição de function
<img width="1624" height="584" alt="image" src="https://github.com/user-attachments/assets/57718688-63e5-4e9a-a5e4-6bdc20ce4534" />

### Expected behavior
Mostrar o runtime adequado
<img width="1175" height="531" alt="image" src="https://github.com/user-attachments/assets/630d4d2a-39d1-4429-aa3e-8f6c79849318" />

### How was it solved
Adicionado prop com o valor

### How to test
Editar function e validar