### PR TITLE
hotfix: fix undefined applicationId in origins API route on rules engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.52.0",
+  "version": "1.52.2",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/services/edge-application-origins-services/edit-origin-service.js
+++ b/src/services/edge-application-origins-services/edit-origin-service.js
@@ -7,7 +7,7 @@ import { queryKeys } from '@/services/v2/base/query/queryKeys'
 export const editOriginService = async (payload) => {
   const parsedPayload = adapt(payload)
   let httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeEdgeApplicationBaseUrl()}/${payload.edgeApplicationId}/origins/${payload.id}`,
+    url: `${makeEdgeApplicationBaseUrl()}/${payload.applicationId}/origins/${payload.id}`,
     method: 'PATCH',
     body: parsedPayload
   })
@@ -15,7 +15,7 @@ export const editOriginService = async (payload) => {
   const result = parseHttpResponse(httpResponse)
 
   queryClient.removeQueries({
-    queryKey: queryKeys.application.origins.all(payload.edgeApplicationId)
+    queryKey: queryKeys.application.origins.all(payload.applicationId)
   })
 
   return result

--- a/src/services/edge-application-origins-services/load-origin-service.js
+++ b/src/services/edge-application-origins-services/load-origin-service.js
@@ -5,9 +5,9 @@ import { BaseService } from '@/services/v2/base/query/baseService'
 
 const baseService = new BaseService()
 
-const fetchOrigin = async ({ edgeApplicationId, id }) => {
+const fetchOrigin = async ({ applicationId, id }) => {
   let httpResponse = await AxiosHttpClientAdapter.request({
-    url: `${makeEdgeApplicationBaseUrl()}/${edgeApplicationId}/origins/${id}`,
+    url: `${makeEdgeApplicationBaseUrl()}/${applicationId}/origins/${id}`,
     method: 'GET'
   })
   httpResponse = adapt(httpResponse)

--- a/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
+++ b/src/tests/services/edge-application-origins-services/edit-origin-service.test.js
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 const fixtures = {
   originMock: {
     id: '0000000-00000000-00a0a00s0as0-000000',
-    edgeApplicationId: 123,
+    applicationId: 123,
     name: 'New Origin',
     originType: 'single_origin',
     originKey: '0000000-00000000-00a0a00s0as0-000000',
@@ -30,7 +30,7 @@ const fixtures = {
   },
   originTypeObjectStorage: {
     id: '0000000-00000000-00a0a00s0as0-000000',
-    edgeApplicationId: 123,
+    applicationId: 123,
     name: 'New Origin',
     originProtocolPolicy: 'http',
     originType: 'object_storage',
@@ -39,14 +39,14 @@ const fixtures = {
   },
   requestPayloadMockLiveIngest: {
     id: '0000000-00000000-00a0a00s0as0-000000',
-    edgeApplicationId: 123,
+    applicationId: 123,
     name: 'New Origin',
     originType: 'live_ingest',
     streamingEndpoint: 'br-east-1.azioningest.net'
   },
   emptyPrefixOrigin: {
     id: '0000000-00000000-00a0a00s0as0-000000',
-    edgeApplicationId: 123,
+    applicationId: 123,
     name: 'New Origin',
     originProtocolPolicy: 'http',
     originType: 'object_storage',
@@ -83,7 +83,7 @@ describe('EdgeApplicationOriginsServices', () => {
     await sut(fixtures.originMock)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/edge_applications/${fixtures.originMock.edgeApplicationId}/origins/${fixtures.originMock.id}`,
+      url: `${version}/edge_applications/${fixtures.originMock.applicationId}/origins/${fixtures.originMock.id}`,
       method: 'PATCH',
       body: {
         origin_type: fixtures.originMock.originType,
@@ -113,7 +113,7 @@ describe('EdgeApplicationOriginsServices', () => {
     await sut(fixtures.originTypeObjectStorage)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/edge_applications/${fixtures.originTypeObjectStorage.edgeApplicationId}/origins/${fixtures.originTypeObjectStorage.id}`,
+      url: `${version}/edge_applications/${fixtures.originTypeObjectStorage.applicationId}/origins/${fixtures.originTypeObjectStorage.id}`,
       method: 'PATCH',
       body: {
         origin_type: fixtures.originTypeObjectStorage.originType,
@@ -135,7 +135,7 @@ describe('EdgeApplicationOriginsServices', () => {
     await sut(fixtures.requestPayloadMockLiveIngest)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/edge_applications/${fixtures.requestPayloadMockLiveIngest.edgeApplicationId}/origins/${fixtures.requestPayloadMockLiveIngest.id}`,
+      url: `${version}/edge_applications/${fixtures.requestPayloadMockLiveIngest.applicationId}/origins/${fixtures.requestPayloadMockLiveIngest.id}`,
       method: 'PATCH',
       body: {
         origin_type: fixtures.requestPayloadMockLiveIngest.originType,
@@ -156,7 +156,7 @@ describe('EdgeApplicationOriginsServices', () => {
     await sut(fixtures.emptyPrefixOrigin)
 
     expect(requestSpy).toHaveBeenCalledWith({
-      url: `${version}/edge_applications/${fixtures.emptyPrefixOrigin.edgeApplicationId}/origins/${fixtures.emptyPrefixOrigin.id}`,
+      url: `${version}/edge_applications/${fixtures.emptyPrefixOrigin.applicationId}/origins/${fixtures.emptyPrefixOrigin.id}`,
       method: 'PATCH',
       body: {
         origin_type: fixtures.emptyPrefixOrigin.originType,
@@ -173,7 +173,7 @@ describe('EdgeApplicationOriginsServices', () => {
     })
     const { sut } = makeSut()
 
-    const feedbackMessage = await sut(fixtures.originMock, fixtures.edgeApplicationId)
+    const feedbackMessage = await sut(fixtures.originMock, fixtures.applicationId)
 
     expect(feedbackMessage).toBe('Your Origin has been edited')
   })

--- a/src/views/EdgeApplicationsOrigins/Drawer/index.vue
+++ b/src/views/EdgeApplicationsOrigins/Drawer/index.vue
@@ -199,14 +199,14 @@
     payload.id = payload.originKey
     return await props.editOriginService({
       ...payload,
-      edgeApplicationId: props.edgeApplicationId
+      applicationId: props.edgeApplicationId
     })
   }
 
   const loadService = async (payload) => {
     const edgeNode = await props.loadOriginService({
       ...payload,
-      edgeApplicationId: props.edgeApplicationId
+      applicationId: props.edgeApplicationId
     })
     return edgeNode
   }


### PR DESCRIPTION
## Summary
- Fixed parameter name mismatch (`edgeApplicationId` → `applicationId`) in origin services (`load` and `edit`) that caused API calls to `edge_applications/undefined/origins/{id}`
- Updated `DrawerOrigin` component to pass `applicationId` consistently to origin services
- Aligned test fixtures with the standardized parameter name

## Test plan
- [x] Open Edge Application > Rules Engine > create/edit a rule with "Set Origin" behavior
- [x] Verify the origins API call uses the correct application ID in the URL
- [x] Verify creating a new origin from within Rules Engine drawer works correctly