### PR TITLE
[ENG-36533] feat: add server-side pagination for table data

### DIFF
--- a/src/services/v2/edge-sql/edge-sql-adapter.js
+++ b/src/services/v2/edge-sql/edge-sql-adapter.js
@@ -252,14 +252,30 @@ export const EdgeSQLAdapter = {
   },
 
   adaptTableInfo({ data }, tableSchema) {
-    const tableInfo = data[0]
-    const rows = formatRowsForDisplay(tableInfo.results?.rows || [])
-    const columnNames = tableSchema.map((col) => col.name)
+    const list = Array.isArray(data) ? data : []
+
+    const isSchemaFromResponse = !Array.isArray(tableSchema) || tableSchema.length === 0
+    const schemaIndex = isSchemaFromResponse ? 0 : -1
+    const selectIndex = isSchemaFromResponse ? 1 : 0
+    const countIndex = isSchemaFromResponse ? 2 : 1
+
+    const resolvedSchema = isSchemaFromResponse
+      ? this.adaptTableSchemaFromPragmaRows(list[schemaIndex]?.results?.rows || [])
+      : tableSchema
+
+    const tableInfo = list[selectIndex]
+    const rows = formatRowsForDisplay(tableInfo?.results?.rows || [])
+    const columnNames = (resolvedSchema || []).map((col) => col.name)
     const mappedRows = mapRowsToObjects(columnNames, rows)
+
+    const countValueRaw = list[countIndex]?.results?.rows?.[0]?.[0]
+    const count = Number(countValueRaw)
+    const totalRecords = Number.isFinite(count) ? count : mappedRows.length
 
     return {
       rows: mappedRows,
-      tableSchema
+      tableSchema: resolvedSchema,
+      totalRecords
     }
   },
 
@@ -340,10 +356,28 @@ export const EdgeSQLAdapter = {
   },
 
   buildTableInfoStatements(tableName, needSchema) {
+    const options = arguments.length > 2 && arguments[2] ? arguments[2] : {}
+    const { paginate = false, page = 1, pageSize = 10 } = options
+
+    const safePage = Math.max(1, Number(page) || 1)
+    const safePageSize = Math.max(1, Number(pageSize) || 10)
+    const offset = (safePage - 1) * safePageSize
+
+    const selectStmt = paginate
+      ? `SELECT * FROM ${tableName} LIMIT ${safePageSize} OFFSET ${offset}`
+      : `SELECT * FROM ${tableName}`
+
+    const statements = []
     if (needSchema) {
-      return [`PRAGMA table_info(${tableName});`, `SELECT * FROM ${tableName}`]
+      statements.push(`PRAGMA table_info(${tableName});`)
     }
-    return [`SELECT * FROM ${tableName}`]
+    statements.push(selectStmt)
+
+    if (paginate) {
+      statements.push(`SELECT COUNT(*) FROM ${tableName}`)
+    }
+
+    return statements
   },
 
   adaptQueryResult({ data }, isCountSelect) {

--- a/src/services/v2/edge-sql/edge-sql-service.js
+++ b/src/services/v2/edge-sql/edge-sql-service.js
@@ -179,10 +179,10 @@ export class EdgeSQLService extends BaseService {
     }
   }
 
-  getTableInfo = async (databaseId, tableName) => {
+  getTableInfo = async (databaseId, tableName, options = {}) => {
     const cachedSchema = getSchemaCache(databaseId, tableName)
     const needSchema = cachedSchema == null
-    const statements = this.adapter?.buildTableInfoStatements?.(tableName, needSchema)
+    const statements = this.adapter?.buildTableInfoStatements?.(tableName, needSchema, options)
 
     const { data } = await this.http.request({
       url: `${this.baseURL}/${databaseId}/query`,
@@ -203,7 +203,8 @@ export class EdgeSQLService extends BaseService {
       adapted = adaptTableInfoFromCache(cachedSchema, data, this.adapter)
     }
 
-    return { count: adapted?.rows?.length, body: adapted }
+    const count = options?.paginate ? adapted?.totalRecords : adapted?.rows?.length
+    return { count, body: adapted }
   }
 
   queryDatabase = async (databaseId, { statements }) => {

--- a/src/templates/list-table-block/sql-database-list.vue
+++ b/src/templates/list-table-block/sql-database-list.vue
@@ -7,6 +7,8 @@
       :columns="props.columns"
       :loading="isLoading"
       :empty-block="emptyBlock"
+      :lazy="props.serverPagination"
+      :totalRecords="props.serverPagination ? props.totalRecords : displayDataForView.length"
       v-model:filters="filters"
       v-model:sortField="sortFieldValue"
       v-model:sortOrder="sortOrderValue"
@@ -350,6 +352,8 @@
     showGridlines: { type: Boolean, default: false },
     data: { type: Array, required: true },
     columns: { type: Array, required: true },
+    serverPagination: { type: Boolean, default: false },
+    totalRecords: { type: Number, default: 0 },
     showInsertColumn: { type: Boolean, default: true },
     addButtonLabel: { type: String, default: '' },
     disabledAddButton: { type: Boolean, default: false },

--- a/src/views/EdgeSQL/TablesView.vue
+++ b/src/views/EdgeSQL/TablesView.vue
@@ -54,11 +54,14 @@
         :title="tableName"
         :isLoading="isLoadingQuery"
         :columns="tableColumns"
+        :serverPagination="!isColumnView"
+        :totalRecords="tableTotalRecords"
         :delete-service="deleteService"
         data-testid="table-list"
         @row-edit-saved="handleActionRowTable"
         @row-edit-cancel="onRowEditCancel"
         @reload-table="selectTable(selectedTable)"
+        @page="handlePage"
         :disabled-action="isApplyingChanges"
         @view-change="handleViewChange"
         :title-delete-dialog="titleDeleteDialog"
@@ -124,6 +127,9 @@
   const alterColumnQuery = ref('')
   const columns = ref([])
   const tableRows = ref([])
+  const tableTotalRecords = ref(0)
+  const currentPage = ref(1)
+  const currentPageSize = ref(10)
   const isLoadingQuery = ref(false)
   const notShowEmptyBlock = ref(false)
 
@@ -312,7 +318,12 @@
     selectedTable.value = table
     notShowEmptyBlock.value = true
     try {
-      const result = await edgeSQLService.getTableInfo(currentDatabase.value.id, table.name)
+      currentPage.value = 1
+      const result = await edgeSQLService.getTableInfo(currentDatabase.value.id, table.name, {
+        paginate: true,
+        page: currentPage.value,
+        pageSize: currentPageSize.value
+      })
       columns.value = result.body.tableSchema.map(({ name, type }) => ({
         field: name,
         tagType: type?.toLowerCase?.() ?? String(type || ''),
@@ -322,6 +333,31 @@
 
       tableRows.value = result.body.rows
       tableSchema.value = result.body.tableSchema
+      tableTotalRecords.value = result.count || 0
+    } finally {
+      isLoadingQuery.value = false
+    }
+  }
+
+  const handlePage = async (event) => {
+    if (!selectedTable.value || isColumnView.value) return
+
+    currentPage.value = Number(event?.page) + 1
+    currentPageSize.value = Number(event?.rows) || currentPageSize.value
+
+    isLoadingQuery.value = true
+    try {
+      const result = await edgeSQLService.getTableInfo(
+        currentDatabase.value.id,
+        selectedTable.value.name,
+        {
+          paginate: true,
+          page: currentPage.value,
+          pageSize: currentPageSize.value
+        }
+      )
+      tableRows.value = result.body.rows
+      tableTotalRecords.value = result.count || 0
     } finally {
       isLoadingQuery.value = false
     }


### PR DESCRIPTION
## Feature

Jira: [ENG-36533]

### Description

Added **server-side pagination** support for EdgeSQL table data queries to avoid loading entire tables at once.

The EdgeSQL `getTableInfo` flow now supports pagination parameters and returns a proper `totalRecords` count using `COUNT(*)`. The table component also received props to toggle whether pagination is handled server-side or not, keeping the previous behavior as default.

### How to test

1. Go to **EdgeSQL > Tables** and select a table with many rows.
2. Confirm the first load fetches only the first page (default page size).
3. Use the paginator to navigate to the next pages.
4. Confirm each page change triggers a new request and updates the table rows.
5. Switch to **Schema** view and confirm it still works as before.

### UI Changes (if applicable)

No visual changes besides pagination behavior now being backed by server requests.

[ENG-36533]: https://aziontech.atlassian.net/browse/ENG-36533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ