### PR TITLE
[ENG-36550] fix: fix upload cancellation, duplicated requests and overflow bulk actions on resize

### DIFF
--- a/src/composables/useEdgeStorage.js
+++ b/src/composables/useEdgeStorage.js
@@ -28,6 +28,7 @@ const selectedFiles = ref([])
 const isDownloading = ref(false)
 const showDragAndDrop = ref(false)
 const folderPath = ref('')
+const abortController = ref(null)
 
 const processProgress = computed(() => {
   if (operationType.value === 'upload') {
@@ -157,9 +158,11 @@ export const useEdgeStorage = () => {
       currentItemProgress.value = 0
       totalBytesProcessed.value = 0
       totalBytesToProcess.value = itemsToProcess.value.reduce((sum, file) => sum + file.size, 0)
+      abortController.value = new AbortController()
 
       try {
         for (const file of itemsToProcess.value) {
+          if (abortController.value.signal.aborted) break
           currentProcessingItem.value = {
             name: file.name,
             size: formatBytes(file.size),
@@ -175,13 +178,18 @@ export const useEdgeStorage = () => {
               file,
               selectedBucket.value.name,
               onProgress,
-              folderPath.value
+              folderPath.value,
+              abortController.value.signal
             )
             processedItems.value.push(file)
             totalBytesProcessed.value += file.size
             currentItemProgress.value = 100
             processCount.value++
           } catch (fileError) {
+            if (fileError.code === 'ERR_CANCELED' || fileError.name === 'CanceledError') {
+              isProcessing.value = false
+              break
+            }
             failedItems.value.push({ file, error: fileError })
           }
         }
@@ -397,6 +405,14 @@ export const useEdgeStorage = () => {
     }
   }
 
+  const cancelRequest = () => {
+    if (abortController.value) {
+      abortController.value.abort()
+    }
+    isProcessing.value = false
+    currentProcessingItem.value = null
+  }
+
   return {
     buckets,
     selectedBucket,
@@ -425,6 +441,7 @@ export const useEdgeStorage = () => {
     selectedFiles,
     isDownloading,
     showDragAndDrop,
-    folderPath
+    folderPath,
+    cancelRequest
   }
 }

--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -119,7 +119,8 @@ export class EdgeStorageService extends BaseService {
     file = {},
     bucketName = '',
     onProgress = null,
-    prefix = ''
+    prefix = '',
+    signal = null
   ) => {
     const config = {}
 
@@ -137,6 +138,11 @@ export class EdgeStorageService extends BaseService {
         onProgress(progress)
       }
     }
+
+    if (signal) {
+      config.signal = signal
+    }
+
     await this.http.request({
       method: 'POST',
       url: `${this.baseURL}/buckets/${bucketName}/objects/${encodeURIComponent(prefix)}${

--- a/src/services/v2/utils/errorHandler.js
+++ b/src/services/v2/utils/errorHandler.js
@@ -4,15 +4,17 @@ export class ErrorHandler {
     UNEXPECTED_ERROR: 'An unexpected error occurred. Please try again.'
   }
 
-  constructor(status, messages) {
+  constructor(status, messages, code) {
     this.status = status
     this.message = Array.isArray(messages) ? messages : [messages]
+    this.code = code
   }
 
   static create(error) {
     const status = error?.response?.status || 500
+    const code = error?.code || null
     const messages = this._extractMessages(error)
-    return new ErrorHandler(status, messages)
+    return new ErrorHandler(status, messages, code)
   }
 
   static createMeta(axiosError) {

--- a/src/templates/list-table-block/folder-list.vue
+++ b/src/templates/list-table-block/folder-list.vue
@@ -727,7 +727,7 @@
         :field="col.field"
         :header="selectedItems.length === 0 ? col.header : ''"
         :sortField="selectedItems.length > 0 ? null : col?.sortField"
-        headerClass="relative w-[20rem]"
+        headerClass="relative w-[20rem] overflow-visible"
         :class="{ 'hover:cursor-pointer ': !disabledList }"
         data-testid="data-table-column"
       >

--- a/src/views/EdgeStorage/ListView.vue
+++ b/src/views/EdgeStorage/ListView.vue
@@ -267,18 +267,13 @@
   }
 
   const handleBreadcrumbClick = (item) => {
-    if (item.index === 0) {
-      folderPath.value = ''
-    } else {
+    let newPath = ''
+    if (item.index !== 0) {
       const folders = folderPath.value.split('/').filter((folder) => folder.trim() !== '')
       const pathToFolder = folders.slice(0, item.index).join('/')
-      folderPath.value = `${pathToFolder}/`
+      newPath = `${pathToFolder}/`
     }
-    selectedBucket.value.continuation_token = null
-    currentPage.value = 1
-    router.replace({ query: folderPath.value ? { folderPath: folderPath.value } : {} })
-    filesTableNeedRefresh.value = true
-    listServiceFilesRef.value?.reload()
+    router.replace({ query: newPath ? { folderPath: newPath } : {} })
   }
   const handleCreateBucketTrackEvent = () => {
     tracker.product.clickToCreate({
@@ -323,27 +318,20 @@
     input.click()
   }
 
-  const handleEditFolder = async (item) => {
+  const handleEditFolder = (item) => {
     if (item.isParentNav) {
       goBackToBucket()
     } else if (item.isFolder) {
-      folderPath.value += item.name
-      router.replace({ query: folderPath.value ? { folderPath: folderPath.value } : {} })
-      filesTableNeedRefresh.value = true
-      await listServiceFilesRef.value?.reload()
-      currentPage.value = 1
+      const newPath = folderPath.value + item.name
+      router.replace({ query: newPath ? { folderPath: newPath } : {} })
     }
   }
 
-  const goBackToBucket = async () => {
+  const goBackToBucket = () => {
     const pathSegments = folderPath.value.split('/').filter((segment) => segment !== '')
     pathSegments.pop()
-    folderPath.value = pathSegments.length > 0 ? pathSegments.join('/') + '/' : ''
-    selectedBucket.value.continuation_token = null
-    router.replace({ query: folderPath.value ? { folderPath: folderPath.value } : {} })
-    filesTableNeedRefresh.value = true
-    await listServiceFilesRef.value?.reload()
-    currentPage.value = 1
+    const newPath = pathSegments.length > 0 ? pathSegments.join('/') + '/' : ''
+    router.replace({ query: newPath ? { folderPath: newPath } : {} })
   }
   const handleMultipleDelete = () => {
     Promise.resolve().then(async () => {
@@ -471,13 +459,7 @@
         return
       }
       const newPath = folderPath.value + folderName + '/'
-      folderPath.value = newPath
       router.replace({ query: { folderPath: newPath } })
-      if (!isPaginationLoading.value) {
-        currentPage.value = 1
-      }
-      filesTableNeedRefresh.value = true
-      listServiceFilesRef.value?.reload()
     }
     isCreatingNewFolder.value = false
     newFolderName.value = ''
@@ -494,11 +476,21 @@
     if (!newId) {
       selectBucket(null)
     } else {
-      const bucket = buckets.value.find((bucket) => bucket.name === newId)
-      selectBucket(bucket)
-
-      if (route.query?.folderPath) {
-        folderPath.value = route.query.folderPath
+      if (selectedBucket.value?.name !== newId) {
+        const bucket = buckets.value.find((bucket) => bucket.name === newId)
+        selectBucket(bucket)
+      } else {
+        if (route.query?.folderPath) {
+          folderPath.value = route.query.folderPath
+        } else {
+          folderPath.value = ''
+        }
+        if (selectedBucket.value) {
+          selectedBucket.value.continuation_token = null
+        }
+        currentPage.value = 1
+        filesTableNeedRefresh.value = true
+        listServiceFilesRef.value?.reload()
       }
     }
     breadcrumbs.update(route.meta.breadCrumbs ?? [], route)
@@ -510,13 +502,6 @@
       handleRouteChange()
     },
     { immediate: true }
-  )
-
-  watch(
-    () => route.params.id,
-    () => {
-      handleRouteChange()
-    }
   )
 
   watch(folderPath, () => {

--- a/src/views/EdgeStorage/components/ProgressCard.vue
+++ b/src/views/EdgeStorage/components/ProgressCard.vue
@@ -42,7 +42,7 @@
   import { computed } from 'vue'
   import { useEdgeStorage } from '@/composables/useEdgeStorage'
 
-  const { isProcessing, operationType, processStatus } = useEdgeStorage()
+  const { isProcessing, operationType, processStatus, cancelRequest } = useEdgeStorage()
 
   const showProgress = computed(() => {
     return isProcessing.value
@@ -65,6 +65,6 @@
   })
 
   const handleCancel = () => {
-    isProcessing.value = false
+    cancelRequest()
   }
 </script>


### PR DESCRIPTION
## Bug fix
https://aziontech.atlassian.net/browse/ENG-36550 
https://aziontech.atlassian.net/browse/ENG-36551
https://aziontech.atlassian.net/browse/ENG-36552

### What was the problem?
- **Double API Requests:** When navigating inside folders in the Edge Storage interface, two API requests were being fired simultaneously (one from the click handler and another from the router watcher).
- **Upload Cancellation:** Canceling a file upload in the UI did not abort the underlying HTTP request, causing the upload to continue in the background despite the user's action.

### Expected behavior
- **Navigation:** Clicking on a folder or breadcrumb should trigger a single API request to fetch the folder contents.
- **Cancellation:** Clicking the cancel button during an upload should immediately abort the HTTP request and stop the data transfer.

### How was it solved
- **Refactored Navigation Logic:** Updated `ListView.vue` to use the Vue Router URL as the single source of truth. Removed redundant local state updates and manual `reload()` calls in `handleEditFolder`, `goBackToBucket`, and `handleBreadcrumbClick`. Now, these actions only update the route, and a single watcher handles the data fetching.
- **Implemented AbortController:**
    - Added `AbortController` to `useEdgeStorage.js` to manage request cancellation.
    - Updated `EdgeStorageService` to accept an `AbortSignal`.
    - Exposed a `cancelRequest` method in the composable that aborts the controller and resets the upload state.
    - Updated `ProgressCard.vue` to use the new cancellation method.
- **Error Handling:** Updated `ErrorHandler` to properly recognize cancellation errors (`ERR_CANCELED`) and prevent them from being treated as unexpected failures.

### How to test
**1. Double Request Fix** 
- Open the Browser DevTools (Network tab).
- Go to the Edge Storage bucket list.
- Click on a folder to navigate inside.
- **Verify:** Only one request to the contents endpoint should appear in the Network tab.
- Navigate back using the breadcrumb.
- **Verify:** Only one request is triggered.

**2. Upload Cancellation**
- Start uploading a large file.
- Inspect the Network tab to see the pending `POST` request.
- Click the "X" (Close/Cancel) button on the progress card.
- **Verify:** The request in the Network tab should be marked as "canceled" (or failed depending on the browser), and the UI should reset immediately.

https://github.com/user-attachments/assets/61f8cd22-3822-41bf-b50f-6904cf35b251

