### PR TITLE
[ENG-35484] feat: add file rename support with inline editing in Edge Storage

### DIFF
--- a/src/composables/useEdgeStorage.js
+++ b/src/composables/useEdgeStorage.js
@@ -431,6 +431,28 @@ export const useEdgeStorage = () => {
     }
   }
 
+  const renameFile = async (file, newName) => {
+    if (!selectedBucket.value || !file || !newName) return
+
+    const bucketName = selectedBucket.value.name
+    const currentObjectKey = folderPath.value ? folderPath.value + file.name : file.name
+    const newObjectKey = folderPath.value ? folderPath.value + newName : newName
+
+    try {
+      await edgeStorageService.renameEdgeStorageBucketFile(
+        bucketName,
+        currentObjectKey,
+        newObjectKey
+      )
+      filesTableNeedRefresh.value = true
+      handleToast('success', 'Rename Successful', `File renamed to "${newName}" successfully`)
+    } catch (error) {
+      const errorMessage = error.message || 'An unexpected error occurred during rename.'
+      handleToast('error', 'Rename Failed', errorMessage)
+      throw error
+    }
+  }
+
   const handleFileChange = async (event) => {
     const files = event.dataTransfer?.files || event.target?.files
     if (files.length) {
@@ -518,6 +540,7 @@ export const useEdgeStorage = () => {
     removeFiles,
     deleteMultipleFiles,
     moveFiles,
+    renameFile,
     getBucketSelected,
     bucketTableNeedRefresh,
     validationSchema,

--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -231,6 +231,27 @@ export class EdgeStorageService extends BaseService {
     return results
   }
 
+  renameEdgeStorageBucketFile = async (
+    bucketName = '',
+    currentObjectKey = '',
+    newObjectKey = ''
+  ) => {
+    await this.copyEdgeStorageBucketFile(bucketName, currentObjectKey, newObjectKey)
+
+    try {
+      await this.deleteEdgeStorageBucketFiles(bucketName, currentObjectKey)
+    } catch (deleteError) {
+      try {
+        await this.deleteEdgeStorageBucketFiles(bucketName, newObjectKey)
+      } catch {
+        // rollback cleanup failed — both files now exist
+      }
+      throw deleteError
+    }
+
+    return `File renamed from "${currentObjectKey}" to "${newObjectKey}" successfully`
+  }
+
   deleteEdgeStorageBucketFiles = async (bucketName = '', fileName = '') => {
     await this.http.request({
       method: 'DELETE',

--- a/src/templates/list-table-block/folder-list.vue
+++ b/src/templates/list-table-block/folder-list.vue
@@ -26,7 +26,10 @@
     'page',
     'save-new-folder',
     'cancel-new-folder',
-    'update:new-folder-name'
+    'update:new-folder-name',
+    'save-rename',
+    'cancel-rename',
+    'update:renameValue'
   ])
 
   const props = defineProps({
@@ -141,6 +144,18 @@
     containerWidth: {
       type: Number,
       default: 0
+    },
+    renamingItem: {
+      type: Object,
+      default: null
+    },
+    renameValue: {
+      type: String,
+      default: ''
+    },
+    isRenaming: {
+      type: Boolean,
+      default: false
     }
   })
 
@@ -402,9 +417,17 @@
     emit('update:newFolderName', event.target.value)
   }
 
+  const handleRenameInput = (event) => {
+    emit('update:renameValue', event.target.value)
+  }
+
   const showActions = (rowData) => {
     return (
-      !rowData.isFolder && !rowData.isParentNav && !rowData.isNewFolder && !rowData.isSkeletonRow
+      !rowData.isFolder &&
+      !rowData.isParentNav &&
+      !rowData.isNewFolder &&
+      !rowData.isSkeletonRow &&
+      !(props.renamingItem && rowData.id === props.renamingItem.id)
     )
   }
 
@@ -799,6 +822,43 @@
                 size="small"
                 outlined
                 @click="emit('cancel-new-folder')"
+              />
+            </div>
+          </template>
+          <template
+            v-else-if="
+              col.field === 'name' && props.renamingItem && rowData.id === props.renamingItem.id
+            "
+          >
+            <div class="flex items-center gap-2">
+              <InputText
+                :value="props.renameValue"
+                @input="handleRenameInput"
+                @keyup.enter="!props.isRenaming && emit('save-rename')"
+                @keyup.escape="!props.isRenaming && emit('cancel-rename')"
+                placeholder="Enter new name"
+                class="flex-1"
+                :disabled="props.isRenaming"
+                autofocus
+                size="small"
+              />
+              <PrimeButton
+                :icon="props.isRenaming ? 'pi pi-spin pi-spinner' : 'pi pi-check'"
+                size="small"
+                outlined
+                @click="emit('save-rename')"
+                :disabled="
+                  props.isRenaming ||
+                  !props.renameValue.trim() ||
+                  props.renameValue === props.renamingItem.name
+                "
+              />
+              <PrimeButton
+                icon="pi pi-times"
+                size="small"
+                outlined
+                :disabled="props.isRenaming"
+                @click="emit('cancel-rename')"
               />
             </div>
           </template>

--- a/src/views/EdgeStorage/ListView.vue
+++ b/src/views/EdgeStorage/ListView.vue
@@ -81,6 +81,9 @@
                 :headerContainer="headerContainer"
                 :buttonsContainer="buttonsContainer"
                 :containerWidth="containerWidth"
+                :renamingItem="renamingItem"
+                :renameValue="renameValue"
+                :isRenaming="isRenaming"
                 exportFileName="Files"
                 @on-row-click-edit-folder="handleEditFolder"
                 @delete-selected-items="handleDeleteSelectedItems"
@@ -92,6 +95,9 @@
                 @save-new-folder="handleSaveNewFolder"
                 @cancel-new-folder="handleCancelNewFolder"
                 @update:newFolderName="newFolderName = $event"
+                @save-rename="handleSaveRename"
+                @cancel-rename="handleCancelRename"
+                @update:renameValue="renameValue = $event"
                 class="w-full"
               >
                 <template #search-slot>
@@ -192,6 +198,7 @@
     selectedBucket,
     deleteMultipleFiles,
     moveFiles,
+    renameFile,
     uploadFiles,
     filesTableNeedRefresh,
     handleDownload,
@@ -210,6 +217,12 @@
       icon: 'pi pi-download',
       type: 'action',
       commandAction: (item) => handleDownload(item)
+    },
+    {
+      label: 'Rename',
+      icon: 'pi pi-pencil',
+      type: 'action',
+      commandAction: (item) => startRenaming(item)
     },
     {
       label: 'Move',
@@ -262,6 +275,9 @@
   const currentPage = ref(1)
   const isCreatingNewFolder = ref(false)
   const newFolderName = ref('')
+  const renamingItem = ref(null)
+  const renameValue = ref('')
+  const isRenaming = ref(false)
 
   const needFetchToAPI = computed(() => {
     return selectedBucket.value && (!selectedBucket.value.files || filesTableNeedRefresh.value)
@@ -510,6 +526,36 @@
   const handleCancelNewFolder = () => {
     isCreatingNewFolder.value = false
     newFolderName.value = ''
+  }
+
+  const startRenaming = (item) => {
+    renamingItem.value = item
+    renameValue.value = item.name
+  }
+
+  const handleSaveRename = async () => {
+    const newName = renameValue.value.trim()
+    if (!newName || newName === renamingItem.value.name) {
+      handleCancelRename()
+      return
+    }
+
+    try {
+      isRenaming.value = true
+      await renameFile(renamingItem.value, newName)
+      renamingItem.value = null
+      renameValue.value = ''
+      listServiceFilesRef.value?.reload()
+    } catch {
+      // toast already shown by composable
+    } finally {
+      isRenaming.value = false
+    }
+  }
+
+  const handleCancelRename = () => {
+    renamingItem.value = null
+    renameValue.value = ''
   }
 
   const handleRouteChange = () => {


### PR DESCRIPTION
## Feature

### Description

Implements file renaming in Edge Storage using a **copy-and-delete strategy** with automatic rollback on failure.

**Changes:**

- **Service** (`edge-storage-service.js`): Added `renameEdgeStorageBucketFile` method that copies the file to the new name, deletes the original, and rolls back if the delete fails.
- **Composable** (`useEdgeStorage.js`): Added `renameFile` function with toast notifications for success/failure.
- **Template** (`folder-list.vue`): Added inline `InputText` for renaming directly in the file list table with save/cancel buttons, Enter/Escape keyboard shortcuts, and loading state.
- **View** (`ListView.vue`): Added "Rename" action to the file context menu and wired up rename state management (`renamingItem`, `renameValue`, `isRenaming`).

### How to test

1. Navigate to **Edge Storage** and select a bucket with files
2. Right-click on a file (or use the actions menu) and select **Rename**
3. An inline text input should appear in the file name column
4. Type a new name and press **Enter** or click the **check** button
5. Verify the file is renamed successfully (toast notification appears)
6. Try pressing **Escape** or the **X** button to cancel — the original name should remain
7. Try renaming to the same name — it should cancel automatically
8. Verify that during the rename operation, the input and buttons show a loading/disabled state