### PR TITLE
[ENG-36487] feat: add cache support for functions and storage buckets listing

### DIFF
--- a/src/router/routes/team-permission/index.js
+++ b/src/router/routes/team-permission/index.js
@@ -1,5 +1,4 @@
 import * as TeamPermissionService from '@/services/team-permission'
-import { documentationAccountsProducts } from '@/helpers/azion-documentation-catalog'
 
 /** @type {import('vue-router').RouteRecordRaw} */
 export const teamsPermissionRoutes = {
@@ -9,11 +8,6 @@ export const teamsPermissionRoutes = {
       path: '',
       name: 'teams-permission',
       component: () => import('@views/TeamsPermissions/ListView.vue'),
-      props: {
-        listTeamPermissionService: TeamPermissionService.listTeamPermissionService,
-        deleteTeamPermissionService: TeamPermissionService.deleteTeamPermissionService,
-        documentationService: documentationAccountsProducts.teamPermissions
-      },
       meta: {
         title: 'Teams Permissions',
         breadCrumbs: [

--- a/src/services/team-permission/create-team-permission-service.js
+++ b/src/services/team-permission/create-team-permission-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import * as Errors from '@/services/axios/errors'
 import { makeTeamPermissionBaseUrl } from './make-team-permission-base-url'
 import { teamsService } from '@/services/users-services/list-teams-service'
+import { teamPermissionService } from './team-permission-service'
 
 export const createTeamPermissionsService = async (payload) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -12,6 +13,7 @@ export const createTeamPermissionsService = async (payload) => {
 
   const result = parseHttpResponse(httpResponse)
   await teamsService.invalidateTeamsCache()
+  await teamPermissionService.invalidateCache()
   return result
 }
 

--- a/src/services/team-permission/delete-team-permission-service.js
+++ b/src/services/team-permission/delete-team-permission-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeTeamPermissionBaseUrl } from './make-team-permission-base-url'
 import * as Errors from '@/services/axios/errors'
 import { teamsService } from '@/services/users-services/list-teams-service'
+import { teamPermissionService } from './team-permission-service'
 
 export const deleteTeamPermissionService = async (teamPermissionId) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
@@ -11,6 +12,7 @@ export const deleteTeamPermissionService = async (teamPermissionId) => {
 
   const result = parseHttpResponse(httpResponse)
   await teamsService.invalidateTeamsCache()
+  await teamPermissionService.invalidateCache()
   return result
 }
 

--- a/src/services/team-permission/edit-team-permission-service.js
+++ b/src/services/team-permission/edit-team-permission-service.js
@@ -2,6 +2,7 @@ import { AxiosHttpClientAdapter } from '../axios/AxiosHttpClientAdapter'
 import { makeTeamPermissionBaseUrl } from './make-team-permission-base-url'
 import * as Errors from '@/services/axios/errors'
 import { teamsService } from '@/services/users-services/list-teams-service'
+import { teamPermissionService } from './team-permission-service'
 
 export const editTeamPermissionService = async (payload) => {
   const parsedPayload = adapt(payload)
@@ -13,6 +14,7 @@ export const editTeamPermissionService = async (payload) => {
 
   const result = parseHttpResponse(httpResponse)
   await teamsService.invalidateTeamsCache()
+  await teamPermissionService.invalidateCache()
   return result
 }
 

--- a/src/services/team-permission/index.js
+++ b/src/services/team-permission/index.js
@@ -4,6 +4,7 @@ import { listPermissionService } from './list-permissions-service'
 import { createTeamPermissionsService } from './create-team-permission-service'
 import { loadTeamPermissionService } from './load-team-permission-service'
 import { editTeamPermissionService } from './edit-team-permission-service'
+import { teamPermissionService } from './team-permission-service'
 
 export {
   listTeamPermissionService,
@@ -11,5 +12,6 @@ export {
   listPermissionService,
   createTeamPermissionsService,
   loadTeamPermissionService,
-  editTeamPermissionService
+  editTeamPermissionService,
+  teamPermissionService
 }

--- a/src/services/team-permission/team-permission-service.js
+++ b/src/services/team-permission/team-permission-service.js
@@ -1,0 +1,71 @@
+import { BaseService } from '@/services/v2/base/query/baseService'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
+import { makeTeamPermissionBaseUrl } from './make-team-permission-base-url'
+
+const parseStatusData = (status) => {
+  return status
+    ? { content: 'Active', severity: 'success' }
+    : { content: 'Inactive', severity: 'danger' }
+}
+
+const adaptList = (results) => {
+  if (!Array.isArray(results)) return []
+
+  return results.map((team) => ({
+    id: team.id,
+    name: team.name,
+    permissions: team.permissions?.length ? team.permissions.map((item) => item.name) : [],
+    status: parseStatusData(team.is_active)
+  }))
+}
+
+class TeamPermissionService extends BaseService {
+  constructor() {
+    super()
+    this.baseURL = makeTeamPermissionBaseUrl()
+  }
+
+  #fetchTeamPermissionList = async (params = {}) => {
+    const { data } = await this.http.request({
+      method: 'GET',
+      url: this.baseURL,
+      params: {
+        ordering: 'name',
+        page: 1,
+        page_size: 100,
+        ...params
+      }
+    })
+
+    return {
+      body: adaptList(data.results),
+      count: data.count
+    }
+  }
+
+  prefetchList = () => {
+    return this.usePrefetchQuery(queryKeys.teamPermission.list({}), () =>
+      this.#fetchTeamPermissionList()
+    )
+  }
+
+  listTeamPermissionService = async (params = {}) => {
+    const firstPage = params?.page === 1
+    const skipCache = params?.skipCache || params?.hasFilter || params?.search
+
+    return await this.useEnsureQueryData(
+      queryKeys.teamPermission.list(),
+      () => this.#fetchTeamPermissionList(),
+      {
+        persist: firstPage && !skipCache,
+        skipCache
+      }
+    )
+  }
+
+  invalidateCache = async () => {
+    await this.queryClient.removeQueries({ queryKey: queryKeys.teamPermission.all })
+  }
+}
+
+export const teamPermissionService = new TeamPermissionService()

--- a/src/services/v2/base/auth/sessionManager.js
+++ b/src/services/v2/base/auth/sessionManager.js
@@ -15,6 +15,8 @@ import { edgeDNSService } from '@/services/v2/edge-dns/edge-dns-service'
 import { edgeFunctionService } from '@/services/v2/edge-function/edge-function-service'
 import { edgeConnectorsService } from '@/services/v2/edge-connectors/edge-connectors-service'
 import { dataStreamService } from '@/services/v2/data-stream/data-stream-service'
+import { wafService } from '@/services/v2/waf/waf-service'
+import { edgeSQLService } from '@/services/v2/edge-sql/edge-sql-service'
 
 const STORAGE_KEY = 'tableDefinitions'
 const DEFAULT_PAGE_SIZE = 10
@@ -55,11 +57,13 @@ const prefetchInBackground = async () => {
   Promise.allSettled([
     variablesService.prefetchList(),
     marketplaceService.prefetchMarketplace(),
-    edgeStorageService.prefetchList(),
-    edgeDNSService.prefetchList(),
-    edgeFunctionService.prefetchList(),
-    edgeConnectorsService.prefetchList(),
-    dataStreamService.prefetchList()
+    edgeStorageService.prefetchList(pageSize),
+    edgeDNSService.prefetchList(pageSize),
+    edgeFunctionService.prefetchList(pageSize),
+    edgeConnectorsService.prefetchList(pageSize),
+    dataStreamService.prefetchList(pageSize),
+    wafService.prefetchList(pageSize),
+    edgeSQLService.prefetchList(pageSize)
   ])
 }
 

--- a/src/services/v2/base/query/queryKeys.js
+++ b/src/services/v2/base/query/queryKeys.js
@@ -195,5 +195,20 @@ export const queryKeys = {
     all: ['edge-connectors'],
     list: (params) => [...queryKeys.edgeConnectors.all, 'list', params],
     detail: (id) => [...queryKeys.edgeConnectors.all, 'detail', id]
+  },
+  teamPermission: {
+    all: ['team-permissions'],
+    list: (params) => [...queryKeys.teamPermission.all, 'list', params],
+    detail: (id) => [...queryKeys.teamPermission.all, 'detail', id]
+  },
+  waf: {
+    all: ['waf-rules'],
+    list: (params) => [...queryKeys.waf.all, 'list', params],
+    detail: (id) => [...queryKeys.waf.all, 'detail', id]
+  },
+  edgeSql: {
+    all: ['edge-sql'],
+    list: (params) => [...queryKeys.edgeSql.all, 'list', params],
+    detail: (id) => [...queryKeys.edgeSql.all, 'detail', id]
   }
 }

--- a/src/services/v2/data-stream/data-stream-service.js
+++ b/src/services/v2/data-stream/data-stream-service.js
@@ -44,8 +44,25 @@ export class DataStreamService extends BaseService {
     }
   }
 
-  prefetchList = () => {
-    return this.usePrefetchQuery(queryKeys.dataStream.list({}), () => this.#fetchDataStreamList())
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      ordering: '-last_modified',
+      fields: [
+        'id',
+        'name',
+        'active',
+        'outputs',
+        'transform',
+        'inputs',
+        'last_editor',
+        'last_modified'
+      ]
+    }
+    return this.usePrefetchQuery(queryKeys.dataStream.list(defaultParams), () =>
+      this.#fetchDataStreamList(defaultParams)
+    )
   }
 
   listDataStreamService = async (params = { pageSize: 10 }) => {
@@ -53,8 +70,8 @@ export class DataStreamService extends BaseService {
     const skipCache = params?.skipCache || params?.hasFilter || params?.search
 
     return await this.useEnsureQueryData(
-      queryKeys.dataStream.list(),
-      () => this.#fetchDataStreamList(),
+      queryKeys.dataStream.list(params),
+      () => this.#fetchDataStreamList(params),
       {
         persist: firstPage && !skipCache,
         skipCache

--- a/src/services/v2/edge-connectors/edge-connectors-service.js
+++ b/src/services/v2/edge-connectors/edge-connectors-service.js
@@ -25,9 +25,15 @@ export class EdgeConnectorsService extends BaseService {
     }
   }
 
-  prefetchList = () => {
-    return this.usePrefetchQuery(queryKeys.edgeConnectors.list({}), () =>
-      this.#fetchConnectorsList()
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      fields: [],
+      ordering: '-last_modified'
+    }
+    return this.usePrefetchQuery(queryKeys.edgeConnectors.list(defaultParams), () =>
+      this.#fetchConnectorsList(defaultParams)
     )
   }
 
@@ -36,8 +42,8 @@ export class EdgeConnectorsService extends BaseService {
     const skipCache = params?.skipCache || params?.hasFilter || params?.search
 
     return await this.useEnsureQueryData(
-      queryKeys.edgeConnectors.list(),
-      () => this.#fetchConnectorsList(),
+      queryKeys.edgeConnectors.list(params),
+      () => this.#fetchConnectorsList(params),
       {
         persist: firstPage && !skipCache,
         skipCache

--- a/src/services/v2/edge-dns/edge-dns-service.js
+++ b/src/services/v2/edge-dns/edge-dns-service.js
@@ -29,18 +29,30 @@ export class EdgeDNSService extends BaseService {
     }
   }
 
-  prefetchList = () => {
-    return this.usePrefetchQuery(queryKeys.edgeDNS.list({}), () => this.#fetchDNSList())
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      fields: ['id', 'name', 'domain', 'active', 'last_modified'],
+      ordering: '-last_modified'
+    }
+    return this.usePrefetchQuery(queryKeys.edgeDNS.list(defaultParams), () =>
+      this.#fetchDNSList(defaultParams)
+    )
   }
 
   listEdgeDNSService = async (params = { pageSize: 10, fields: [] }) => {
     const firstPage = params?.page === 1
     const skipCache = params?.skipCache || params?.hasFilter || params?.search
 
-    return await this.useEnsureQueryData(queryKeys.edgeDNS.list(), () => this.#fetchDNSList(), {
-      persist: firstPage && !skipCache,
-      skipCache
-    })
+    return await this.useEnsureQueryData(
+      queryKeys.edgeDNS.list(params),
+      () => this.#fetchDNSList(params),
+      {
+        persist: firstPage && !skipCache,
+        skipCache
+      }
+    )
   }
 
   loadEdgeDNSService = async ({ id, params = { fields: [] } }) => {

--- a/src/services/v2/edge-function/edge-function-service.js
+++ b/src/services/v2/edge-function/edge-function-service.js
@@ -92,7 +92,9 @@ export class EdgeFunctionService extends BaseService {
     }
   }
 
-  #fetchFunctionsList = async (params = { pageSize: 100, fields: [] }) => {
+  #fetchFunctionsList = async (
+    params = { pageSize: 100, fields: [], ordering: '-last_modified' }
+  ) => {
     const { data } = await this.http.request({
       method: 'GET',
       url: this.#getUrl(),
@@ -110,7 +112,14 @@ export class EdgeFunctionService extends BaseService {
   }
 
   prefetchList = () => {
-    return this.usePrefetchQuery(queryKeys.edgeFunction.list({}), () => this.#fetchFunctionsList())
+    const defaultParams = {
+      pageSize: 100,
+      fields: [],
+      ordering: '-last_modified'
+    }
+    return this.usePrefetchQuery(queryKeys.edgeFunction.list(defaultParams), () =>
+      this.#fetchFunctionsList(defaultParams)
+    )
   }
 
   listEdgeFunctionsService = async (params = { pageSize: 100, fields: [] }) => {
@@ -119,7 +128,7 @@ export class EdgeFunctionService extends BaseService {
 
     return await this.useEnsureQueryData(
       queryKeys.edgeFunction.list(),
-      () => this.#fetchFunctionsList(),
+      () => this.#fetchFunctionsList(params),
       {
         persist: firstPage && !skipCache,
         skipCache

--- a/src/services/v2/edge-sql/edge-sql-service.js
+++ b/src/services/v2/edge-sql/edge-sql-service.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { BaseService } from '@/services/v2/base/query/baseService'
 import { EdgeSQLAdapter } from './edge-sql-adapter'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
 import { extractAffectedTableNames } from '../utils/statement-utils'
 import {
   getSchemaCache,
@@ -27,15 +28,7 @@ export class EdgeSQLService extends BaseService {
     }
   }
 
-  listDatabases = async (
-    params = {
-      orderBy: 'name',
-      sort: 'asc',
-      page: 1,
-      pageSize: 10,
-      search: ''
-    }
-  ) => {
+  #fetchDatabasesList = async (params = {}) => {
     const { data } = await this.http.request({
       url: this.baseURL,
       method: 'GET',
@@ -52,6 +45,40 @@ export class EdgeSQLService extends BaseService {
     }
   }
 
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      fields: ['id', 'name', 'status', 'active', 'last_modified', 'last_editor'],
+      ordering: 'name'
+    }
+    return this.usePrefetchQuery(queryKeys.edgeSql.list(defaultParams), () =>
+      this.#fetchDatabasesList(defaultParams)
+    )
+  }
+
+  listDatabases = async (
+    params = {
+      orderBy: 'name',
+      sort: 'asc',
+      page: 1,
+      pageSize: 10,
+      search: ''
+    }
+  ) => {
+    const firstPage = params?.page === 1
+    const skipCache = params?.skipCache || params?.hasFilter || params?.search
+
+    return await this.useEnsureQueryData(
+      queryKeys.edgeSql.list(),
+      () => this.#fetchDatabasesList(params),
+      {
+        persist: firstPage && !skipCache,
+        skipCache
+      }
+    )
+  }
+
   createDatabase = async ({ name }) => {
     const body = this.adapter?.adaptDatabaseCreatePayload?.({ name })
 
@@ -65,6 +92,8 @@ export class EdgeSQLService extends BaseService {
 
     const shouldMonitor = adaptedData.status && !['created', 'ready'].includes(adaptedData.status)
 
+    this.queryClient.removeQueries({ queryKey: queryKeys.edgeSql.all })
+
     return this._formatSuccessResponse(adaptedData, null, {
       shouldMonitor,
       databaseId: adaptedData.id,
@@ -77,6 +106,8 @@ export class EdgeSQLService extends BaseService {
       url: `${this.baseURL}/${id}`,
       method: 'DELETE'
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.edgeSql.all })
 
     const feedback = this.adapter?.adaptDatabaseDelete?.(data)
     return feedback

--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -16,7 +16,7 @@ export class EdgeStorageService extends BaseService {
       params: {
         search: '',
         fields: '',
-        ordering: 'name',
+        ordering: '-last_modified',
         page: 1,
         pageSize: 10,
         ...params
@@ -26,9 +26,15 @@ export class EdgeStorageService extends BaseService {
     return this.adapter?.transformListEdgeStorageBuckets?.(data, params)
   }
 
-  prefetchList = () => {
-    return this.usePrefetchQuery(queryKeys.edgeStorage.buckets.list({}), () =>
-      this.#fetchBucketsList()
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      ordering: '-last_modified',
+      fields: ['name', 'size', 'last_editor', 'last_modified', 'workloads_access']
+    }
+    return this.usePrefetchQuery(queryKeys.edgeStorage.buckets.list(defaultParams), () =>
+      this.#fetchBucketsList(defaultParams)
     )
   }
 
@@ -37,8 +43,8 @@ export class EdgeStorageService extends BaseService {
     const skipCache = params?.skipCache || params?.hasFilter || params?.search
 
     return await this.useEnsureQueryData(
-      queryKeys.edgeStorage.buckets.list(),
-      () => this.#fetchBucketsList(),
+      queryKeys.edgeStorage.buckets.list(params),
+      () => this.#fetchBucketsList(params),
       {
         persist: firstPage && !skipCache,
         skipCache

--- a/src/services/v2/waf/waf-service.js
+++ b/src/services/v2/waf/waf-service.js
@@ -1,5 +1,6 @@
 import { BaseService } from '@/services/v2/base/query/baseService'
 import { WafAdapter } from './waf-adapter'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
 export class WafService extends BaseService {
   constructor() {
     super()
@@ -7,9 +8,7 @@ export class WafService extends BaseService {
     this.baseURL = 'v4/workspace/wafs'
   }
 
-  listWafRules = async (
-    params = { search: '', fields: '', ordering: 'name', page: 1, pageSize: 10 }
-  ) => {
+  #fetchWafRulesList = async (params = {}) => {
     const { data } = await this.http.request({
       method: 'GET',
       url: this.baseURL,
@@ -32,6 +31,34 @@ export class WafService extends BaseService {
     }
   }
 
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      page: 1,
+      pageSize,
+      fields: [],
+      ordering: '-last_modified'
+    }
+    return this.usePrefetchQuery(queryKeys.waf.list(defaultParams), () =>
+      this.#fetchWafRulesList(defaultParams)
+    )
+  }
+
+  listWafRules = async (
+    params = { search: '', fields: '', ordering: 'name', page: 1, pageSize: 10 }
+  ) => {
+    const firstPage = params?.page === 1
+    const skipCache = params?.skipCache || params?.hasFilter || params?.search
+
+    return await this.useEnsureQueryData(
+      queryKeys.waf.list(),
+      () => this.#fetchWafRulesList(params),
+      {
+        persist: firstPage && !skipCache,
+        skipCache
+      }
+    )
+  }
+
   createWafRule = async (payload) => {
     const adaptedPayload = this.adapter.adaptWafRulePayload(payload)
     const { data: response } = await this.http.request({
@@ -39,6 +66,8 @@ export class WafService extends BaseService {
       url: this.baseURL,
       body: adaptedPayload
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.waf.all })
 
     return response.data
   }
@@ -51,6 +80,8 @@ export class WafService extends BaseService {
       body: adaptedPayload
     })
 
+    this.queryClient.removeQueries({ queryKey: queryKeys.waf.all })
+
     return 'Your WAF rule has been updated.'
   }
 
@@ -59,6 +90,8 @@ export class WafService extends BaseService {
       method: 'DELETE',
       url: `${this.baseURL}/${wafId}`
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.waf.all })
 
     return 'WAF Rule successfully deleted.'
   }
@@ -80,6 +113,8 @@ export class WafService extends BaseService {
       url: `${this.baseURL}/${payload.id}/clone`,
       body
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.waf.all })
 
     return {
       feedback: 'Your WAF rule has been cloned',

--- a/src/views/EdgeStorage/components/BucketListTable.vue
+++ b/src/views/EdgeStorage/components/BucketListTable.vue
@@ -5,7 +5,7 @@
     :columns="columns"
     :actions="actions"
     :apiFields="fields"
-    defaultOrderingFieldName="-lastModified"
+    defaultOrderingFieldName="-last_modified"
     enableEditClick
     editPagePath="/object-storage"
     exportFileName="Buckets"

--- a/src/views/TeamsPermissions/ListView.vue
+++ b/src/views/TeamsPermissions/ListView.vue
@@ -5,15 +5,12 @@
   import FetchListTableBlock from '@/templates/list-table-block/with-fetch-ordering-and-pagination.vue'
   import { computed, inject } from 'vue'
   import { DataTableActionsButtons } from '@/components/DataTable'
+  import { teamPermissionService } from '@/services/team-permission'
+  import { deleteTeamPermissionService } from '@/services/team-permission'
+  import { documentationAccountsProducts } from '@/helpers/azion-documentation-catalog'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
-
-  const props = defineProps({
-    listTeamPermissionService: { required: true, type: Function },
-    deleteTeamPermissionService: { required: true, type: Function },
-    documentationService: { required: true, type: Function }
-  })
 
   const TEAM_PERMISSIONS_API_FIELDS = ['id', 'name', 'permissions', 'is_active']
 
@@ -23,7 +20,7 @@
       type: 'delete',
       title: 'team',
       icon: 'pi pi-trash',
-      service: props.deleteTeamPermissionService
+      service: deleteTeamPermissionService
     }
   ]
 
@@ -104,7 +101,7 @@
     </template>
     <template #content>
       <FetchListTableBlock
-        :listService="listTeamPermissionService"
+        :listService="teamPermissionService.listTeamPermissionService"
         :columns="getColumns"
         editPagePath="/teams-permission/edit"
         emptyListMessage="No teams found."
@@ -122,7 +119,7 @@
           description: 'Create your first team to define and assign permissions to users.',
           createButtonLabel: 'Team',
           createPagePath: 'teams-permission/create',
-          documentationService: documentationService
+          documentationService: documentationAccountsProducts.teamPermissions
         }"
       >
       </FetchListTableBlock>


### PR DESCRIPTION
## Feature
https://aziontech.atlassian.net/browse/ENG-36487

### Description

Implemented query key management and caching strategy for multiple v2 services to improve performance and reduce unnecessary API calls. This feature adds prefetch capabilities and smart cache invalidation across the following services:

**Services updated:**
- **Edge Functions** ([edge-function-service.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/edge-function/edge-function-service.js:0:0-0:0))
- **Edge Storage** (`edge-storage-service.js`)
- **Edge DNS** (`edge-dns-service.js`)
- **Data Stream** ([data-stream-service.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/data-stream/data-stream-service.js:0:0-0:0))
- **Edge Connectors** (`edge-connectors-service.js`)
- **Team Permissions** (`team-permission-service.js`)
- **WAF Rules** ([waf-service.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/waf/waf-service.js:0:0-0:0))
- **Edge SQL** ([edge-sql-service.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/edge-sql/edge-sql-service.js:0:0-0:0))

**Key changes:**
- Added `queryKeys` entries for each service in [queryKeys.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/base/query/queryKeys.js:0:0-0:0)
- Implemented `prefetchList()` method for preloading data
- Added `useEnsureQueryData()` for smart caching with skip conditions
- Cache invalidation on create/edit/delete operations via `queryClient.removeQueries()`
- Session manager updates to support the caching infrastructure

### How to test

1. Navigate to any of the updated modules (Edge Functions, WAF Rules, Edge SQL, etc.)
2. Observe that the list loads and is cached
3. Navigate away and return - data should load from cache (faster)
4. Create, edit, or delete an item
5. Verify the list refreshes with updated data (cache invalidation working)
6. Use browser DevTools Network tab to confirm reduced API calls on subsequent visits