### PR TITLE
[ENG-36506] fix: add limit and offset to storage metrics query

### DIFF
--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -219,7 +219,9 @@ export class EdgeStorageService extends BaseService {
           filter: {
             tsGte: "${tsGte}"
             tsLt: "${tsLt}"
-          }
+          },
+          limit: 1000,
+          offset: 0
         ) {
           bucketName
           storedGb


### PR DESCRIPTION
## Bug fix

### What was the problem?

A query GraphQL de métricas de storage (`storageMetrics`) não incluía os parâmetros `limit` e `offset`, o que poderia resultar em dados incompletos ou comportamento inconsistente na exibição do tamanho (size) dos buckets no Object Storage.

### Expected behavior

A query deve incluir `limit` e `offset` para garantir que todos os dados de métricas sejam retornados corretamente, permitindo a exibição precisa do tamanho dos buckets.

### How was it solved

Adicionados os parâmetros `limit: 1000` e `offset: 0` na query `storageMetrics` do serviço `EdgeStorageService`.

### How to test

1. Acesse a listagem de buckets no Object Storage
2. Verifique que a coluna de tamanho (size) exibe os valores corretamente
3. Confirme que buckets com dados mostram o tamanho em GB/MB/KB apropriadamente