### PR TITLE
[ENG-36687] fix: add null guards for clipboard, inputRefs and menuRef access

### DIFF
--- a/src/templates/list-table-block/folder-list.vue
+++ b/src/templates/list-table-block/folder-list.vue
@@ -317,7 +317,7 @@
       throw new Error('Please provide an id for each data item through the service adapter')
     }
     selectedId.value = selectedID
-    menuRef.value[selectedID].toggle(event)
+    menuRef.value[selectedID]?.toggle(event)
   }
 
   const editItemSelected = (item) => {

--- a/src/templates/list-table-block/index.vue
+++ b/src/templates/list-table-block/index.vue
@@ -638,7 +638,7 @@
       throw new Error('Please provide an id for each data item through the service adapter')
     }
     selectedId.value = selectedID
-    menuRef.value[selectedID].toggle(event)
+    menuRef.value[selectedID]?.toggle(event)
   }
 
   const editItemSelected = ({ data: item }) => {

--- a/src/templates/mfa-authenticate-block/index.vue
+++ b/src/templates/mfa-authenticate-block/index.vue
@@ -102,7 +102,7 @@
 
   const handlePaste = (event) => {
     event.preventDefault()
-    const pastedData = event.clipboardData.getData('text')
+    const pastedData = event.clipboardData?.getData('text') || ''
 
     for (let mfaDigitIndex = 0; mfaDigitIndex < pastedData.length; mfaDigitIndex++) {
       digitsMfa[mfaDigitIndex].value.value = pastedData[mfaDigitIndex]
@@ -132,7 +132,7 @@
     //check delete code
     if (event.key === 'Backspace' || event.keyCode === 8) {
       const nextInput = inputRefs.value[index - 1]
-      if (index) {
+      if (index && nextInput?.$el) {
         nextInput.$el.focus()
       }
       digitsMfa[index].value.value = ''
@@ -148,7 +148,7 @@
         //get the next input
         const nextInput = inputRefs.value[index + 1]
         digitsMfa[index].value.value = parseInt(event.key)
-        setTimeout(() => nextInput.$el.focus(), 100)
+        setTimeout(() => nextInput?.$el?.focus(), 100)
       }
 
       if (index === MFA_CODE_LENGTH - 1) {

--- a/src/templates/mfa-setup-block/index.vue
+++ b/src/templates/mfa-setup-block/index.vue
@@ -130,7 +130,7 @@
 
   const handlePaste = (event) => {
     event.preventDefault()
-    const pastedData = event.clipboardData.getData('text')
+    const pastedData = event.clipboardData?.getData('text') || ''
 
     for (let mfaDigitIndex = 0; mfaDigitIndex < pastedData.length; mfaDigitIndex++) {
       digitsMfa[mfaDigitIndex].value.value = pastedData[mfaDigitIndex]
@@ -149,7 +149,7 @@
     //check delete code
     if (event.key === 'Backspace' || event.keyCode === 8) {
       const nextInput = inputRefs.value[index - 1]
-      if (index) {
+      if (index && nextInput?.$el) {
         nextInput.$el.focus()
       }
       digitsMfa[index].value.value = ''
@@ -165,7 +165,7 @@
         //get the next input
         const nextInput = inputRefs.value[index + 1]
         digitsMfa[index].value.value = parseInt(event.key)
-        setTimeout(() => nextInput.$el.focus(), 100)
+        setTimeout(() => nextInput?.$el?.focus(), 100)
       }
 
       if (index === MFA_CODE_LENGTH - 1) {


### PR DESCRIPTION
## Summary
- Add null guards for `event.clipboardData`, `inputRefs.value[index]`, and `menuRef.value[selectedID]` to prevent TypeError
- Addresses 5 Sentry issues (CONSOLE-HF, K7, 7Y, KD, GW)

## Root cause
- **MFA blocks**: `event.clipboardData` can be `null` in some browsers when the paste event carries no data. Also, `inputRefs.value[index]` can be `undefined` if the index is out of range (e.g., backspace on the first digit).
- **List table blocks**: `menuRef.value[selectedID]` may not exist if the DOM hasn't rendered the menu yet.

## Changes
- **mfa-authenticate-block/index.vue**: `event.clipboardData?.getData('text') || ''`, `nextInput?.$el` guard before `.focus()`
- **mfa-setup-block/index.vue**: Same pattern as authenticate block
- **list-table-block/index.vue**: `menuRef.value[selectedID]?.toggle(event)`
- **list-table-block/folder-list.vue**: `menuRef.value[selectedID]?.toggle(event)`

## Test plan
- [ ] Verify MFA paste functionality works across browsers (Chrome, Firefox, Safari)
- [ ] Verify MFA input navigation with backspace on first digit doesn't throw
- [ ] Verify context menu toggle on list tables works when DOM is loading
- [ ] Run existing test suite to confirm no regressions