### PR TITLE
[NO-ISSUE] fix: edge storage resolve loading state flicker and select all functionality

### DIFF
--- a/src/composables/useEdgeStorage.js
+++ b/src/composables/useEdgeStorage.js
@@ -28,6 +28,8 @@ const selectedFiles = ref([])
 const isDownloading = ref(false)
 const showDragAndDrop = ref(false)
 const folderPath = ref('')
+const isFilesLoading = ref(false)
+const hadFilesBeforeLoading = ref(false)
 
 const processProgress = computed(() => {
   if (operationType.value === 'upload') {
@@ -195,6 +197,7 @@ export const useEdgeStorage = () => {
         if (successCount) {
           filesTableNeedRefresh.value = true
           showDragAndDrop.value = false
+          hadFilesBeforeLoading.value = true
           handleToast(
             failureCount > 0 ? 'warn' : 'success',
             failureCount > 0 ? 'Upload Partially Completed' : 'Upload Successful',
@@ -425,6 +428,8 @@ export const useEdgeStorage = () => {
     selectedFiles,
     isDownloading,
     showDragAndDrop,
-    folderPath
+    folderPath,
+    isFilesLoading,
+    hadFilesBeforeLoading
   }
 }

--- a/src/templates/list-table-block/folder-list.vue
+++ b/src/templates/list-table-block/folder-list.vue
@@ -335,9 +335,9 @@
     if (rowData.isSkeletonRow || rowData.isFolder || rowData.isParentNav || rowData.isNewFolder)
       return
 
-    const isSelected = selectedItems.value.includes(rowData)
+    const isSelected = selectedItems.value.some((item) => item.id === rowData.id)
     if (isSelected) {
-      selectedItems.value = selectedItems.value.filter((item) => item !== rowData)
+      selectedItems.value = selectedItems.value.filter((item) => item.id !== rowData.id)
     } else {
       selectedItems.value = [...selectedItems.value, rowData]
     }
@@ -358,13 +358,12 @@
     const selectableRows = filterData.value.filter(
       (row) => !row.isFolder && !row.isParentNav && !row.isNewFolder && !row.isSkeletonRow
     )
-    return (
-      selectableRows.length > 0 && selectableRows.every((row) => selectedItems.value.includes(row))
-    )
+    const selectedIds = selectedItems.value.map((item) => item.id)
+    return selectableRows.length > 0 && selectableRows.every((row) => selectedIds.includes(row.id))
   })
 
   const stateClassRules = (row) => {
-    if (selectedItems.value.find((item) => item.id === row.id)) {
+    if (selectedItems.value.some((item) => item.id === row.id)) {
       return 'bg-[var(--table-body-row-hover-bg)] bg-altered'
     }
     return ''
@@ -704,8 +703,10 @@
               height="1.5rem"
             />
             <Checkbox
-              v-else-if="selectedItems.includes(rowData) && !rowData.isNewFolder"
-              :model-value="selectedItems.includes(rowData)"
+              v-else-if="
+                selectedItems.some((item) => item.id === rowData.id) && !rowData.isNewFolder
+              "
+              :model-value="selectedItems.some((item) => item.id === rowData.id)"
               @update:model-value="toggleRowSelection(rowData)"
               @click.stop="toggleRowSelection(rowData)"
               binary

--- a/src/views/EdgeStorage/components/DragAndDrop.vue
+++ b/src/views/EdgeStorage/components/DragAndDrop.vue
@@ -3,38 +3,65 @@
     <div
       class="flex flex-col items-center gap-5 justify-center w-full mx-auto text-center py-16 border border-solid surface-border rounded-lg transition-colors"
     >
-      <div
-        class="rounded-full border surface-border flex items-center justify-center w-[90px] h-[90px] mb-1"
-      >
-        <i class="pi pi-cloud-upload text-4xl text-color-primary"></i>
-      </div>
-
-      <div class="flex flex-col gap-4">
-        <h3 class="text-lg font-medium text-color-primary">
-          Drag files here to add them to your bucket
-        </h3>
-
-        <div class="flex justify-center">
-          <SplitButton
-            size="small"
-            label="Add to files"
-            @click="openFileSelector('files')"
-            :model="uploadMenuItems"
-            primary
-            class="whitespace-nowrap"
-            :disabled="isProcessing"
-            :menuButtonProps="{
-              class: 'rounded-l-none',
-              style: { color: 'var(--primary-text-color) !important' }
-            }"
-            :pt="{
-              root: { class: 'h-[2rem]' }
-            }"
+      <!-- Loading State -->
+      <template v-if="isLoading">
+        <Skeleton
+          shape="circle"
+          width="90px"
+          height="90px"
+          class="mb-1"
+        />
+        <div class="flex flex-col gap-4 items-center">
+          <Skeleton
+            width="280px"
+            height="1.5rem"
+          />
+          <Skeleton
+            width="100px"
+            height="2rem"
           />
         </div>
-      </div>
+        <Skeleton
+          width="250px"
+          height="1rem"
+        />
+      </template>
 
-      <p class="text-sm text-color-secondary">Files larger than 300 MB cannot be uploaded.</p>
+      <!-- Empty State -->
+      <template v-else>
+        <div
+          class="rounded-full border surface-border flex items-center justify-center w-[90px] h-[90px] mb-1"
+        >
+          <i class="pi pi-cloud-upload text-4xl text-color-primary"></i>
+        </div>
+
+        <div class="flex flex-col gap-4">
+          <h3 class="text-lg font-medium text-color-primary">
+            Drag files here to add them to your bucket
+          </h3>
+
+          <div class="flex justify-center">
+            <SplitButton
+              size="small"
+              label="Add to files"
+              @click="openFileSelector('files')"
+              :model="uploadMenuItems"
+              primary
+              class="whitespace-nowrap"
+              :disabled="isProcessing"
+              :menuButtonProps="{
+                class: 'rounded-l-none',
+                style: { color: 'var(--primary-text-color) !important' }
+              }"
+              :pt="{
+                root: { class: 'h-[2rem]' }
+              }"
+            />
+          </div>
+        </div>
+
+        <p class="text-sm text-color-secondary">Files larger than 300 MB cannot be uploaded.</p>
+      </template>
     </div>
   </div>
 </template>
@@ -42,7 +69,15 @@
 <script setup>
   import { onMounted, onUnmounted } from 'vue'
   import SplitButton from 'primevue/splitbutton'
+  import Skeleton from 'primevue/skeleton'
   import { useEdgeStorage } from '@/composables/useEdgeStorage'
+
+  defineProps({
+    isLoading: {
+      type: Boolean,
+      default: false
+    }
+  })
 
   const { uploadFiles, isProcessing } = useEdgeStorage()
   const emit = defineEmits(['reload'])


### PR DESCRIPTION
## Summary

This PR fixes two issues in the Edge Storage S3 interface:

1. **Loading state showing empty table** - The interface would briefly show an empty table before displaying content or the DragAndDrop component, causing a poor user experience.

2. **Select All not working** - The "Select All" checkbox in the table header was not selecting objects due to object reference comparison issues.

## Problems & Solutions

### Problem 1: Loading State Flicker

**Symptoms:**
- When opening a bucket, the table would appear empty momentarily
- Transitions between table and DragAndDrop were jarring
- Users perceived the bucket as empty before data loaded

**Root Cause:**
- No coordination between loading state and UI display decision
- `showDragAndDrop` was only updated after API response
- During loading, the UI didn't know what to show

**Solution:**
- Added `hadFilesBeforeLoading` state to remember previous state
- Created `shouldShowTable` computed property that uses the previous state during loading
- Added skeleton loading UI to DragAndDrop component
- Now the UI maintains consistency during loading transitions

| Scenario | Before | After |
|----------|--------|-------|
| Open bucket with files | Table → Empty → Table with data | Table with skeleton → Table with data |
| Open empty bucket | Table → Empty → DragAndDrop | DragAndDrop with skeleton → DragAndDrop |
| Refresh bucket with files | Brief empty flash | Smooth skeleton transition |
| Delete last file | Abrupt change to DragAndDrop | Smooth transition |

### Problem 2: Select All Not Working

**Symptoms:**
- Clicking "Select All" checkbox didn't select any rows
- Individual row selection worked, but bulk selection failed

**Root Cause:**
- Selection used `Array.includes()` which compares by object reference
- When data reloads, new objects are created via `.map()`, breaking reference equality
- `selectedItems.includes(row)` always returned false for reloaded data

**Solution:**
- Changed all selection comparisons to use ID-based comparison
- `includes(row)` → `some(item => item.id === row.id)`
- Added automatic selection clearing when navigating between folders

## Changes Made

### `src/composables/useEdgeStorage.js`
- Added `isFilesLoading` ref for tracking loading state
- Added `hadFilesBeforeLoading` ref for remembering previous state
- Set `hadFilesBeforeLoading = true` after successful upload

### `src/views/EdgeStorage/ListView.vue`
- Added `shouldShowTable` computed for smart UI switching
- Save `hadFilesBeforeLoading` before starting API calls
- Reset state when selecting a new bucket
- Clear selection when navigating folders

### `src/views/EdgeStorage/components/DragAndDrop.vue`
- Added `isLoading` prop
- Added skeleton loading UI with proper layout

### `src/templates/list-table-block/folder-list.vue`
- Changed `isAllSelected` to compare by ID
- Changed `toggleRowSelection` to compare by ID
- Changed `stateClassRules` to use `.some()` for consistency
- Updated template checkbox conditions to use ID comparison

## Testing Checklist

- [ ] Open bucket with files - should show table with skeleton during load
- [ ] Open empty bucket - should show DragAndDrop with skeleton during load
- [ ] Refresh bucket - should maintain table/DragAndDrop without flicker
- [ ] Click "Select All" - should select all file rows (not folders)
- [ ] Navigate to subfolder - selection should clear
- [ ] Delete last file - should transition smoothly to DragAndDrop
- [ ] Upload to empty bucket - should transition smoothly to table