### PR TITLE
fix: move tab selection before async load to prevent false redirect in Edge Applications

### DIFF
--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -172,12 +172,12 @@
     let selectedTab = tab
     if (!tab) selectedTab = 'main-settings'
 
+    const activeTabIndexByRoute = mapTabs.value[selectedTab]
+    changeTab(activeTabIndexByRoute)
+
     edgeApplication.value = { ...edgeApplication.value, ...(await handleLoadEdgeApplication()) }
     isApplicationLoaded.value = true
     verifyTab(edgeApplication.value)
-
-    const activeTabIndexByRoute = mapTabs.value[selectedTab]
-    changeTab(activeTabIndexByRoute)
 
     breadcrumbs.update(route.meta.breadCrumbs ?? [], route, edgeApplication.value?.name)
     preloadTabData()


### PR DESCRIPTION
## Bug fix

### What was the problem?

### Expected behavior

### How was it solved

### How to test
