### PR TITLE
feat: implement systemic toast pattern for Team Permissions creation

### DIFF
--- a/src/services/v2/team-permission/team-permission-service.js
+++ b/src/services/v2/team-permission/team-permission-service.js
@@ -90,6 +90,7 @@ export class TeamPermissionService extends BaseService {
     this.queryClient.removeQueries({ queryKey: queryKeys.teams.all })
 
     return {
+      id: data.data.id,
       feedback: 'Your Team Permission has been created',
       urlToEditView: `/teams-permission/edit/${data.data.id}`
     }

--- a/src/views/TeamsPermissions/CreateView.vue
+++ b/src/views/TeamsPermissions/CreateView.vue
@@ -29,10 +29,24 @@
     return initialValues
   }
 
-  const handleTrackSuccessCreated = () => {
+  const handleResponse = (response) => {
     tracker.product.productCreated({
       productName: 'Teams Permissions'
     })
+    handleToast(response)
+  }
+
+  const handleToast = (response) => {
+    const toast = {
+      feedback: 'Your team permission has been created',
+      actions: {
+        link: {
+          label: 'View Team Permission',
+          callback: () => response.redirectToUrl(`/teams-permission/edit/${response.id}`)
+        }
+      }
+    }
+    response.showToastWithActions(toast)
   }
 
   const handleTrackFailCreated = (error) => {
@@ -63,8 +77,9 @@
         :cleanFormCallback="resetForm"
         :schema="validationSchema"
         :initialValues="initialValues"
-        @on-response="handleTrackSuccessCreated"
+        @on-response="handleResponse"
         @on-response-fail="handleTrackFailCreated"
+        disableToast
       >
         <template #form>
           <FormFieldsTeamPermissions


### PR DESCRIPTION
## Feature

### Description

Implementação do padrão sistêmico de toasts na tela de Team Permissions para adequar a exibição de feedback de sucesso ao padrão adotado na plataforma.

**Alterações realizadas:**
- Adicionada função `handleToast` para exibir toast de sucesso com link de ação
- Implementada função `handleResponse` que combina tracking de criação com exibição do toast
- Atualizado serviço de team permission para retornar `id` na resposta
- Adicionada prop `disableToast` ao `CreateFormBlock` para desabilitar o toast padrão
- Toast exibe: "Your team permission has been created" com link "View Team Permission"
- Redirecionamento para listagem após criação com exibição automática do toast

### How to test

1. Navegar para a tela de criação de Team Permission
2. Preencher o formulário com dados válidos (nome e permissões)
3. Clicar em "Create"
4. Verificar que:
   - Usuário é redirecionado para a listagem de Team Permissions
   - Toast de sucesso aparece no canto inferior direito
   - Toast exibe mensagem: "Your team permission has been created"
   - Toast contém link "View Team Permission" que redireciona para edição
   - Toast desaparece automaticamente após 5 segundos
5. Clicar no link do toast para verificar redirecionamento para página de edição

### UI Changes (if applicable)

- **Toast de sucesso**: Exibição de notificação temporária com ícone de sucesso (verde)
- **Mensagem clara**: "Your team permission has been created"
- **Link de ação**: "View Team Permission" permite acesso direto à entidade criada
- **Comportamento**: Toast desaparece automaticamente ou pode ser fechado manualmente
- **Consistência**: Padrão visual e comportamental idêntico ao de outras telas (Variables, Workloads, WAF Rules, etc)