### PR TITLE
[ENG-36492] fix: hide setting tab sql database

### DIFF
--- a/src/views/EdgeSQL/TabsView.vue
+++ b/src/views/EdgeSQL/TabsView.vue
@@ -149,6 +149,7 @@
         </TabPanel>
         <TabPanel
           header="Settings"
+          v-if="false"
           :pt="{
             root: { 'data-testid': 'sql-database-tabs__tab__settings' }
           }"


### PR DESCRIPTION
## Bug fix

Jira: [ENG-36492]

### What was the problem?

The EdgeSQL edit view currently shows a **Settings** tab that should not be available yet. This can confuse users and expose an unfinished flow.

### Expected behavior

The **Settings** tab should be hidden until the feature is ready to be released.

### How was it solved

The `TabPanel` with header **Settings** was guarded with `v-if="false"` to remove it from the UI while keeping the implementation in place for future re-enable.

### How to test

1. Go to **EdgeSQL Database > Edit** (Tabs view).
2. Confirm only the expected tabs are visible (e.g. Results / History if applicable).
3. Confirm the **Settings** tab is not displayed.

[ENG-36492]: https://aziontech.atlassian.net/browse/ENG-36492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ