### PR TITLE
[NO-ISSOE] fix: adjust teams exhibition in user management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/services/users-services/list-users-service.js
+++ b/src/services/users-services/list-users-service.js
@@ -45,18 +45,12 @@ const OWNER_AS_TAG = {
 }
 
 const parseUser = (user) => {
-  const formatTeams = (teams) => {
-    return teams.length > 1
-      ? teams.map((team) => team.name).join(', ')
-      : teams.map((team) => team.name)
-  }
-
   return {
     id: user.id,
     firstName: user.first_name,
     lastName: user.last_name,
     email: user.email,
-    teams: formatTeams(user.teams),
+    teams: user.teams.map((team) => team.name),
     mfa: ACTIVE_AS_TAG[user.two_factor_enabled],
     status: ACTIVE_AS_TAG[user.is_active],
     owner: OWNER_AS_TAG[user.is_account_owner]

--- a/src/tests/services/users-services/list-users-service.test.js
+++ b/src/tests/services/users-services/list-users-service.test.js
@@ -119,7 +119,7 @@ describe('UsersServices', () => {
         firstName: fixtures.disabledUserMock.first_name,
         lastName: fixtures.disabledUserMock.last_name,
         email: fixtures.disabledUserMock.email,
-        teams: 'Default Team, Azion Team',
+        teams: ['Default Team', 'Azion Team'],
         mfa: {
           content: 'Inactive',
           severity: 'danger'

--- a/src/views/Users/ListView.vue
+++ b/src/views/Users/ListView.vue
@@ -71,65 +71,73 @@
     }
   }
 
-  const getColumns = computed(() => [
-    {
-      field: 'firstName',
-      header: 'First Name',
-      sortField: 'first_name'
-    },
-    {
-      field: 'lastName',
-      header: 'Last Name',
-      sortField: 'last_name'
-    },
-    {
-      field: 'email',
-      header: 'Email Address'
-    },
-    {
-      field: 'teams',
-      header: 'Teams',
-      disableSort: true
-    },
-    {
-      field: 'mfa',
-      header: 'MFA',
-      type: 'component',
-      disableSort: true,
-      component: (columnData) => {
-        return columnBuilder({
-          data: columnData,
-          columnAppearance: 'tag'
-        })
+  const getColumns = computed(() => {
+    return [
+      {
+        field: 'firstName',
+        header: 'First Name',
+        sortField: 'first_name'
+      },
+      {
+        field: 'lastName',
+        header: 'Last Name',
+        sortField: 'last_name'
+      },
+      {
+        field: 'email',
+        header: 'Email Address'
+      },
+      {
+        field: 'teams',
+        header: 'Teams',
+        disableSort: true,
+        type: 'component',
+        component: (columnData) =>
+          columnBuilder({
+            data: columnData,
+            columnAppearance: 'text-array-with-popup'
+          })
+      },
+      {
+        field: 'mfa',
+        header: 'MFA',
+        type: 'component',
+        disableSort: true,
+        component: (columnData) => {
+          return columnBuilder({
+            data: columnData,
+            columnAppearance: 'tag'
+          })
+        }
+      },
+      {
+        field: 'owner',
+        header: 'Account Owner',
+        filterPath: 'owner.content',
+        type: 'component',
+        disableSort: true,
+        component: (columnData) => {
+          return columnBuilder({
+            data: columnData,
+            columnAppearance: 'tag'
+          })
+        }
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        disableSort: true,
+        filterPath: 'status.content',
+        type: 'component',
+        component: (columnData) => {
+          return columnBuilder({
+            data: columnData,
+            columnAppearance: 'tag'
+          })
+        }
       }
-    },
-    {
-      field: 'owner',
-      header: 'Account Owner',
-      filterPath: 'owner.content',
-      type: 'component',
-      disableSort: true,
-      component: (columnData) => {
-        return columnBuilder({
-          data: columnData,
-          columnAppearance: 'tag'
-        })
-      }
-    },
-    {
-      field: 'status',
-      header: 'Status',
-      disableSort: true,
-      filterPath: 'status.content',
-      type: 'component',
-      component: (columnData) => {
-        return columnBuilder({
-          data: columnData,
-          columnAppearance: 'tag'
-        })
-      }
-    }
-  ])
+    ]
+  })
 </script>
 
 <template>


### PR DESCRIPTION
## Bug fix

### What was the problem?

The Teams column in Users Management was displaying teams as a comma-separated string (e.g., "Default Team, Azion Team") instead of using the standard array display with popup component. This was inconsistent with how arrays are displayed in other parts of the application.

### Expected behavior

Teams should be displayed as an array with a popup component (`text-array-with-popup`), showing the first item and a "+N" tag for additional items, with a popup on hover/click to see all teams.

### How was it solved

1. **Service layer** ([list-users-service.js](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/users-services/list-users-service.js:0:0-0:0)): Removed the `formatTeams` function that was joining team names with commas. Now returns a simple array of team names.

2. **View layer** ([ListView.vue](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/views/Users/ListView.vue:0:0-0:0)): Updated the Teams column configuration to use the `text-array-with-popup` column appearance via `columnBuilder`, consistent with other array fields in the application.

3. **Tests**: Updated test expectations to expect an array `['Default Team', 'Azion Team']` instead of a string `'Default Team, Azion Team'`.

### How to test

1. Navigate to **Account Settings > Users Management**
2. Verify that users with multiple teams display the first team name followed by a "+N" indicator
3. Hover or click on the "+N" tag to see the popup with all team names
4. Verify that users with a single team display just the team name without popup