### PR TITLE
chore: temporaly sleep time incresing to less risk to purge during propagation

### DIFF
--- a/.github/workflows/post-deploy-purge-production.yml
+++ b/.github/workflows/post-deploy-purge-production.yml
@@ -52,8 +52,8 @@ jobs:
 
           while true; do
             COUNT=$((COUNT + 1))
-            echo "[Check $COUNT/$MAX_COUNT] Waiting 15 seconds before next version check..."
-            sleep 15
+            echo "[Check $COUNT/$MAX_COUNT] Waiting 30 seconds before next version check..."
+            sleep 30
 
             echo "Purging package URL: $PACKAGE_URL"
             azion purge --urls "$PACKAGE_URL" --layer edge_caching
@@ -64,6 +64,8 @@ jobs:
             if [ -z "$CURRENT_VERSION" ]; then
               echo "Current version is empty; keeping previous value and continuing to poll."
             elif [ "$CURRENT_VERSION" != "$INITIAL_VERSION" ]; then
+              echo "Triggering final purge..."
+              sleep 15
               azion purge --wildcard "${CONSOLE_URL}/*" --layer edge_caching
               echo "Purge of ${CONSOLE_URL}/* completed."
               break

--- a/.github/workflows/post-deploy-purge-stage.yml
+++ b/.github/workflows/post-deploy-purge-stage.yml
@@ -52,8 +52,8 @@ jobs:
 
           while true; do
             COUNT=$((COUNT + 1))
-            echo "[Check $COUNT/$MAX_COUNT] Waiting 15 seconds before next version check..."
-            sleep 15
+            echo "[Check $COUNT/$MAX_COUNT] Waiting 30 seconds before next version check..."
+            sleep 30
 
             echo "Purging package URL: $PACKAGE_URL"
             azion purge --urls "$PACKAGE_URL" --layer edge_caching
@@ -64,6 +64,8 @@ jobs:
             if [ -z "$CURRENT_VERSION" ]; then
               echo "Current version is empty; keeping previous value and continuing to poll."
             elif [ "$CURRENT_VERSION" != "$INITIAL_VERSION" ]; then
+              echo "Triggering final purge..."
+              sleep 15
               azion purge --wildcard "${CONSOLE_URL}/*" --layer edge_caching
               echo "Purge of ${CONSOLE_URL}/* completed."
               break

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.19",
+  "version": "1.49.20",
   "private": false,
   "type": "module",
   "repository": {


### PR DESCRIPTION
The purge flux sometimes find the update but it is not propagated to all the edges.
So, how we dont have a backend signal, im increasing the sleep time.