### PR TITLE
[ENG-36541] fix: improve Absolute date selection behavior in DataTimeRange

### DIFF
--- a/src/components/base/dataTimeRange/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange/inputDateRange/index.vue
@@ -9,6 +9,8 @@
     formatDateSimple,
     parseDateSimple,
     createRelativeRange,
+    createStartOfDay,
+    createEndOfDay,
     MONTHS,
     RELATIVE_UNITS,
     RELATIVE_DIRECTIONS,
@@ -140,6 +142,45 @@
     } else {
       model.value.labelEnd = ''
     }
+
+    const label = typeof model.value?.label === 'string' ? model.value.label.trim() : ''
+    const labelStart =
+      typeof model.value?.labelStart === 'string' ? model.value.labelStart.trim() : ''
+    const labelEnd = typeof model.value?.labelEnd === 'string' ? model.value.labelEnd.trim() : ''
+
+    const hasNonAbsoluteState =
+      Boolean(label) ||
+      Boolean(labelStart) ||
+      Boolean(labelEnd) ||
+      Boolean(model.value?.relative) ||
+      Boolean(model.value?.relativeStart) ||
+      Boolean(model.value?.relativeEnd) ||
+      labelStart.toLowerCase() === 'now' ||
+      labelEnd.toLowerCase() === 'now'
+
+    const shouldInitializeClickedDayRange =
+      props.mode === 'absolute' &&
+      date &&
+      (hasNonAbsoluteState || !hasInitializedAbsoluteRange.value)
+
+    if (shouldInitializeClickedDayRange) {
+      if (props.editingField === 'start') {
+        model.value.startDate = createStartOfDay(date)
+        model.value.labelStart = ''
+        model.value.relativeStart = null
+      } else {
+        model.value.endDate = createEndOfDay(date)
+        model.value.labelEnd = ''
+        model.value.relativeEnd = null
+      }
+      hasInitializedAbsoluteRange.value = true
+      selectedDate.value = date
+      selectedTime.value = ''
+      hasChanges.value = false
+      emitSelectIfValid()
+      return
+    }
+
     selectedDate.value = date
     updateSelectedDateTime()
     hasChanges.value = false
@@ -232,6 +273,7 @@
       if (props.editingField === 'start') {
         model.value.startDate = newDate
         model.value.labelStart = ''
+        model.value.relativeStart = null
         hasInitializedAbsoluteRange.value = true
         const currentEndDate = model.value.endDate ? new Date(model.value.endDate) : null
 
@@ -247,23 +289,9 @@
           model.value.startDate = new Date(newDate.getTime() - 5 * 60 * 1000)
         }
       } else {
-        const hasStart = Boolean(model.value.startDate)
-        const startEqualsCurrentEnd =
-          hasStart &&
-          Boolean(model.value.endDate) &&
-          new Date(model.value.startDate).getTime() === new Date(model.value.endDate).getTime()
-
-        const shouldInitializeStartDate =
-          !hasInitializedAbsoluteRange.value && (!hasStart || startEqualsCurrentEnd)
-
         model.value.endDate = newDate
         model.value.labelEnd = ''
-
-        if (shouldInitializeStartDate) {
-          model.value.startDate = new Date(newDate.getTime() - 5 * 60 * 1000)
-          model.value.labelStart = ''
-          hasInitializedAbsoluteRange.value = true
-        }
+        model.value.relativeEnd = null
       }
     }
   }


### PR DESCRIPTION
## Bug fix

Jira: [ENG-36541]

### What was the problem?

When switching from **Quick / Relative / Now** to **Absolute** and clicking a date on the calendar, the selection behavior was inconsistent:
- The clicked date could inherit the previous mode state instead of initializing a proper absolute day boundary.
- In some cases, selecting a date in Absolute could unintentionally update both `startDate` and `endDate`, even when the user was editing only one field.

### Expected behavior

- When clicking a day in **Absolute**, the selected field should be initialized with the correct day boundary:
  - `startDate` -> `00:00:00` of the clicked day
  - `endDate` -> `23:59:59` of the clicked day
- Only the field being edited (start or end) should be changed. The other field must not be mutated when it comes from **relative/now** state.

### How was it solved

- Updated `InputDateRange` Absolute date selection to detect non-absolute state (quick/relative/now) and initialize the clicked day boundary.
- Ensured the initialization updates **only the clicked field** (`editingField`), without changing the opposite side.
- Removed implicit logic that could modify the opposite field during Absolute interactions.

### How to test

1. Open any page using `DataTimeRange`.
2. Select a preset in **Quick** (or switch to **Relative** / **Now** and set values).
3. Go to **Absolute** tab.
4. Click on the **startDate** input and pick a day in the calendar.
   - Confirm `startDate` becomes `00:00:00` of the clicked day.
   - Confirm `endDate` is not changed if it was relative/now.
5. Click on the **endDate** input and pick a day in the calendar.
   - Confirm `endDate` becomes `23:59:59` of the clicked day.
   - Confirm `startDate` is not changed.

[ENG-36541]: https://aziontech.atlassian.net/browse/ENG-36541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ