### PR TITLE
[ENG-36547] feat: add cache hydration for digital certificates edit flow

### DIFF
--- a/src/services/v2/digital-certificates/digital-certificates-cr-service.js
+++ b/src/services/v2/digital-certificates/digital-certificates-cr-service.js
@@ -1,4 +1,5 @@
 import { BaseService } from '@/services/v2/base/query/baseService'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
 export class DigitalCertificatesCRService extends BaseService {
   constructor() {
@@ -12,6 +13,8 @@ export class DigitalCertificatesCRService extends BaseService {
       url: this.baseURL,
       body: payload
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.digitalCertificates.all })
   }
 }
 

--- a/src/services/v2/digital-certificates/digital-certificates-crl-service.js
+++ b/src/services/v2/digital-certificates/digital-certificates-crl-service.js
@@ -121,6 +121,21 @@ export class DigitalCertificatesCRLService extends BaseService {
 
     return 'CRL successfully deleted!'
   }
+
+  getCRLFromCache = (id) => {
+    if (!id) return undefined
+
+    return super.getFromCache({
+      queryKey: queryKeys.digitalCertificatesCRL.all,
+      id,
+      listPath: 'body',
+      select: (item) => ({
+        id: item.id,
+        name: item.name,
+        type: 'CRL'
+      })
+    })
+  }
 }
 
 export const digitalCertificatesCRLService = new DigitalCertificatesCRLService()

--- a/src/services/v2/digital-certificates/digital-certificates-csr-service.js
+++ b/src/services/v2/digital-certificates/digital-certificates-csr-service.js
@@ -1,5 +1,6 @@
 import { BaseService } from '@/services/v2/base/query/baseService'
 import { DigitalCertificatesCSRAdapter } from '@/services/v2/digital-certificates/digital-certificates-csr-adapter'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
 export class DigitalCertificatesCSRService extends BaseService {
   constructor() {
@@ -15,6 +16,8 @@ export class DigitalCertificatesCSRService extends BaseService {
       url: this.baseURL,
       body
     })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.digitalCertificates.all })
 
     return data
   }

--- a/src/services/v2/digital-certificates/digital-certificates-service.js
+++ b/src/services/v2/digital-certificates/digital-certificates-service.js
@@ -37,6 +37,8 @@ export class DigitalCertificatesService extends BaseService {
       processError: false
     })
 
+    this.queryClient.removeQueries({ queryKey: queryKeys.digitalCertificates.all })
+
     if (response?.meta?.certificate) {
       return { id: response.meta.certificate }
     }
@@ -163,6 +165,32 @@ export class DigitalCertificatesService extends BaseService {
     this.queryClient.removeQueries({ queryKey: queryKeys.digitalCertificates.all })
 
     return 'Digital certificate successfully deleted!'
+  }
+
+  getCertificateFromCache = (id) => {
+    if (!id) return undefined
+
+    const typeMap = {
+      'TLS Certificate': 'edge_certificate',
+      'Trusted CA Certificate': 'trusted_ca_certificate'
+    }
+
+    return super.getFromCache({
+      queryKey: queryKeys.digitalCertificates.all,
+      id,
+      listPath: 'body',
+      select: (item) => ({
+        id: item.id,
+        name: item.name,
+        type: typeMap[item.type] || item.type,
+        managed: item.managed,
+        authority: item.authority,
+        status: item.status?.status?.content,
+        issuer: item.issuer,
+        subjectName: item.subjectName,
+        validity: item.validity
+      })
+    })
   }
 }
 

--- a/src/views/DigitalCertificates/EditView.vue
+++ b/src/views/DigitalCertificates/EditView.vue
@@ -11,6 +11,7 @@
         :editService="editServiceRender"
         :loadService="loadServiceRender"
         :schema="validationSchema"
+        :initialValues="cachedCertificate"
         updatedRedirect="list-digital-certificates"
         @loaded-service-object="setCertificateName"
         @on-edit-success="handleTrackSuccessEdit"
@@ -20,6 +21,7 @@
           <FormFieldsEditDigitalCertificates
             :clipboardWrite="props.clipboardWrite"
             :documentationService="props.documentationService"
+            :isLoading="isDetailLoading"
           />
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading, values }">
@@ -50,17 +52,6 @@
   import { digitalCertificatesCRLService } from '@/services/v2/digital-certificates/digital-certificates-crl-service'
   import { useDigitalCertificate } from './FormFields/composables/certificate'
 
-  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
-  const tracker = inject('tracker')
-  const route = useRoute()
-  const breadcrumbs = useBreadcrumbs()
-  const certificateName = ref('Edit Digital Certificate')
-
-  const setCertificateName = (certificate) => {
-    certificateName.value = certificate.name
-    breadcrumbs.update(route.meta.breadCrumbs ?? [], route, certificate.name)
-  }
-
   const props = defineProps({
     clipboardWrite: {
       type: Function,
@@ -72,7 +63,33 @@
     }
   })
 
+  /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
+  const tracker = inject('tracker')
+  const route = useRoute()
+  const breadcrumbs = useBreadcrumbs()
   const { certificateTypeList } = useDigitalCertificate()
+
+  const cachedCertificate = computed(() => {
+    if (certificateTypeList.value === 'CRL') {
+      return digitalCertificatesCRLService.getCRLFromCache(route.params.id) ?? {}
+    }
+    return digitalCertificatesService.getCertificateFromCache(route.params.id) ?? {}
+  })
+
+  const certificateName = ref(cachedCertificate.value?.name || 'Edit Digital Certificate')
+  const isDetailLoading = ref(true)
+
+  if (cachedCertificate.value?.name) {
+    breadcrumbs.update(route.meta.breadCrumbs ?? [], route, cachedCertificate.value.name)
+  }
+
+  const setCertificateName = (certificate) => {
+    certificateName.value = certificate.name
+    breadcrumbs.update(route.meta.breadCrumbs ?? [], route, certificate.name)
+    if ('certificate' in certificate || 'csr' in certificate) {
+      isDetailLoading.value = false
+    }
+  }
 
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field.'),

--- a/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
+++ b/src/views/DigitalCertificates/FormFields/FormFieldsEditDigitalCertificates.vue
@@ -16,6 +16,10 @@
     documentationService: {
       type: Function,
       required: true
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   })
 
@@ -116,6 +120,7 @@
             placeholder="-----BEGIN CERTIFICATE----&#10;-----END CERTIFICATE-----"
             name="certificate"
             :value="certificate"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
             data-testid="digital-certificate__certificate-field"
           />
         </div>
@@ -127,6 +132,7 @@
             name="csr"
             disabled
             :value="csr"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
           />
         </div>
         <div class="flex flex-col sm:max-w-lg w-full gap-2">
@@ -168,6 +174,7 @@
             label="Certificate"
             name="certificate"
             :value="certificate"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
             data-testid="digital-certificate__certificate-field"
             placeholder="-----BEGIN CERTIFICATE----&#10;-----END CERTIFICATE-----"
           />
@@ -177,44 +184,15 @@
             label="Private Key"
             name="privateKey"
             :value="privateKey"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
             placeholder="For security purposes, the current private key isn't exhibited, but it was correctly registered. Paste a new private key in this field to update it."
           />
         </div>
       </template>
     </FormHorizontal>
-
-    <!-- CRL case -->
-    <FormHorizontal
-      v-if="isCertificateType.crl"
-      title="Update a Server Certificate"
-      description="Paste the PEM-encoded CRL in the respective field to update the certificate. The current certificate is hidden to protect sensitive information."
-    >
-      <template #inputs>
-        <div class="flex flex-col sm:max-w-lg w-full gap-2">
-          <FieldText
-            label="Name"
-            name="name"
-            required
-            :value="name"
-            placeholder="My digital certificate"
-            data-testid="digital-certificate__name-field"
-          />
-        </div>
-        <div class="flex flex-col sm:max-w-lg w-full gap-2">
-          <FieldTextArea
-            label="Certificate"
-            name="certificate"
-            :value="certificate"
-            data-testid="digital-certificate__certificate-field"
-            placeholder="-----BEGIN CRL----&#10;-----END CRL-----"
-          />
-        </div>
-      </template>
-    </FormHorizontal>
-
     <!-- Trusted case -->
     <FormHorizontal
-      v-if="isCertificateType.trustedCertificate"
+      v-else-if="isCertificateType.trustedCertificate"
       title="Update Trusted CA Certificate"
       description="Paste the PEM-encoded Trusted CA certificate in the respective field to update the certificate. The current certificate is hidden to protect sensitive information."
     >
@@ -235,8 +213,39 @@
             data-testid="trusted-certificates-form__certificate-field"
             name="certificate"
             :value="certificate"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
             placeholder="-----BEGIN CERTIFICATE----&#10;-----END CERTIFICATE-----"
             description="Intermediate certificates are accepted."
+          />
+        </div>
+      </template>
+    </FormHorizontal>
+
+    <!-- CRL case -->
+    <FormHorizontal
+      v-else-if="isCertificateType.crl"
+      title="Update a Server Certificate"
+      description="Paste the PEM-encoded CRL in the respective field to update the certificate. The current certificate is hidden to protect sensitive information."
+    >
+      <template #inputs>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <FieldText
+            label="Name"
+            name="name"
+            required
+            :value="name"
+            placeholder="My digital certificate"
+            data-testid="digital-certificate__name-field"
+          />
+        </div>
+        <div class="flex flex-col sm:max-w-lg w-full gap-2">
+          <FieldTextArea
+            label="Certificate"
+            name="certificate"
+            :value="certificate"
+            :icon="props.isLoading ? 'pi pi-spin pi-spinner' : ''"
+            data-testid="digital-certificate__certificate-field"
+            placeholder="-----BEGIN CRL----&#10;-----END CRL-----"
           />
         </div>
       </template>


### PR DESCRIPTION
## Feature

### Description

Implementa hidratação de dados via cache para o fluxo de edição de Digital Certificates, melhorando a experiência do usuário ao pré-carregar dados do cache da listagem.

**Principais alterações:**

- **DigitalCertificatesService**: Adicionado método `getCertificateFromCache()` que recupera dados do certificado do cache do TanStack Query
- **DigitalCertificatesCRLService**: Adicionado método `getCRLFromCache()` para certificados CRL
- **EditView.vue**: 
  - Implementado `cachedCertificate` computed que busca dados do cache baseado no tipo de certificado
  - Passa `initialValues` para o formulário com dados do cache
  - Atualiza breadcrumb imediatamente se nome disponível no cache
  - Controla estado `isDetailLoading` para indicar carregamento dos detalhes completos
- **FormFieldsEditDigitalCertificates.vue**: 
  - Adicionada prop `isLoading` para controlar estado de carregamento
  - Exibe spinner nos campos de textarea enquanto carrega dados completos do certificado
- **Invalidação de cache**: Adicionado `removeQueries` após criação de certificado para garantir dados atualizados

### How to test

1. Acesse a listagem de Digital Certificates
2. Clique em um certificado para editar
3. Observe que os dados básicos (nome, tipo, status) aparecem imediatamente
4. Os campos de certificate/private key mostram spinner enquanto carregam os dados completos
5. Após carregamento, os campos são preenchidos com os dados do certificado
6. Verifique que o breadcrumb mostra o nome do certificado imediatamente (se disponível no cache)