### PR TITLE
[ENG-36686] fix: add optional chaining to prevent TypeError on undefined .find() calls

### DIFF
--- a/src/components/base/advanced-filter-system/constants/query-fields.js
+++ b/src/components/base/advanced-filter-system/constants/query-fields.js
@@ -63,7 +63,7 @@ const formatFieldData = (fieldData) => ({
 
 const extractFieldFormat = (fields, dataset) => {
   const datasetField = fields.fieldsDataSet.fields.find(({ name }) => name === dataset)
-  return datasetField.type.ofType.fields.reduce((formattedFields, fieldData) => {
+  return datasetField?.type?.ofType?.fields?.reduce((formattedFields, fieldData) => {
     const hasAliasName = FILTERS_RULES().ALIAS_MAPPING[fieldData.name]
     const newField = {
       [fieldData.name]: formatFieldData(fieldData)

--- a/src/services/v2/data-stream/data-stream-adapter.js
+++ b/src/services/v2/data-stream/data-stream-adapter.js
@@ -255,7 +255,7 @@ export const DataStreamAdapter = {
   transformListDataStream(data) {
     return (
       data?.map((dataStream) => {
-        const dataSourceInput = dataStream.inputs.find((input) => input.type === 'raw_logs')
+        const dataSourceInput = dataStream.inputs?.find((input) => input.type === 'raw_logs')
         const dataSetType = dataStream.outputs[0].type
         const samplingTransform = dataStream.transform?.find((item) => item.type === 'sampling')
         const templateId = dataStream.transform?.find((item) => item.type === 'render_template')
@@ -266,8 +266,8 @@ export const DataStreamAdapter = {
           name: dataStream.name,
           templateName: dataStream.templateName,
           dataSource:
-            dataSourceInput.attributes.data_source ||
-            mapDataSourceName[dataSourceInput.attributes.data_source],
+            dataSourceInput?.attributes?.data_source ||
+            mapDataSourceName[dataSourceInput?.attributes?.data_source],
           endpointType: endpointTypeNameMap[dataSetType] || dataSetType,
           template: templateId?.attributes?.template ?? 'CUSTOM_TEMPLATE',
           domainOption: samplingTransform ? '1' : '0',
@@ -347,7 +347,7 @@ export const DataStreamAdapter = {
   transformLoadDataStream(data) {
     const [payload, workloads, templateData] = data
 
-    const dataSourceInput = payload.inputs.find((input) => input.type === 'raw_logs')
+    const dataSourceInput = payload.inputs?.find((input) => input.type === 'raw_logs')
     const samplingTransform = payload.transform?.find((item) => item.type === 'sampling')
     const templateId = payload.transform?.find((item) => item.type === 'render_template')
     const endpointOutput = payload.outputs[0]

--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -48,7 +48,7 @@ export const useAccountStore = defineStore({
       return hasPermissionToEdit || state.account.is_account_owner
     },
     hasPermissionToViewDataStream(state) {
-      return !!state.account.permissions.find(
+      return !!state.account.permissions?.find(
         (permission) => permission.name === 'View Data Stream'
       )
     },

--- a/src/views/RealTimeEvents/Drawer/activityHistory.vue
+++ b/src/views/RealTimeEvents/Drawer/activityHistory.vue
@@ -33,7 +33,7 @@
   }
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/dataStream.vue
+++ b/src/views/RealTimeEvents/Drawer/dataStream.vue
@@ -39,7 +39,7 @@
   }
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/edgeDNS.vue
+++ b/src/views/RealTimeEvents/Drawer/edgeDNS.vue
@@ -32,7 +32,7 @@
   }
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/edgeFunctions.vue
+++ b/src/views/RealTimeEvents/Drawer/edgeFunctions.vue
@@ -36,7 +36,7 @@
   }
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/edgeFunctionsConsole.vue
+++ b/src/views/RealTimeEvents/Drawer/edgeFunctionsConsole.vue
@@ -42,7 +42,7 @@
   )
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/httpRequests.vue
+++ b/src/views/RealTimeEvents/Drawer/httpRequests.vue
@@ -40,7 +40,7 @@
   const wafTotalProcessedTooltip = 'Total number of processed requests.'
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/imageProcessor.vue
+++ b/src/views/RealTimeEvents/Drawer/imageProcessor.vue
@@ -45,7 +45,7 @@
   }
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/RealTimeEvents/Drawer/tieredCache.vue
+++ b/src/views/RealTimeEvents/Drawer/tieredCache.vue
@@ -42,7 +42,7 @@
     'Time, in seconds, the cached object is considered valid (not expired). After the time expiration, when a new request occurs, L2 Caching queries the data on the origin (upstream).'
 
   const getValueByKey = (key) => {
-    const item = details.value.data.find((obj) => obj.key === key)
+    const item = details.value.data?.find((obj) => obj.key === key)
     return item ? item.value : '-'
   }
 

--- a/src/views/WafRules/Drawer/index.vue
+++ b/src/views/WafRules/Drawer/index.vue
@@ -320,11 +320,16 @@
     valueNetworkId.value = props.parentSelectedFilter.network?.id
     selectedFilter.value = props.parentSelectedFilter
     const { disabledIP, disabledCountries } = selectedFilter.value.network?.value || {}
-    listFields.value.find((item) => item.value === 'ip_address').disabled = disabledIP
-    listFields.value.find((item) => item.value === 'ip_address').networkListDisabled = disabledIP
-    listFields.value.find((item) => item.value === 'country').disabled = disabledCountries
-    listFields.value.find((item) => item.value === 'country').networkListDisabled =
-      disabledCountries
+    const ipField = listFields.value.find((item) => item.value === 'ip_address')
+    if (ipField) {
+      ipField.disabled = disabledIP
+      ipField.networkListDisabled = disabledIP
+    }
+    const countryField = listFields.value.find((item) => item.value === 'country')
+    if (countryField) {
+      countryField.disabled = disabledCountries
+      countryField.networkListDisabled = disabledCountries
+    }
 
     selectedFilterAdvanced.value = props.parentSelectedFilterAdvanced
     nextTick(() => {

--- a/src/views/WafRules/ListWafRulesTuning.vue
+++ b/src/views/WafRules/ListWafRulesTuning.vue
@@ -97,7 +97,7 @@
   })
 
   const timeName = computed(
-    () => timeOptions.value.find((item) => item.value === selectedFilter.value.hourRange).name
+    () => timeOptions.value.find((item) => item.value === selectedFilter.value.hourRange)?.name
   )
 
   const listFields = ref([


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) to prevent `TypeError: Cannot read properties of undefined (reading 'find')` across 13 files
- Fix unguarded `.find()` calls in 8 RealTimeEvents Drawers, WAF Rules Drawer, WAF Rules Tuning, Account Store, Data Stream Adapter, and Query Fields
- Addresses ~27 Sentry issues (CONSOLE-CV, CW, CX, CY, CZ, D0~DH)

## Root cause
The `getValueByKey` function in RealTimeEvents Drawers accesses `details.value.data.find()` without verifying `data` exists. When the API returns incomplete data or the watcher resets `details.value = {}`, `data` is `undefined` and `.find()` throws TypeError.

## Changes
- **RealTimeEvents Drawers (8 files)**: `details.value.data.find(...)` → `details.value.data?.find(...)`
- **WAF Rules Drawer**: Extract `.find()` result to variable with `if` guard before accessing properties
- **WAF Rules Tuning**: `.find(...).name` → `.find(...)?.name`
- **Account Store**: `permissions.find(...)` → `permissions?.find(...)`
- **Data Stream Adapter**: `inputs.find(...)` → `inputs?.find(...)` and `dataSourceInput.attributes` → `dataSourceInput?.attributes`
- **Query Fields**: `datasetField.type.ofType.fields.reduce(...)` → `datasetField?.type?.ofType?.fields?.reduce(...)`

## Test plan
- [ ] Verify RealTimeEvents Drawers open without errors when API returns incomplete data
- [ ] Verify WAF Rules Drawer handles missing IP field gracefully
- [ ] Verify Data Stream edit/create works with incomplete inputs
- [ ] Run existing test suite to confirm no regressions