### PR TITLE
[ENG-36675] fix: add optional chaining to prevent TypeError on undefined operatorInfo

### DIFF
--- a/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
+++ b/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
@@ -81,7 +81,7 @@ export default class Aql {
         }
 
         let parsedValue
-        if (suggestion && operatorInfo.type.toLowerCase() === 'int') {
+        if (suggestion && operatorInfo?.type.toLowerCase() === 'int') {
           parsedValue = Number(value)
         } else if (
           operator.toUpperCase() === 'IN' &&


### PR DESCRIPTION
## Bug fix

### What was the problem?

A `TypeError: Cannot read properties of undefined (reading 'type')` was thrown in the AQL (Azion Query Language) filter component when `operatorInfo` was `undefined`. This occurred in `azion-query-language.js` when attempting to access `operatorInfo.type` without first checking if `operatorInfo` exists.

### Expected behavior

The filter should handle cases where `operatorInfo` is undefined gracefully, without throwing a runtime TypeError.

### How was it solved

Added optional chaining (`?.`) to the `operatorInfo` access at line 84 of `azion-query-language.js`:

```diff
- if (suggestion && operatorInfo.type.toLowerCase() === 'int') {
+ if (suggestion && operatorInfo?.type.toLowerCase() === 'int') {
```

This ensures that if `operatorInfo` is `undefined`, the expression short-circuits to `undefined` instead of throwing a TypeError.

### How to test

1. Navigate to any page that uses the Advanced Filter with AQL (e.g., Edge Applications, Domains)
2. Interact with the filter input, entering various filter expressions
3. Try entering incomplete or malformed filter expressions
4. Verify that no `TypeError: Cannot read properties of undefined` errors appear in the console
5. Confirm the filter continues to work correctly for valid expressions