### PR TITLE
[ENG-36545] feat: add cache hydration for network lists edit flow

### DIFF
--- a/src/services/network-lists-services/list-countries-service.js
+++ b/src/services/network-lists-services/list-countries-service.js
@@ -21,7 +21,7 @@ export const listCountriesService = async () => {
 }
 
 const adapt = (httpResponse) => {
-  const countriesFormated = httpResponse.body.data.allCountries.map((countryItem) => {
+  const countriesFormated = httpResponse.body.data?.allCountries.map((countryItem) => {
     const formattedItem = {
       name: countryItem.name,
       value: countryItem.code2

--- a/src/services/v2/network-lists/network-lists-service.js
+++ b/src/services/v2/network-lists/network-lists-service.js
@@ -115,6 +115,27 @@ export class NetworkListsService extends BaseService {
 
     return 'Network list successfully deleted.'
   }
+
+  getNetworkListFromCache = (id) => {
+    if (!id) return undefined
+
+    const listTypeMap = {
+      'IP/CIDR': 'ip_cidr',
+      ASN: 'asn',
+      Countries: 'countries'
+    }
+
+    return super.getFromCache({
+      queryKey: queryKeys.networkLists.all,
+      id,
+      listPath: 'body',
+      select: (item) => ({
+        id: item.id,
+        name: item.name,
+        networkListType: listTypeMap[item.listType] || item.listType
+      })
+    })
+  }
 }
 
 export const networkListsService = new NetworkListsService()

--- a/src/views/NetworkLists/EditView.vue
+++ b/src/views/NetworkLists/EditView.vue
@@ -18,6 +18,8 @@
   const breadcrumbs = useBreadcrumbs()
   const networkListName = ref('Network List')
 
+  const cachedNetworkList = networkListsService.getNetworkListFromCache(route.params?.id) ?? {}
+
   const props = defineProps({
     listCountriesService: { type: Function, required: true },
     updatedRedirect: { type: String, required: true }
@@ -98,6 +100,7 @@
       <EditFormBlock
         :editService="networkListsService.editNetworkList"
         :loadService="networkListsService.loadNetworkList"
+        :initialValues="cachedNetworkList"
         @on-edit-success="handleTrackSuccessEdit"
         @on-edit-fail="handleTrackFailEdit"
         @loaded-service-object="setNetworkListName"


### PR DESCRIPTION
## Feature

### Description

Implementa hidratação de dados via cache para o fluxo de edição de Network Lists, melhorando a experiência do usuário ao pré-carregar dados já disponíveis no cache.

**Alterações realizadas:**

1. **network-lists-service.js**: Adicionado método `getNetworkListFromCache()` que:
   - Busca dados do cache usando `queryKey` do TanStack Query
   - Mapeia os tipos de lista (`IP/CIDR` → `ip_cidr`, `ASN` → `asn`, `Countries` → `countries`)
   - Retorna `id`, `name` e `networkListType` para pré-popular o formulário

2. **EditView.vue**: 
   - Utiliza `getNetworkListFromCache()` para obter dados iniciais
   - Passa `cachedNetworkList` como `initialValues` para o `EditFormBlock`

3. **list-countries-service.js**: 
   - Adicionado optional chaining (`?.`) para evitar erro quando `allCountries` é undefined

### How to test

1. Acesse a listagem de Network Lists
2. Aguarde o carregamento da lista (dados são cacheados)
3. Clique em "Edit" em qualquer Network List
4. Observe que o formulário já exibe o nome e tipo da lista imediatamente (dados do cache)
5. Aguarde o carregamento completo dos dados do servidor
6. Verifique que os dados permanecem consistentes