### PR TITLE
[NO-ISSUE] chore: remove staeg console instance function (not used)

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -5,15 +5,6 @@
   "env": "production",
   "prefix": "20240821142547",
   "not-first-run": true,
-  "function": {
-    "id": 28363,
-    "name": "__DEFAULT__",
-    "file": ".edge/worker.js",
-    "args": "azion/stage/args.json",
-    "instance-id": 27187,
-    "instance-name": "__DEFAULT__",
-    "cache-id": 0
-  },
   "application": {
     "id": 1724264169,
     "name": "__DEFAULT__"


### PR DESCRIPTION
Was interface deleted the Instance Function, during deploy can not be updated.
We will remove from code and retry the deploy.
