### PR TITLE
[ENG-35272] feat: add info to contact azion copilot and support

### DIFF
--- a/src/layout/components/navbar/feedback.vue
+++ b/src/layout/components/navbar/feedback.vue
@@ -54,27 +54,49 @@
       </div>
     </div>
     <template #footer>
-      <div class="flex justify-content-end gap-2">
-        <PrimeButton
-          type="button"
-          label="Cancel"
-          outlined
-          size="small"
-          class="w-20"
-          @click="visible = false"
-          data-testid="feedback-dialog__dialog-footer__cancel-button"
-        />
-        <PrimeButton
-          type="button"
-          severity="secondary"
-          label="Send feedback"
-          class="w-36"
-          size="small"
-          icon="pi pi-send"
-          :loading="loading"
-          @click="sendFeedback()"
-          data-testid="feedback-dialog__dialog-footer__confirm-button"
-        />
+      <div class="flex justify-between items-center w-full">
+        <div class="flex flex-wrap text-xs font-normal justify-start gap-1">
+          <span>Have a technical issue? Contact</span>
+          <span>
+            <a
+              class="text-[var(--text-color-link)] hover:text-[var(--text-color-link-hover)] cursor-pointer hover:underline"
+              small
+              @click="openCopilot"
+              data-testid="feedback-dialog__dialog-footer__copilot-link"
+              >Azion Copilot</a
+            >
+            or
+            <a
+              class="text-[var(--text-color-link)] hover:text-[var(--text-color-link-hover)] cursor-pointer hover:underline"
+              :href="AZION_CONTACT_SUPPORT"
+              target="_blank"
+              data-testid="feedback-dialog__dialog-footer__support-link"
+              >Azion Support</a
+            >
+          </span>
+        </div>
+        <div class="flex gap-2">
+          <PrimeButton
+            type="button"
+            label="Cancel"
+            outlined
+            size="small"
+            class="w-20"
+            @click="visible = false"
+            data-testid="feedback-dialog__dialog-footer__cancel-button"
+          />
+          <PrimeButton
+            type="button"
+            severity="secondary"
+            label="Send feedback"
+            class="w-36"
+            size="small"
+            icon="pi pi-send"
+            :loading="loading"
+            @click="sendFeedback()"
+            data-testid="feedback-dialog__dialog-footer__confirm-button"
+          />
+        </div>
       </div>
     </template>
   </Dialog>
@@ -85,6 +107,8 @@
   import { storeToRefs } from 'pinia'
   import { useAccountStore } from '@/stores/account'
   import { createFeedbackServices } from '@/services/feedback-services'
+  import { useLayout } from '@/composables/use-layout'
+  import { AZION_CONTACT_SUPPORT } from '@/helpers/azion-documentation-window-opener'
   import { useToast } from 'primevue/usetoast'
   import Dialog from 'primevue/dialog'
   import Dropdown from 'primevue/dropdown'
@@ -108,6 +132,7 @@
   })
 
   const { accountData: account } = storeToRefs(useAccountStore())
+  const { OpenSidebarComponent } = useLayout()
   const toast = useToast()
 
   const visible = ref(false)
@@ -120,6 +145,11 @@
     { name: 'Idea', code: 'idea' },
     { name: 'Other', code: 'other' }
   ]
+
+  const openCopilot = () => {
+    visible.value = false
+    OpenSidebarComponent('copilot')
+  }
 
   const resetForm = () => {
     selectedIssueType.value = 'issue'


### PR DESCRIPTION
## Feature
[ENG-35272] feat: add info to contact azion copilot and support
### Description
Adicionado link no feedback para redirecionar ao Copilot ou ao Azion Support, em vez de utilizar o formulário de feedback para abrir um problema na plataforma.
### How to test

### UI Changes (if applicable)


[ENG-35272]: https://aziontech.atlassian.net/browse/ENG-35272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ