### PR TITLE
fix: move azion lib to dev dependencies, used during deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.16",
+  "version": "1.49.17",
   "private": false,
   "type": "module",
   "repository": {
@@ -50,7 +50,6 @@
     "@vueuse/core": "^10.11.1",
     "analytics": "^0.8.19",
     "axios": "^1.12.0",
-    "azion": "^1.20.10",
     "azion-theme": "^1.16.2",
     "c3": "^0.7.20",
     "caniuse-lite": "^1.0.30001751",
@@ -77,6 +76,7 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
+    "azion": "^1.20.10",
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
     "@cypress/code-coverage": "^3.12.39",


### PR DESCRIPTION
## Description

The comand `yarn package-audit` has some fixes to solve.

**From 10** vulnerabilities found  **to 8** vulnerabilities found.
azion lib has some fixes to do in the dependencies version.

The `azion` currently it is used only during the cicd, on this moment the best option is move to devDependencie

---

10: https://github.com/aziontech/azion-console-kit/actions/runs/21329424917/job/61391810390?pr=3182
8: https://github.com/aziontech/azion-console-kit/actions/runs/21341302642/job/61421082802?pr=3183