### PR TITLE
[ENG-36520] fix: update header/breadcrumb after renaming resources

### DIFF
--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -204,8 +204,9 @@
   }
 
   const updatedApplication = (application) => {
-    edgeApplication.value = { ...application }
+    edgeApplication.value = { ...edgeApplication.value, ...application }
     verifyTab(edgeApplication.value)
+    breadcrumbs.update(route.meta.breadCrumbs ?? [], route, edgeApplication.value?.name)
   }
 
   const getTabFromIndex = (selectedTabIndex) => {

--- a/src/views/EdgeApplications/V3/EditView.vue
+++ b/src/views/EdgeApplications/V3/EditView.vue
@@ -119,6 +119,6 @@
   const formSubmit = async (onSubmit, values, formValid) => {
     await onSubmit()
     if (!formValid) return
-    emit('updatedApplication', values)
+    emit('updatedApplication', { ...props.edgeApplication, ...values })
   }
 </script>

--- a/src/views/EdgeFirewall/EditView.vue
+++ b/src/views/EdgeFirewall/EditView.vue
@@ -35,7 +35,7 @@
   const formSubmit = async (onSubmit, values, formValid) => {
     if (!formValid) return
     await onSubmit()
-    emit('updatedFirewall', values)
+    emit('updatedFirewall', { ...props.edgeFirewall, ...values })
   }
 
   const loadEdgeFirewallService = () => {

--- a/src/views/EdgeFirewall/TabsView.vue
+++ b/src/views/EdgeFirewall/TabsView.vue
@@ -175,8 +175,9 @@
   })
 
   const updatedFirewall = (firewall) => {
-    edgeFirewall.value = { ...firewall }
+    edgeFirewall.value = { ...edgeFirewall.value, ...firewall }
     verifyTab(edgeFirewall.value)
+    breadcrumbs.update(route.meta.breadCrumbs ?? [], route, edgeFirewall.value?.name)
   }
 
   onMounted(() => {

--- a/src/views/WafRules/EditView.vue
+++ b/src/views/WafRules/EditView.vue
@@ -85,7 +85,9 @@
   const formSubmit = async (onSubmit, values, formValid) => {
     await onSubmit()
     if (formValid) {
-      emit('handleWafRulesUpdated', values)
+      const updatedWafRule = { ...props.waf, ...values }
+      setWafRuleName(updatedWafRule)
+      emit('handleWafRulesUpdated', updatedWafRule)
     }
   }
 </script>


### PR DESCRIPTION
## Bug fix

### What was the problem?

After renaming an entity in edit views, the page header (and sometimes the breadcrumb) would continue showing the old name until a reload/navigation happened. This was caused by emitting only partial form `values` on save and/or replacing the local entity state with an incomplete object, so the reactive source used by the header wasn’t updated reliably.

### Expected behavior

When editing and saving a new name, the header title and breadcrumb should reflect the new name immediately, without requiring a refresh.

### How was it solved

- Updated edit views to emit a merged payload (`{ ...currentEntity, ...values }`) instead of only `values`, ensuring the parent receives a complete object with the updated `name`.
- Updated parent tabs views to merge updates into the existing reactive entity state (instead of replacing it with a potentially partial object).
- Triggered breadcrumb update right after save so navigation/header stays consistent.

### How to test

1. **Edge Firewall**
   - Go to `Firewalls > Edit`
   - Change the firewall name and click **Save**
   - Confirm the page header and breadcrumb update immediately to the new name

2. **WAF Rules**
   - Go to `WAF Rules > Edit`
   - Change the rule name and click **Save**
   - Confirm the page header and breadcrumb update immediately

3. **Edge Application (V3)**
   - Go to `Edge Applications > Edit (V3)`
   - Change the application name and click **Save**
   - Confirm the page header and breadcrumb update immediately