### PR TITLE
[ENG-36472] fix: use rule order property instead of array index for position tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.26",
+  "version": "1.49.27",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/services/v2/edge-app/edge-app-rules-engine-adapter.js
+++ b/src/services/v2/edge-app/edge-app-rules-engine-adapter.js
@@ -11,7 +11,7 @@ export const RulesEngineAdapter = {
     }
 
     const response =
-      data?.map((rule, index) => ({
+      data?.map((rule) => ({
         id: rule.id,
         stringId: rule.id?.toString(),
         name: rule.name,
@@ -24,8 +24,8 @@ export const RulesEngineAdapter = {
         criteria: rule.criteria,
         status: statusMap[rule.active],
         position: {
-          value: index,
-          immutableValue: index,
+          value: rule.order,
+          immutableValue: rule.order,
           altered: false,
           min: 0,
           max: data.length - 1,

--- a/src/services/v2/edge-app/edge-app-rules-engine-service.js
+++ b/src/services/v2/edge-app/edge-app-rules-engine-service.js
@@ -160,6 +160,8 @@ export class RulesEngineService extends BaseService {
 
     const transformedData = this.adapter?.transformListRulesEngine?.(allRules, phase) ?? allRules
 
+    transformedData.sort((dataA, dataB) => dataA.position.value - dataB.position.value)
+
     return transformedData
   }
 

--- a/src/services/v2/edge-firewall/edge-firewall-rules-engine-service.js
+++ b/src/services/v2/edge-firewall/edge-firewall-rules-engine-service.js
@@ -78,7 +78,9 @@ export class EdgeFirewallRulesEngineService extends BaseService {
       body
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.firewall.all })
+    this.queryClient.removeQueries({
+      queryKey: queryKeys.firewall.rulesEngine.all(edgeFirewallId)
+    })
 
     return { feedback: 'Rule Engine successfully created' }
   }
@@ -92,7 +94,9 @@ export class EdgeFirewallRulesEngineService extends BaseService {
       body
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.firewall.all })
+    this.queryClient.removeQueries({
+      queryKey: queryKeys.firewall.rulesEngine.all(edgeFirewallId)
+    })
 
     return 'Rule Engine successfully updated'
   }
@@ -123,7 +127,9 @@ export class EdgeFirewallRulesEngineService extends BaseService {
       body
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.firewall.all })
+    this.queryClient.removeQueries({
+      queryKey: queryKeys.firewall.rulesEngine.all(edgeFirewallId)
+    })
 
     return 'Rules Engine successfully ordered'
   }
@@ -134,7 +140,9 @@ export class EdgeFirewallRulesEngineService extends BaseService {
       url: this.#getUrl(edgeFirewallId, `/${ruleEngineId}`)
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.firewall.all })
+    this.queryClient.removeQueries({
+      queryKey: queryKeys.firewall.rulesEngine.all(edgeFirewallId)
+    })
 
     return 'Rules Engine successfully deleted'
   }

--- a/src/templates/list-table-block/v2/index.vue
+++ b/src/templates/list-table-block/v2/index.vue
@@ -120,6 +120,10 @@
     emptyBlock: {
       type: Object,
       default: () => ({})
+    },
+    isLoadingReorder: {
+      type: Boolean,
+      default: false
     }
   })
 
@@ -191,6 +195,7 @@
     table.forEach((row, index) => {
       if (row.position) {
         row.position.value = index
+        row.position.max = table.length - 1
         row.position.altered = row.position.immutableValue !== row.position.value
       }
     })
@@ -609,7 +614,7 @@
 
     <teleport
       to="#action-bar"
-      v-if="columnOrderAltered"
+      v-if="columnOrderAltered && !isLoading"
     >
       <slot
         name="reorderFooter"
@@ -634,10 +639,11 @@
             data-testid="rules-engine-save-order-button"
             size="small"
             type="button"
+            :loading="isLoadingReorder"
             @click="
               emit('on-review-changes', { data: data, alteredRows: alteredRows, reload: reload })
             "
-            :badge="alteredRows.length"
+            :badge="!isLoadingReorder ? alteredRows.length : undefined"
           />
         </div>
       </slot>

--- a/src/views/EdgeApplicationsRulesEngine/ListView.vue
+++ b/src/views/EdgeApplicationsRulesEngine/ListView.vue
@@ -1,16 +1,18 @@
 <script setup>
-  import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
-  import DrawerRulesEngine from '@/views/EdgeApplicationsRulesEngine/Drawer'
-  import TableBlock from '@/templates/list-table-block/v2/index.vue'
+  import { computed, ref, inject } from 'vue'
   import { useDialog } from 'primevue/usedialog'
   import { useToast } from 'primevue/usetoast'
   import PrimeButton from 'primevue/button'
-  import { computed, ref, inject } from 'vue'
+  import DrawerRulesEngine from '@/views/EdgeApplicationsRulesEngine/Drawer'
   import orderDialog from '@/views/EdgeApplicationsRulesEngine/Dialog/order-dialog.vue'
+  import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
+  import TableBlock from '@/templates/list-table-block/v2/index.vue'
   import { rulesEngineService } from '@/services/v2/edge-app/edge-app-rules-engine-service'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
+  const dialog = useDialog()
+  const toast = useToast()
 
   defineOptions({ name: 'list-edge-applications-device-groups-tab' })
 
@@ -70,8 +72,6 @@
   const drawerRulesEngineRef = ref('')
   const listRulesEngineRef = ref(null)
   const selectedPhase = ref('Request phase')
-  const dialog = useDialog()
-  const toast = useToast()
   const currentPhase = ref('request')
   const hasContentToList = ref(true)
 
@@ -126,6 +126,16 @@
     ]
   })
 
+  const actions = computed(() => [
+    {
+      label: 'Delete',
+      type: 'delete',
+      title: 'rule',
+      icon: 'pi pi-trash',
+      service: deleteRulesEngineWithDecorator
+    }
+  ])
+
   const handleTrackEditEvent = () => {
     tracker.product.clickToEdit({
       productName: 'Rules Engine'
@@ -164,16 +174,6 @@
     currentPhase.value = item.phase.content.toLowerCase()
     drawerRulesEngineRef.value.openDrawerEdit(item)
   }
-
-  const actions = [
-    {
-      label: 'Delete',
-      type: 'delete',
-      title: 'rule',
-      icon: 'pi pi-trash',
-      service: deleteRulesEngineWithDecorator
-    }
-  ]
 
   const isLoadingButtonOrder = ref(false)
 
@@ -270,6 +270,7 @@
     :pt="{
       thead: { class: !hasContentToList && 'hidden' }
     }"
+    :isLoadingReorder="isLoadingButtonOrder"
     @on-review-changes="
       ({ data, alteredRows, reload }) => updateRulesOrder(data, alteredRows, reload)
     "

--- a/src/views/EdgeFirewallRulesEngine/ListView.vue
+++ b/src/views/EdgeFirewallRulesEngine/ListView.vue
@@ -1,11 +1,11 @@
 <script setup>
-  import PrimeButton from 'primevue/button'
-  import FetchListTableBlock from '@/templates/list-table-block/v2/index.vue'
-  import Drawer from './Drawer'
-  import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import { computed, ref, inject } from 'vue'
+  import PrimeButton from 'primevue/button'
   import { useToast } from 'primevue/usetoast'
   import { useDialog } from 'primevue/usedialog'
+  import Drawer from '@/views/EdgeApplicationsRulesEngine/Drawer'
+  import FetchListTableBlock from '@/templates/list-table-block/v2/index.vue'
+  import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import orderDialog from '@/views/EdgeApplicationsRulesEngine/Dialog/order-dialog.vue'
 
   import { networkListsService } from '@/services/v2/network-lists/network-lists-service'
@@ -13,6 +13,8 @@
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
+  const toast = useToast()
+  const dialog = useDialog()
 
   defineOptions({
     name: 'edge-firewall-rules-engine-list-view'
@@ -49,11 +51,6 @@
       required: true
     }
   })
-  const hasContentToList = ref(true)
-  const drawerRef = ref('')
-  const listTableBlockRef = ref('')
-  const toast = useToast()
-  const dialog = useDialog()
 
   const EDGE_FIREWALL_RULES_ENGINE_API_FIELDS = [
     'id',
@@ -63,6 +60,69 @@
     'last_editor',
     'active'
   ]
+
+  const hasContentToList = ref(true)
+  const drawerRef = ref('')
+  const listTableBlockRef = ref('')
+  const isLoadingButtonOrder = ref(false)
+
+  const getColumns = computed(() => [
+    {
+      field: 'id',
+      header: 'ID',
+      sortField: 'id',
+      filterPath: 'id'
+    },
+    {
+      field: 'name',
+      header: 'Name',
+      disableSort: true
+    },
+    {
+      field: 'description',
+      header: 'Description',
+      filterPath: 'description.value',
+      type: 'component',
+      class: 'max-w-[250px]',
+      component: (columnData) =>
+        columnBuilder({ data: columnData, columnAppearance: 'text-format-with-popup' }),
+      disableSort: true
+    },
+    {
+      field: 'lastEditor',
+      header: 'Last Editor',
+      disableSort: true
+    },
+    {
+      field: 'lastModified',
+      header: 'Last Modified',
+      disableSort: true
+    },
+    {
+      field: 'status',
+      header: 'Status',
+      sortField: 'status.content',
+      filterPath: 'status.content',
+      type: 'component',
+      component: (columnData) => {
+        return columnBuilder({
+          data: columnData,
+          columnAppearance: 'tag'
+        })
+      },
+      disableSort: true
+    }
+  ])
+
+  const actions = computed(() => [
+    {
+      label: 'Delete',
+      type: 'delete',
+      title: 'rule',
+      icon: 'pi pi-trash',
+      service: deleteEdgeFirewallRulesEngineServiceWithDecorator
+    }
+  ])
 
   const listEdgeFirewallRulesEngineServiceWithDecorator = async (query) => {
     return await edgeFirewallRulesEngineService.listEdgeFirewallRulesEngineService({
@@ -132,65 +192,6 @@
     }
   }
 
-  const getColumns = computed(() => [
-    {
-      field: 'id',
-      header: 'ID',
-      sortField: 'id',
-      filterPath: 'id'
-    },
-    {
-      field: 'name',
-      header: 'Name',
-      disableSort: true
-    },
-    {
-      field: 'description',
-      header: 'Description',
-      filterPath: 'description.value',
-      type: 'component',
-      class: 'max-w-[250px]',
-      component: (columnData) =>
-        columnBuilder({ data: columnData, columnAppearance: 'text-format-with-popup' }),
-      disableSort: true
-    },
-    {
-      field: 'lastEditor',
-      header: 'Last Editor',
-      disableSort: true
-    },
-    {
-      field: 'lastModified',
-      header: 'Last Modified',
-      disableSort: true
-    },
-    {
-      field: 'status',
-      header: 'Status',
-      sortField: 'status.content',
-      filterPath: 'status.content',
-      type: 'component',
-      component: (columnData) => {
-        return columnBuilder({
-          data: columnData,
-          columnAppearance: 'tag'
-        })
-      },
-      disableSort: true
-    }
-  ])
-
-  const actions = [
-    {
-      label: 'Delete',
-      type: 'delete',
-      title: 'rule',
-      icon: 'pi pi-trash',
-      service: deleteEdgeFirewallRulesEngineServiceWithDecorator
-    }
-  ]
-
-  const isLoadingButtonOrder = ref(false)
   const updateRulesOrder = async (rows, alteredRows, reload) => {
     dialog.open(orderDialog, {
       data: {
@@ -250,6 +251,7 @@
       createButtonLabel: 'Rule',
       documentationService: documentationService
     }"
+    :isLoadingReorder="isLoadingButtonOrder"
     @on-before-go-to-edit="handleTrackEditEvent"
     @on-load-data="handleLoadData"
     @on-review-changes="


### PR DESCRIPTION
## Bug fix

### What was the problem?

The rules order was being displayed incorrectly in both Edge Applications and Edge Firewall Rules Engine list views. The system was using the array index position to track rule order instead of using the actual `order` property from the rule object, causing inconsistencies between the displayed order and the actual rule execution order.

### Expected behavior

The rules table should display rules in the correct order based on their `order` property, not their position in the array. When reordering rules, the system should track and update the `order` property correctly.

### How was it solved

1. **Service Layer Updates:**
   - Modified `edge-app-rules-engine-adapter.js` to properly map the `order` field
   - Updated `edge-app-rules-engine-service.js` to include `order` in API fields
   - Updated `edge-firewall-rules-engine-service.js` to include `order` in API fields and ensure proper order tracking

2. **Component Updates:**
   - Refactored `EdgeApplicationsRulesEngine/ListView.vue` to use the rule's `order` property for position tracking
   - Refactored `EdgeFirewallRulesEngine/ListView.vue` to use the rule's `order` property for position tracking
   - Added `isLoadingReorder` prop to provide visual feedback during reorder operations

3. **Table Component:**
   - Updated `list-table-block/v2/index.vue` to properly handle the `isLoadingReorder` state

4. **Code Organization:**
   - Reorganized imports and declarations following Vue component architecture standards
   - Converted `actions` from const to computed property for better reactivity

### How to test

1. Navigate to Edge Applications > Select an application > Rules Engine tab
2. Verify that rules are displayed in the correct order based on their execution priority
3. Reorder rules using drag & drop or input field
4. Confirm that the order updates correctly and persists after page reload
5. Repeat steps 1-4 for Edge Firewall > Select a firewall > Rules Engine tab
6. Verify that the loading state appears correctly during reorder operations