### PR TITLE
fix(auth): skip unnecessary /api/user/me request when unauthenticated

### DIFF
--- a/src/helpers/account-handler.js
+++ b/src/helpers/account-handler.js
@@ -1,6 +1,7 @@
 import { ProccessRequestError } from '@/services/axios/errors'
 import { AccountNotFoundError } from '@/services/axios/errors/account-not-found-error'
 import { sessionManager } from '@/services/v2/base/auth/sessionManager'
+import { useAccountStore } from '@/stores/account'
 
 export class AccountHandler {
   constructor(switchAccountService, listTypeAccountService) {
@@ -44,6 +45,7 @@ export class AccountHandler {
     await sessionManager.switchAccount()
     const accountId = await this.searchAccount(clientId)
     const { firstLogin } = await this.switchAccountService(accountId)
+    useAccountStore().setHasSession(true)
     return { name: firstLogin ? 'additional-data' : 'home' }
   }
 
@@ -54,6 +56,7 @@ export class AccountHandler {
   async switchAccountAndRedirect(accountId) {
     await sessionManager.switchAccount()
     const { firstLogin } = await this.switchAccountService(accountId)
+    useAccountStore().setHasSession(true)
 
     if (firstLogin) {
       window.location = '/signup/additional-data'

--- a/src/router/hooks/guards/accountGuard.js
+++ b/src/router/hooks/guards/accountGuard.js
@@ -7,20 +7,23 @@ export async function accountGuard({ to, accountStore, tracker }) {
   const userNotIsLoggedIn = !accountStore.hasActiveUserId
   const isPrivateRoute = !to.meta.isPublic
 
-  if (userNotIsLoggedIn) {
-    if (isPrivateRoute) {
-      try {
-        await loadUserAndAccountInfo()
+  if (userNotIsLoggedIn && isPrivateRoute) {
+    if (!accountStore.hasSession) {
+      setRedirectRoute(to)
+      return '/login'
+    }
 
-        if (to.meta.isPublic) {
-          return '/'
-        }
-      } catch {
-        setRedirectRoute(to)
-        await tracker.reset()
-        await sessionManager.logout()
-        return '/login'
+    try {
+      await loadUserAndAccountInfo()
+
+      if (to.meta.isPublic) {
+        return '/'
       }
+    } catch {
+      setRedirectRoute(to)
+      await tracker.reset()
+      await sessionManager.logout()
+      return '/login'
     }
   }
 }

--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -3,10 +3,11 @@ import { defineStore } from 'pinia'
 export const useAccountStore = defineStore({
   id: 'account',
   persist: {
-    paths: ['identifySignUpProvider']
+    paths: ['identifySignUpProvider', 'hasSession']
   },
   state: () => ({
     account: {},
+    hasSession: false,
     identifySignUpProvider: '',
     accountStatuses: {
       BLOCKED: 'BLOCKED',
@@ -138,8 +139,12 @@ export const useAccountStore = defineStore({
     setAccountData(account) {
       this.account = { ...this.account, ...account }
     },
+    setHasSession(value) {
+      this.hasSession = !!value
+    },
     resetAccount() {
       this.account = {}
+      this.hasSession = false
       this.identifySignUpProvider = ''
     },
     setSsoSignUpMethod(method) {

--- a/src/tests/helpers/account-handler-has-session.test.js
+++ b/src/tests/helpers/account-handler-has-session.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AccountHandler } from '@/helpers/account-handler'
+import { useAccountStore } from '@/stores/account'
+
+vi.mock('@/stores/account', () => ({
+  useAccountStore: vi.fn()
+}))
+
+vi.mock('@/services/v2/base/auth/sessionManager', () => ({
+  sessionManager: {
+    switchAccount: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+describe('AccountHandler hasSession flag', () => {
+  it('should set hasSession=true after successful switchAndReturnAccountPage', async () => {
+    const setHasSession = vi.fn()
+    useAccountStore.mockReturnValue({ setHasSession })
+
+    const switchAccountService = vi.fn().mockResolvedValue({ firstLogin: false })
+    const listTypeAccountService = vi.fn()
+    const handler = new AccountHandler(switchAccountService, listTypeAccountService)
+
+    await handler.switchAndReturnAccountPage('123')
+
+    expect(setHasSession).toHaveBeenCalledWith(true)
+  })
+
+  it('should set hasSession=true after successful switchAccountAndRedirect', async () => {
+    const setHasSession = vi.fn()
+    useAccountStore.mockReturnValue({ setHasSession })
+
+    const switchAccountService = vi.fn().mockResolvedValue({ firstLogin: false })
+    const listTypeAccountService = vi.fn()
+    const handler = new AccountHandler(switchAccountService, listTypeAccountService)
+
+    delete window.location
+    window.location = { replace: vi.fn() }
+
+    await handler.switchAccountAndRedirect('456')
+
+    expect(setHasSession).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/tests/router/hooks/guards/account-guard.test.js
+++ b/src/tests/router/hooks/guards/account-guard.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { accountGuard } from '@/router/hooks/guards/accountGuard'
+
+vi.mock('@/helpers/account-data', () => ({
+  loadUserAndAccountInfo: vi.fn()
+}))
+
+vi.mock('@/helpers', () => ({
+  setRedirectRoute: vi.fn()
+}))
+
+vi.mock('@/services/v2/base/auth', () => ({
+  sessionManager: {
+    logout: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+describe('accountGuard hasSession check', () => {
+  it('should redirect to login without calling API when hasSession=false', async () => {
+    const { loadUserAndAccountInfo } = await import('@/helpers/account-data')
+
+    const result = await accountGuard({
+      to: { meta: { isPublic: false }, fullPath: '/products' },
+      accountStore: { hasActiveUserId: false, hasSession: false },
+      tracker: { reset: vi.fn() }
+    })
+
+    expect(loadUserAndAccountInfo).not.toHaveBeenCalled()
+    expect(result).toBe('/login')
+  })
+
+  it('should attempt session restore when hasSession=true', async () => {
+    const { loadUserAndAccountInfo } = await import('@/helpers/account-data')
+    loadUserAndAccountInfo.mockResolvedValue(undefined)
+
+    const result = await accountGuard({
+      to: { meta: { isPublic: false }, fullPath: '/products' },
+      accountStore: { hasActiveUserId: false, hasSession: true },
+      tracker: { reset: vi.fn() }
+    })
+
+    expect(loadUserAndAccountInfo).toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('should not interfere when user is already logged in', async () => {
+    const { loadUserAndAccountInfo } = await import('@/helpers/account-data')
+    loadUserAndAccountInfo.mockClear()
+
+    const result = await accountGuard({
+      to: { meta: { isPublic: false }, fullPath: '/products' },
+      accountStore: { hasActiveUserId: true, hasSession: true },
+      tracker: { reset: vi.fn() }
+    })
+
+    expect(loadUserAndAccountInfo).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('should not interfere on public routes', async () => {
+    const { loadUserAndAccountInfo } = await import('@/helpers/account-data')
+    loadUserAndAccountInfo.mockClear()
+
+    const result = await accountGuard({
+      to: { meta: { isPublic: true }, fullPath: '/login' },
+      accountStore: { hasActiveUserId: false, hasSession: false },
+      tracker: { reset: vi.fn() }
+    })
+
+    expect(loadUserAndAccountInfo).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/tests/stores/account.test.js
+++ b/src/tests/stores/account.test.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAccountStore } from '@/stores/account'
+
+describe('account store session state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should start with hasSession=false', () => {
+    const store = useAccountStore()
+    expect(store.hasSession).toBe(false)
+  })
+
+  it('should set hasSession=true only when explicitly marked', () => {
+    const store = useAccountStore()
+    store.setAccountData({ id: 1 })
+    expect(store.hasSession).toBe(false)
+    store.setHasSession(true)
+    expect(store.hasSession).toBe(true)
+  })
+
+  it('should reset hasSession=false on resetAccount', () => {
+    const store = useAccountStore()
+    store.setHasSession(true)
+    store.resetAccount()
+    expect(store.hasSession).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

When an unauthenticated user (or a user who has logged out) navigates to any private route, the `accountGuard` always attempts to restore the session by calling `loadUserAndAccountInfo()`, which hits `GET /api/user/me`, `GET /api/account/info`, and `GET /api/account/job-role`.

Since the session cookie is HTTP-only and inaccessible from JavaScript, the frontend has no way to know upfront that there's no valid session. The result is a wasted round-trip that returns 401 before redirecting to `/login`.

## Solution

Introduce a `hasSession` flag in the Pinia account store that acts as a **client-side session indicator**:

### How it works

1. **After successful authentication** (`switchAccountService()` succeeds in `AccountHandler`), the flag is set to `true`
2. **On logout/account-switch cleanup** (`resetAccount()`), the flag is set to `false`
3. **The flag is persisted to localStorage** via `pinia-plugin-persistedstate`, so it survives page refreshes
4. **The `accountGuard`** checks this flag before attempting session bootstrap:
   - `hasSession = false` → redirect to `/login` immediately (no API call)
   - `hasSession = true` → attempt `loadUserAndAccountInfo()` as before

### Self-healing behavior

When `hasSession = true` but the server session has actually expired, the API call returns 401. The existing `catch` block handles this by calling `sessionManager.logout()` → `resetAccount()`, which clears the flag. On the next visit, the user goes straight to `/login`.

### Edge cases validated

| Scenario | Status |
|----------|--------|
| Email/password login | Covered — `switchAndReturnAccountPage()` sets flag |
| SSO/OAuth login | Covered — converges on same `switchAndReturnAccountPage()` flow |
| MFA login | Covered — MFA routes are `isPublic: true`; after MFA, `switchAndReturnAccountPage()` sets flag |
| Logout | Covered — `resetAccount()` clears flag |
| Account switch | Covered — clears then re-sets flag after switch succeeds |
| Cross-tab broadcast (SWITCH_ACCOUNT) | Covered — `store-handler.js` calls `resetAccount()` |
| Race condition (logoutGuard → accountGuard) | Safe — `logoutGuard` runs before `accountGuard` in pipeline |
| Server session expired | Self-heals — 401 triggers cleanup, flag cleared |
| Cookie valid but localStorage cleared | Known limitation — forces re-login; acceptable trade-off |

## Files changed

| File | Change |
|------|--------|
| `src/stores/account.js` | Add `hasSession` to state, persist paths, `setHasSession()` action, clear in `resetAccount()` |
| `src/helpers/account-handler.js` | Call `setHasSession(true)` after successful `switchAccountService()` |
| `src/router/hooks/guards/accountGuard.js` | Short-circuit to `/login` when `!hasSession` |
| `src/tests/stores/account.test.js` | 3 tests for store flag behavior |
| `src/tests/helpers/account-handler-has-session.test.js` | 2 tests for handler flag setting |
| `src/tests/router/hooks/guards/account-guard.test.js` | 4 tests for guard short-circuit logic |

## Test plan

- [ ] Unit tests pass (`vitest run` on the 3 new test files)
- [ ] Full headless suite passes with no regressions
- [ ] Manual: fresh browser (never logged in) → private route → redirects to `/login` without `/api/user/me` call
- [ ] Manual: logged in → refresh → `/api/user/me` is called normally
- [ ] Manual: logout → private route → redirects to `/login` without `/api/user/me` call
- [ ] Manual: expired server session → `/api/user/me` returns 401 → redirects to `/login` and clears flag