### PR TITLE
[ENG-36094] fix: remove preview button on the functions page

### DIFF
--- a/src/views/EdgeFunctions/CreateView.vue
+++ b/src/views/EdgeFunctions/CreateView.vue
@@ -7,7 +7,6 @@
   import ActionBarBlockWithTeleport from '@templates/action-bar-block/action-bar-with-teleport'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import FormFieldsCreateEdgeFunctions from './FormFields/FormFieldsCreateEdgeFunctions'
-  import MobileCodePreview from './components/mobile-code-preview.vue'
   import HelloWorldSample from '@/helpers/edge-function-hello-world'
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
   import { useLoadingStore } from '@/stores/loading'
@@ -120,7 +119,6 @@
         pageTitle="Create Function"
         description="Configure function code, triggers, and execution settings."
       >
-        <MobileCodePreview :updateObject="updateObject" />
       </PageHeadingBlock>
     </template>
     <template #content>


### PR DESCRIPTION
## Feature
[ENG-36094] fix: remove preview button on the functions page
### Description
Quando está em mobile está aparecendo um botão de preview na página de create de functions, e foi removido, pois não é mais usado.
### How to test

### UI Changes (if applicable)


[ENG-36094]: https://aziontech.atlassian.net/browse/ENG-36094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ