### PR TITLE
[ENG-36517] fix: use correct store for DataStream edit permission check

### DIFF
--- a/src/views/DataStream/FormFields/blocks/OutputSection.vue
+++ b/src/views/DataStream/FormFields/blocks/OutputSection.vue
@@ -814,6 +814,7 @@
   import { computed, ref, watch } from 'vue'
   import { useField } from 'vee-validate'
   import { useThemeStore } from '@/stores/theme'
+  import { useAccountStore } from '@/stores/account'
   import FieldDropdown from '@/templates/form-fields-inputs/fieldDropdown.vue'
   import FieldText from '@/templates/form-fields-inputs/fieldText.vue'
   import FieldTextArea from '@/templates/form-fields-inputs/fieldTextArea.vue'
@@ -825,7 +826,8 @@
   import FieldNumber from '@/templates/form-fields-inputs/fieldNumber.vue'
   import FieldGroupRadio from '@/templates/form-fields-inputs/fieldGroupRadio.vue'
 
-  const store = useThemeStore()
+  const themeStore = useThemeStore()
+  const accountStore = useAccountStore()
 
   const { value: endpoint } = useField('endpoint')
   const { value: endpointUrl } = useField('endpointUrl')
@@ -892,7 +894,9 @@
   const { value: containerName } = useField('containerName')
   const { value: blobToken } = useField('blobToken')
 
-  const hasNoPermissionToEditDataStream = computed(() => !store.hasPermissionToEditDataStream)
+  const hasNoPermissionToEditDataStream = computed(
+    () => !accountStore.hasPermissionToEditDataStream
+  )
 
   const listEndpoint = ref([
     { label: 'Standard HTTP/HTTPS POST', value: 'standard' },
@@ -927,7 +931,7 @@
   ])
 
   const theme = computed(() => {
-    return store.currentTheme === 'light' ? 'vs' : 'vs-dark'
+    return themeStore.currentTheme === 'light' ? 'vs' : 'vs-dark'
   })
 
   const DEFAULT_MONACO_OPTIONS = {


### PR DESCRIPTION
## Bug fix
https://aziontech.atlassian.net/browse/ENG-36517
### What was the problem?

The `OutputSection.vue` component was incorrectly using `themeStore.hasPermissionToEditDataStream` to check edit permissions. The `hasPermissionToEditDataStream` property doesn't exist in the theme store - it belongs to the account store.

### Expected behavior

The permission check should use `accountStore.hasPermissionToEditDataStream` to correctly determine if the user has permission to edit DataStream configurations.

### How was it solved

- Imported `useAccountStore` from `@/stores/account`
- Renamed `store` to `themeStore` for clarity
- Added `accountStore` instance
- Updated `hasNoPermissionToEditDataStream` computed to use `accountStore.hasPermissionToEditDataStream`
- Kept `themeStore` for theme-related functionality (Monaco editor theme)

### How to test

1. Access DataStream edit page with a user that has edit permissions
2. Verify that the output section fields are editable
3. Access with a user without edit permissions
4. Verify that the fields are correctly disabled/read-only