### PR TITLE
[ENG-36406] fix: resolve domain parsing by matching against Edge DNS zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ src/views/Playground/PlaygroundView.vue
 .vulcan
 specs.json
 .claude/
+.opencode/
 CLAUDE.md
 docs/ARCHITECTURE.md

--- a/src/services/v2/utils/adapter/domainAdapter.js
+++ b/src/services/v2/utils/adapter/domainAdapter.js
@@ -22,13 +22,60 @@ function parseWildcardDomain(urlOrHostname) {
   }
 }
 
-export function getPrimaryDomain(urlOrHostname) {
+/**
+ * Attempts to match a domain against known Edge DNS zones.
+ * Returns the longest matching zone (most specific).
+ *
+ * @param {string} cleanDomain - Domain without wildcard prefix
+ * @param {string[]} zones - Array of zone domain strings from Edge DNS
+ * @returns {{ domain: string, subdomain: string } | null}
+ */
+function matchDomainToZone(cleanDomain, zones) {
+  if (!zones || !zones.length || !cleanDomain) return null
+
+  const lowerDomain = cleanDomain.toLowerCase()
+
+  // Sort by length descending so we match the most specific zone first
+  const sortedZones = [...zones].sort((valA, valB) => valB.length - valA.length)
+
+  for (const zone of sortedZones) {
+    const lowerZone = zone.toLowerCase()
+
+    if (lowerDomain === lowerZone) {
+      return { domain: zone, subdomain: '' }
+    }
+
+    if (lowerDomain.endsWith(`.${lowerZone}`)) {
+      const subdomain = cleanDomain.slice(0, cleanDomain.length - zone.length - 1)
+      return { domain: zone, subdomain }
+    }
+  }
+
+  return null
+}
+
+export function getPrimaryDomain(urlOrHostname, zones = []) {
   if (!urlOrHostname || typeof urlOrHostname !== 'string') {
     return { domain: '', subdomain: '' }
   }
 
   const wildcardInfo = parseWildcardDomain(urlOrHostname)
 
+  // 1. Try zone-aware matching first
+  const zoneMatch = matchDomainToZone(wildcardInfo.cleanDomain, zones)
+
+  if (zoneMatch) {
+    if (wildcardInfo.hasWildcard) {
+      return {
+        ...zoneMatch,
+        subdomain: wildcardInfo.wildcardPrefix,
+        isWildcard: true
+      }
+    }
+    return zoneMatch
+  }
+
+  // 2. Fallback to psl.parse
   const parsed = psl.parse(wildcardInfo.cleanDomain)
 
   if (parsed && parsed.domain) {

--- a/src/services/v2/workload/workload-adapter.js
+++ b/src/services/v2/workload/workload-adapter.js
@@ -12,12 +12,12 @@ const convertPortsArrayToIntegers = (ports) => {
   return ports.map((port) => parseInt(port.value))
 }
 
-function extractAzionAppSubdomain(fullDomains) {
+function extractAzionAppSubdomain(fullDomains, zones = []) {
   const cleanDomains = []
   let azionAppSubdomains = ''
 
   fullDomains.forEach((full) => {
-    const { domain, subdomain } = getPrimaryDomain(full)
+    const { domain, subdomain } = getPrimaryDomain(full, zones)
 
     if (domain === 'azion.app') {
       azionAppSubdomains = subdomain
@@ -135,8 +135,8 @@ export const WorkloadAdapter = {
       }
     })
   },
-  transformLoadWorkload({ data: workload }, workloadDeployment) {
-    const { azionAppSubdomains, cleanDomains } = extractAzionAppSubdomain(workload.domains)
+  transformLoadWorkload({ data: workload }, workloadDeployment, zones = []) {
+    const { azionAppSubdomains, cleanDomains } = extractAzionAppSubdomain(workload.domains, zones)
     return {
       id: workload.id,
       name: workload.name,

--- a/src/services/v2/workload/workload-service.js
+++ b/src/services/v2/workload/workload-service.js
@@ -6,6 +6,7 @@ import { workloadDeploymentService } from './workload-deployments-service'
 import { digitalCertificatesService } from '../digital-certificates/digital-certificates-service'
 import { DigitalCertificatesAdapter } from '../digital-certificates/digital-certificates-adapter'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
+import { edgeDNSService } from '../edge-dns/edge-dns-service'
 
 export const DEFAULT_FIELDS = [
   'name',
@@ -29,6 +30,7 @@ export class WorkloadService extends BaseService {
     this.workloadDeployment = workloadDeploymentService
     this.digitalCertificate = digitalCertificatesService
     this.digitalCertificateAdapter = DigitalCertificatesAdapter
+    this.edgeDNS = edgeDNSService
 
     this._certificateId = null
     this._objLetEncrypt = null
@@ -56,9 +58,16 @@ export class WorkloadService extends BaseService {
       url: `${this.baseURL}/${id}`
     })
 
-    const workloadDeployment = await this.workloadDeployment.listWorkloadDeployment(id)
+    const [workloadDeployment, zonesResponse] = await Promise.all([
+      this.workloadDeployment.listWorkloadDeployment(id),
+      this.edgeDNS
+        .listEdgeDNSService({ fields: ['domain'], active: 'True' })
+        .catch(() => ({ body: [] }))
+    ])
 
-    return this.adapter?.transformLoadWorkload?.(data, workloadDeployment[0]) ?? data
+    const zones = (zonesResponse?.body || []).map((zone) => zone.domain?.content ?? zone.domain)
+
+    return this.adapter?.transformLoadWorkload?.(data, workloadDeployment[0], zones) ?? data
   }
 
   prefetchList = (pageSize = 10) => {

--- a/src/views/Workload/FormFields/blocks/domainsBlock.vue
+++ b/src/views/Workload/FormFields/blocks/domainsBlock.vue
@@ -75,8 +75,8 @@
     }
   }
 
-  const updateDomainType = (domainId, value) => {
-    const domain = domainsList.value.find((domainItem) => domainItem.id === domainId)
+  const updateDomainType = (index, value) => {
+    const domain = domainsList.value[index]
     if (domain) {
       domain.domain = value
     }
@@ -186,7 +186,7 @@
                   :class="{ 'p-invalid': domainsErrorMessage }"
                   :value="domain.subdomain"
                   @blur="handleLetEncrypt"
-                  @input="updateDomainSubdomain(index, $event.target.value)"
+                  @input="updateDomainSubdomain(index, $event)"
                   data-testid="domains-form__subdomain-field"
                 />
               </div>


### PR DESCRIPTION
## Bug fix

### What was the problem?

When typing a subdomain in the workload creation/edit screen, the console threw errors because the domain parsing relied exclusively on `psl.parse`, which cannot recognize custom domains registered as Edge DNS zones. This caused incorrect domain/subdomain splitting and runtime errors in the UI.

Additionally, the `domainsBlock.vue` component had issues with domain type updates using `id` instead of array `index`, and the subdomain input event was not being handled correctly.

### Expected behavior

The domain parsing should correctly identify the root domain and subdomain for both standard TLDs and custom Edge DNS zones, without throwing console errors.

### How was it solved

- **Zone-aware domain matching** (`domainAdapter.js`): Added a new `matchDomainToZone` function that matches a given domain against known Edge DNS zones (sorted by specificity). This is attempted first, with `psl.parse` as a fallback.
- **Zones fetching** (`workload-service.js`): The `loadWorkload` method now fetches Edge DNS zones in parallel with workload deployments, passing them through the adapter chain.
- **Adapter propagation** (`workload-adapter.js`): `transformLoadWorkload` and `extractAzionAppSubdomain` now accept and forward the `zones` parameter to `getPrimaryDomain`.
- **Component fixes** (`domainsBlock.vue`): Fixed `updateDomainType` to use array index instead of domain ID, and corrected the subdomain input event handler.

### How to test

1. Navigate to **Workload > Create** or **Workload > Edit**
2. Add a domain that uses a custom Edge DNS zone (e.g., `sub.mycustomzone.com`)
3. Type in the subdomain input field
4. Verify there are no console errors
5. Verify the domain/subdomain split is correct (the zone should be recognized as the root domain)
6. Also test with standard domains (e.g., `sub.example.com`) to confirm the `psl.parse` fallback still works