### PR TITLE
fix: correct drawer import path in Edge Firewall Rules Engine list view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.49.27",
+  "version": "1.49.28",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/views/EdgeFirewallRulesEngine/ListView.vue
+++ b/src/views/EdgeFirewallRulesEngine/ListView.vue
@@ -3,7 +3,7 @@
   import PrimeButton from 'primevue/button'
   import { useToast } from 'primevue/usetoast'
   import { useDialog } from 'primevue/usedialog'
-  import Drawer from '@/views/EdgeApplicationsRulesEngine/Drawer'
+  import Drawer from '@/views/EdgeFirewallRulesEngine/Drawer'
   import FetchListTableBlock from '@/templates/list-table-block/v2/index.vue'
   import { columnBuilder } from '@/templates/list-table-block/columns/column-builder'
   import orderDialog from '@/views/EdgeApplicationsRulesEngine/Dialog/order-dialog.vue'


### PR DESCRIPTION
## Change the tab to `preview mode` and select the template to your PR


| Type of PR                       | Template                        |
|:---------------------------------|:-------------------------------:|
| Feature, refactoring, tests, etc | [Default](?template=default.md) |
| Bug fix                           | [Bug](?template=bug.md)         |
| Deploy                           | [Deploy](?template=deploy.md)   |