### PR TITLE
fix: d3-color vulnerable to redos, adding in resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.18",
+  "version": "1.49.19",
   "private": false,
   "type": "module",
   "repository": {
@@ -129,6 +129,7 @@
     "strip-ansi": "6.0.1",
     "supports-color": "7.2.0",
     "supports-hyperlinks": "2.3.0",
+    "d3-color": "^3.1.0",
     "axios": "^1.13.3"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,10 +4186,10 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+d3-color@1, d3-color@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-contour@1:
   version "1.3.2"


### PR DESCRIPTION
## BEFORE

With this pull request we found only two vuln.

<img width="863" height="637" alt="Screenshot 2026-01-26 at 11 12 19 AM" src="https://github.com/user-attachments/assets/5ecb230f-7501-4e99-81b9-1d7c3825d393" />


## AFTER

In the beginning of the day we started with 10vuln. 

<img width="713" height="126" alt="Screenshot 2026-01-26 at 11 13 41 AM" src="https://github.com/user-attachments/assets/5eb9fa48-7bf7-4203-af8e-285b917e7d6c" />

