### PR TITLE
[ENG-36637] fix: remove verifyTab from changeTab to prevent TypeError on undefined edgeApplication

### DIFF
--- a/src/views/EdgeApplications/TabsView.vue
+++ b/src/views/EdgeApplications/TabsView.vue
@@ -215,7 +215,6 @@
     router.push({ name: 'edit-application', params, query: {} })
   }
   const changeTab = (index) => {
-    verifyTab(edgeApplication.value)
     const tab = getTabFromIndex(index)
     activeTab.value = index
     changeRouteByTab(tab)


### PR DESCRIPTION
## Bug fix

### What was the problem?

When switching tabs in Edge Applications edit view, `changeTab` called `verifyTab(edgeApplication.value)` which could throw a `TypeError` when `edgeApplication` was still `undefined` (e.g., during initial async load or when navigating before data was fully fetched).

### Expected behavior

Switching tabs should work without errors regardless of the loading state of `edgeApplication`.

### How was it solved

Removed the `verifyTab` call from the `changeTab` function in `EdgeApplications/TabsView.vue`. The tab verification is already handled elsewhere in the component lifecycle, making this call redundant and the source of the TypeError.

### How to test

1. Navigate to an Edge Application edit view.
2. Quickly switch between tabs — no console errors should appear.
3. Verify that tab-specific content still loads correctly for each tab.