### PR TITLE
[ENG-36522] feat: add prefetch and caching for object storage credentials

### DIFF
--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -2,6 +2,13 @@ import { BaseService } from '@/services/v2/base/query/baseService'
 import { EdgeStorageAdapter } from './edge-storage-adapter'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
+const DEFAULT_CREDENTIALS_PARAMS = {
+  page: 1,
+  pageSize: 10,
+  fields: [],
+  ordering: '-last_modified'
+}
+
 export class EdgeStorageService extends BaseService {
   constructor() {
     super()
@@ -240,7 +247,7 @@ export class EdgeStorageService extends BaseService {
     return data.data.edgeStorageMetrics
   }
 
-  listCredentials = async (bucketName, params = {}) => {
+  #fetchCredentials = async (bucketName, params = {}) => {
     const { data } = await this.http.request({
       method: 'GET',
       url: `${this.baseURL}/credentials`,
@@ -249,8 +256,29 @@ export class EdgeStorageService extends BaseService {
         ...params
       }
     })
-
     return this.adapter?.transformListEdgeStorageCredentials?.(data)
+  }
+
+  prefetchCredentials = (bucketName, pageSize = 10) => {
+    const params = {
+      ...DEFAULT_CREDENTIALS_PARAMS,
+      pageSize
+    }
+    return this.usePrefetchQuery(queryKeys.edgeStorage.credentials.list(bucketName, params), () =>
+      this.#fetchCredentials(bucketName, params)
+    )
+  }
+
+  listCredentials = async (bucketName, params = {}) => {
+    const mergedParams = { ...DEFAULT_CREDENTIALS_PARAMS, ...params }
+    const firstPage = mergedParams.page === 1
+    const skipCache = params?.skipCache || params?.hasFilter || params?.search
+
+    return await this.useEnsureQueryData(
+      queryKeys.edgeStorage.credentials.list(bucketName, mergedParams),
+      () => this.#fetchCredentials(bucketName, mergedParams),
+      { persist: firstPage && !skipCache, skipCache }
+    )
   }
   createCredential = async (credential = {}) => {
     const body = this.adapter?.transformCreateEdgeStorageCredential?.(credential)
@@ -260,6 +288,8 @@ export class EdgeStorageService extends BaseService {
       body
     })
 
+    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
+
     return data
   }
   deleteCredential = async (credentialId) => {
@@ -267,6 +297,8 @@ export class EdgeStorageService extends BaseService {
       method: 'DELETE',
       url: `${this.baseURL}/credentials/${credentialId}`
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
   }
 }
 export const edgeStorageService = new EdgeStorageService()

--- a/src/views/Credentials/ObjectStorageCredentials/ListView.vue
+++ b/src/views/Credentials/ObjectStorageCredentials/ListView.vue
@@ -150,6 +150,7 @@
       @on-before-go-to-add-page="handleCreateCredential"
       :actions="actions"
       @on-failed-to-delete="handleFailedToDelete"
+      default-ordering-field-name="-last_modified"
       emptyListMessage="No credentials found."
       isTabs
       :emptyBlock="{

--- a/src/views/EdgeStorage/CredentialsView.vue
+++ b/src/views/EdgeStorage/CredentialsView.vue
@@ -145,8 +145,9 @@
       :isTabs="true"
       :editInDrawer="false"
       emptyListMessage="No credentials found"
-      :paginator="false"
+      :paginator="true"
       :enableEditClick="false"
+      default-ordering-field-name="-last_modified"
       exportFileName="Credentials"
       :emptyBlock="{
         title: 'No credentials found',

--- a/src/views/EdgeStorage/View.vue
+++ b/src/views/EdgeStorage/View.vue
@@ -168,6 +168,10 @@
 
   onMounted(() => {
     breadcrumbs.update(route.meta.breadCrumbs ?? [], route)
+
+    if (!isCreatePage.value) {
+      edgeStorageService.prefetchCredentials(route.params.id)
+    }
   })
 </script>
 


### PR DESCRIPTION
## Feature

### Description

Implemented prefetch and caching support for Object Storage credentials using TanStack Query with IndexedDB persistence.

**Changes:**
- Added `prefetchCredentials()` method to [EdgeStorageService](cci:2://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/services/v2/edge-storage/edge-storage-service.js:11:0-302:1) for preloading credentials data
- Added `#fetchCredentials()` private method with proper cache key structure
- Updated `listCredentials()` to use `useEnsureQueryData` with cache support
- Added prefetch call in [View.vue](cci:7://file:///Users/guilherme.santana/Desktop/azion-console-kit/src/views/EdgeStorage/View.vue:0:0-0:0) `onMounted` when in edit mode
- Added `queryKeys.edgeStorage.credentials` key structure for cache management

### How to test

1. Navigate to Object Storage list
2. Click on a bucket to edit
3. Switch to the "Credentials" tab
4. Verify credentials load quickly (prefetched on mount)
5. Navigate away and return - data should load from cache
6. Create/delete a credential and verify cache invalidation works