### PR TITLE
[ENG-36559] feat: migrate team-permission services to v2 with TanStack Query

### DIFF
--- a/src/router/routes/team-permission/index.js
+++ b/src/router/routes/team-permission/index.js
@@ -1,5 +1,3 @@
-import * as TeamPermissionService from '@/services/team-permission'
-
 /** @type {import('vue-router').RouteRecordRaw} */
 export const teamsPermissionRoutes = {
   path: '/teams-permission',
@@ -22,10 +20,6 @@ export const teamsPermissionRoutes = {
       path: 'create',
       name: 'create-teams-permission',
       component: () => import('@views/TeamsPermissions/CreateView.vue'),
-      props: {
-        createTeamPermissionsService: TeamPermissionService.createTeamPermissionsService,
-        listPermissionService: TeamPermissionService.listPermissionService
-      },
       meta: {
         title: 'Create Team Permission',
         breadCrumbs: [
@@ -44,12 +38,6 @@ export const teamsPermissionRoutes = {
       path: 'edit/:id',
       name: 'edit-teams-permission',
       component: () => import('@views/TeamsPermissions/EditView.vue'),
-      props: {
-        editTeamPermissionService: TeamPermissionService.editTeamPermissionService,
-        loadTeamPermissionService: TeamPermissionService.loadTeamPermissionService,
-        listPermissionService: TeamPermissionService.listPermissionService,
-        updatedRedirect: 'teams-permission'
-      },
       meta: {
         title: 'Edit Team Permission',
         breadCrumbs: [

--- a/src/services/v2/team-permission/index.js
+++ b/src/services/v2/team-permission/index.js
@@ -1,0 +1,1 @@
+export { teamPermissionService } from './team-permission-service'

--- a/src/services/v2/team-permission/team-permission-adapter.js
+++ b/src/services/v2/team-permission/team-permission-adapter.js
@@ -1,0 +1,47 @@
+import { adaptServiceDataResponse } from '@/services/v2/utils/adaptServiceDataResponse'
+
+const parseStatusData = (status) => {
+  return status
+    ? { content: 'Active', severity: 'success' }
+    : { content: 'Inactive', severity: 'danger' }
+}
+
+const transformMap = {
+  id: (value) => value.id,
+  name: (value) => value.name,
+  permissions: (value) =>
+    value.permissions?.length ? value.permissions.map((item) => item.name) : [],
+  status: (value) => parseStatusData(value.is_active)
+}
+
+const loadTransformMap = {
+  id: (value) => value.id,
+  name: (value) => value.name,
+  permissions: (value) => value.permissions,
+  isActive: (value) => value.is_active
+}
+
+export const TeamPermissionAdapter = {
+  transformList(data) {
+    if (!Array.isArray(data)) return []
+    return adaptServiceDataResponse(data, null, transformMap)
+  },
+
+  transformItem(data) {
+    if (!data) return null
+    return {
+      id: loadTransformMap.id(data),
+      name: loadTransformMap.name(data),
+      permissions: loadTransformMap.permissions(data),
+      isActive: loadTransformMap.isActive(data)
+    }
+  },
+
+  transformPayload(payload) {
+    return {
+      name: payload.name,
+      permissions_ids: payload.permissions.map((item) => item.id),
+      is_active: payload.isActive
+    }
+  }
+}

--- a/src/services/v2/team-permission/team-permission-service.js
+++ b/src/services/v2/team-permission/team-permission-service.js
@@ -1,0 +1,142 @@
+import { BaseService } from '@/services/v2/base/query/baseService'
+import { TeamPermissionAdapter } from './team-permission-adapter'
+import { queryKeys } from '@/services/v2/base/query/queryKeys'
+
+export class TeamPermissionService extends BaseService {
+  constructor() {
+    super()
+    this.adapter = TeamPermissionAdapter
+    this.baseURL = 'v4/iam/teams'
+    this.permissionsBaseURL = 'v4/iam/permissions'
+  }
+
+  #fetchList = async (params = {}) => {
+    const { data } = await this.http.request({
+      method: 'GET',
+      url: this.baseURL,
+      params: {
+        ordering: 'name',
+        page: 1,
+        page_size: 100,
+        ...params
+      }
+    })
+
+    return {
+      body: this.adapter.transformList(data.results),
+      count: data.count
+    }
+  }
+
+  prefetchList = (pageSize = 10) => {
+    const defaultParams = {
+      ordering: 'name',
+      page: 1,
+      pageSize
+    }
+    return this.usePrefetchQuery(queryKeys.teamPermission.list(defaultParams), () =>
+      this.#fetchList(defaultParams)
+    )
+  }
+
+  list = async (params = {}) => {
+    const firstPage = params?.page === 1
+    const skipCache = params?.skipCache || params?.hasFilter || params?.search
+
+    return await this.useEnsureQueryData(
+      queryKeys.teamPermission.list(params),
+      () => this.#fetchList(params),
+      {
+        persist: firstPage && !skipCache,
+        skipCache
+      }
+    )
+  }
+
+  getTeamPermissionFromCache = (id) => {
+    if (!id) return undefined
+
+    return super.getFromCache({
+      queryKey: queryKeys.teamPermission.all,
+      id,
+      listPath: 'body',
+      select: (item) => ({
+        id: item.id,
+        name: item.name,
+        isActive: item.status?.content === 'Active'
+      })
+    })
+  }
+
+  load = async ({ id }) => {
+    const { data } = await this.http.request({
+      method: 'GET',
+      url: `${this.baseURL}/${id}`
+    })
+
+    return this.adapter.transformItem(data.data)
+  }
+
+  create = async (payload) => {
+    const body = this.adapter.transformPayload(payload)
+
+    const { data } = await this.http.request({
+      method: 'POST',
+      url: this.baseURL,
+      body
+    })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.teamPermission.all })
+    this.queryClient.removeQueries({ queryKey: queryKeys.teams.all })
+
+    return {
+      feedback: 'Your Team Permission has been created',
+      urlToEditView: `/teams-permission/edit/${data.data.id}`
+    }
+  }
+
+  edit = async (payload) => {
+    const body = this.adapter.transformPayload(payload)
+
+    await this.http.request({
+      method: 'PUT',
+      url: `${this.baseURL}/${payload.id}`,
+      body
+    })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.teamPermission.all })
+    this.queryClient.removeQueries({ queryKey: queryKeys.teams.all })
+
+    return 'Your Team Permission has been updated'
+  }
+
+  delete = async (id) => {
+    await this.http.request({
+      method: 'DELETE',
+      url: `${this.baseURL}/${id}`
+    })
+
+    this.queryClient.removeQueries({ queryKey: queryKeys.teamPermission.all })
+    this.queryClient.removeQueries({ queryKey: queryKeys.teams.all })
+
+    return 'Team Permission successfully deleted'
+  }
+
+  listPermissions = async () => {
+    const { data } = await this.http.request({
+      method: 'GET',
+      url: this.permissionsBaseURL,
+      params: {
+        page_size: 100
+      }
+    })
+
+    return data.results
+  }
+
+  invalidateCache = async () => {
+    await this.queryClient.removeQueries({ queryKey: queryKeys.teamPermission.all })
+  }
+}
+
+export const teamPermissionService = new TeamPermissionService()

--- a/src/views/TeamsPermissions/CreateView.vue
+++ b/src/views/TeamsPermissions/CreateView.vue
@@ -1,36 +1,3 @@
-<template>
-  <ContentBlock>
-    <template #heading>
-      <PageHeadingBlock
-        pageTitle="Create Team"
-        data-testid="teams-permissions__create-view__page-heading"
-        description="Configure permissions for team collaboration."
-      />
-    </template>
-    <template #content>
-      <CreateFormBlock
-        :createService="props.createTeamPermissionsService"
-        :cleanFormCallback="resetForm"
-        :schema="validationSchema"
-        :initialValues="initialValues"
-        @on-response="handleTrackSuccessCreated"
-        @on-response-fail="handleTrackFailCreated"
-      >
-        <template #form>
-          <FormFieldsTeamPermissions :listPermissionService="props.listPermissionService" />
-        </template>
-        <template #action-bar="{ onSubmit, onCancel, loading }">
-          <ActionBarTemplate
-            @onSubmit="onSubmit"
-            @onCancel="onCancel"
-            :loading="loading"
-          />
-        </template>
-      </CreateFormBlock>
-    </template>
-  </ContentBlock>
-</template>
-
 <script setup>
   import { inject } from 'vue'
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
@@ -39,22 +6,12 @@
   import ContentBlock from '@/templates/content-block'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import ActionBarTemplate from '@/templates/action-bar-block/action-bar-with-teleport'
+  import { teamPermissionService } from '@/services/v2/team-permission'
 
   import * as yup from 'yup'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
   const tracker = inject('tracker')
-
-  const props = defineProps({
-    createTeamPermissionsService: {
-      type: Function,
-      required: true
-    },
-    listPermissionService: {
-      type: Function,
-      required: true
-    }
-  })
 
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field'),
@@ -66,6 +23,10 @@
     name: '',
     permissions: [],
     isActive: true
+  }
+
+  const resetForm = () => {
+    return initialValues
   }
 
   const handleTrackSuccessCreated = () => {
@@ -86,3 +47,38 @@
       .track()
   }
 </script>
+
+<template>
+  <ContentBlock>
+    <template #heading>
+      <PageHeadingBlock
+        pageTitle="Create Team"
+        data-testid="teams-permissions__create-view__page-heading"
+        description="Configure permissions for team collaboration."
+      />
+    </template>
+    <template #content>
+      <CreateFormBlock
+        :createService="teamPermissionService.create"
+        :cleanFormCallback="resetForm"
+        :schema="validationSchema"
+        :initialValues="initialValues"
+        @on-response="handleTrackSuccessCreated"
+        @on-response-fail="handleTrackFailCreated"
+      >
+        <template #form>
+          <FormFieldsTeamPermissions
+            :listPermissionService="teamPermissionService.listPermissions"
+          />
+        </template>
+        <template #action-bar="{ onSubmit, onCancel, loading }">
+          <ActionBarTemplate
+            @onSubmit="onSubmit"
+            @onCancel="onCancel"
+            :loading="loading"
+          />
+        </template>
+      </CreateFormBlock>
+    </template>
+  </ContentBlock>
+</template>

--- a/src/views/TeamsPermissions/EditView.vue
+++ b/src/views/TeamsPermissions/EditView.vue
@@ -9,26 +9,7 @@
   import FormFieldsTeamPermissions from '@views/TeamsPermissions/FormFields/FormFieldsTeamPermissions.vue'
   import { handleTrackerError } from '@/utils/errorHandlingTracker'
   import { useBreadcrumbs } from '@/stores/breadcrumbs'
-  import { teamPermissionService } from '@/services/team-permission'
-
-  const props = defineProps({
-    editTeamPermissionService: {
-      type: Function,
-      required: true
-    },
-    loadTeamPermissionService: {
-      type: Function,
-      required: true
-    },
-    listPermissionService: {
-      type: Function,
-      required: true
-    },
-    updatedRedirect: {
-      type: String,
-      required: true
-    }
-  })
+  import { teamPermissionService } from '@/services/v2/team-permission'
 
   const validationSchema = yup.object({
     name: yup.string().required('Name is a required field'),
@@ -98,9 +79,9 @@
     <template #content>
       <EditFormBlock
         @on-load-fail="handleLoadFail"
-        :editService="props.editTeamPermissionService"
-        :loadService="props.loadTeamPermissionService"
-        :updatedRedirect="updatedRedirect"
+        :editService="teamPermissionService.edit"
+        :loadService="teamPermissionService.load"
+        updatedRedirect="teams-permission"
         :initialValues="cachedTeamPermission"
         :schema="validationSchema"
         @loaded-service-object="setTeamName"
@@ -108,7 +89,9 @@
         @on-edit-fail="handleTrackFailEdit"
       >
         <template #form>
-          <FormFieldsTeamPermissions :listPermissionService="props.listPermissionService" />
+          <FormFieldsTeamPermissions
+            :listPermissionService="teamPermissionService.listPermissions"
+          />
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/TeamsPermissions/ListView.vue
+++ b/src/views/TeamsPermissions/ListView.vue
@@ -5,8 +5,7 @@
   import FetchListTableBlock from '@/templates/list-table-block/with-fetch-ordering-and-pagination.vue'
   import { computed, inject } from 'vue'
   import { DataTableActionsButtons } from '@/components/DataTable'
-  import { teamPermissionService } from '@/services/team-permission'
-  import { deleteTeamPermissionService } from '@/services/team-permission'
+  import { teamPermissionService } from '@/services/v2/team-permission'
   import { documentationAccountsProducts } from '@/helpers/azion-documentation-catalog'
 
   /**@type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
@@ -18,7 +17,7 @@
       type: 'delete',
       title: 'team',
       icon: 'pi pi-trash',
-      service: deleteTeamPermissionService
+      service: teamPermissionService.delete
     }
   ]
 
@@ -99,7 +98,7 @@
     </template>
     <template #content>
       <FetchListTableBlock
-        :listService="teamPermissionService.listTeamPermissionService"
+        :listService="teamPermissionService.list"
         :columns="getColumns"
         editPagePath="/teams-permission/edit"
         emptyListMessage="No teams found."


### PR DESCRIPTION
## Feature
[ENG-36559] feat: migrate team-permission services to v2 with TanStack Query
### Description
Migrando Team Permission para v2 
### How to test

### UI Changes (if applicable)


[ENG-36559]: https://aziontech.atlassian.net/browse/ENG-36559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ