### PR TITLE
[ENG-36688] fix: add optional chaining for operatorInfo, element and operator type access

### DIFF
--- a/src/components/base/advanced-filter-system/constants/query-fields.js
+++ b/src/components/base/advanced-filter-system/constants/query-fields.js
@@ -83,7 +83,7 @@ const extractFieldFormat = (fields, dataset) => {
 const formatOperatorData = (operator, fieldName, field) => ({
   value: fieldName.operatorValue,
   group: ALIAS_MAPPING_OPERATOR[operator.name] || fieldName.name,
-  type: FILTERS_RULES().FILTER_LIKE_TYPE[operator.name] || operator.type.name || 'String',
+  type: FILTERS_RULES().FILTER_LIKE_TYPE[operator.name] || operator.type?.name || 'String',
   props: {
     placeholder: field?.placeholder,
     services: MAP_SERVICE_OPERATION[operator.name] || []

--- a/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
+++ b/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
@@ -63,10 +63,10 @@ export default class Aql {
           let beginValue = begin
           let endValue = end
 
-          if (operatorInfo.type === 'IntRange') {
+          if (operatorInfo?.type === 'IntRange') {
             beginValue = parseInt(begin, 10)
             endValue = parseInt(end, 10)
-          } else if (operatorInfo.type === 'FloatRange') {
+          } else if (operatorInfo?.type === 'FloatRange') {
             beginValue = parseFloat(begin)
             endValue = parseFloat(end)
           }
@@ -74,14 +74,14 @@ export default class Aql {
           return {
             field: field,
             value: { begin: beginValue, end: endValue },
-            operator: operatorInfo.value,
+            operator: operatorInfo?.value,
             valueField: this.convertFieldToCamelCase(field),
-            type: operatorInfo.type || 'Int'
+            type: operatorInfo?.type || 'Int'
           }
         }
 
         let parsedValue
-        if (suggestion && operatorInfo?.type.toLowerCase() === 'int') {
+        if (suggestion && operatorInfo?.type?.toLowerCase() === 'int') {
           parsedValue = Number(value)
         } else if (
           operator.toUpperCase() === 'IN' &&
@@ -95,9 +95,9 @@ export default class Aql {
         return {
           field: field,
           value: parsedValue,
-          operator: operatorInfo.value,
+          operator: operatorInfo?.value,
           valueField: this.convertFieldToCamelCase(field),
-          type: operatorInfo.type || 'Int'
+          type: operatorInfo?.type || 'Int'
         }
       })
       .filter((item) => item !== null)

--- a/src/services/v2/network-lists/network-lists-adapter.js
+++ b/src/services/v2/network-lists/network-lists-adapter.js
@@ -56,16 +56,16 @@ export const NetworkListsAdapter = {
   transformLoadNetworkListToDropdown(body) {
     const element = body?.results
 
-    const disabledIP = element.type === 'ip_cidr'
-    const disabledCountries = element.type === 'countries'
+    const disabledIP = element?.type === 'ip_cidr'
+    const disabledCountries = element?.type === 'countries'
 
     return {
       value: {
-        id: element.id,
+        id: element?.id,
         disabledIP,
         disabledCountries
       },
-      name: element.name
+      name: element?.name
     }
   },
   transformListNetworkListToDropdown(data) {


### PR DESCRIPTION
## Summary
- Add optional chaining to prevent `TypeError: Cannot read properties of undefined (reading 'type')` in 3 files
- Completes the fix started in PR #3322 (which only covered line 84 of `azion-query-language.js`)
- Addresses 2 Sentry issues (CONSOLE-7X, CONSOLE-KR)

## Root cause
- **azion-query-language.js**: `operatorInfo` returned by `operatorInfo()` can be `undefined` when no operator matches. PR #3322 fixed only line 84 — lines 66, 69, 79, and 100 were still vulnerable.
- **network-lists-adapter.js**: `body?.results` can return `undefined`, and `element.type` throws TypeError.
- **query-fields.js**: `operator.type` can be undefined when the operator has no type defined.

## Changes
- **azion-query-language.js**: `operatorInfo?.type`, `operatorInfo?.value`, `operatorInfo?.type?.toLowerCase()` on 5 remaining lines
- **network-lists-adapter.js**: `element?.type`, `element?.id`, `element?.name`
- **query-fields.js**: `operator.type?.name`

## Test plan
- [ ] Verify AQL filter works when operator is not found
- [ ] Verify Network Lists load correctly with incomplete API responses
- [ ] Verify Query Fields handle missing operator types gracefully
- [ ] Run existing test suite to confirm no regressions