### PR TITLE
[ENG-36689] fix: add optional chaining for null label and match access

### DIFF
--- a/src/templates/advanced-filter/component/display/chips-default-display.vue
+++ b/src/templates/advanced-filter/component/display/chips-default-display.vue
@@ -23,7 +23,7 @@
   const formattedValue = (filter) => {
     let newFilter = { ...filter }
     if (['Boolean', 'StringObject'].includes(filter?.type))
-      newFilter = { ...filter, value: filter?.value?.label.toLowerCase() }
+      newFilter = { ...filter, value: filter?.value?.label?.toLowerCase() }
 
     const isEmptyString = !newFilter?.value && newFilter?.type === 'String'
 

--- a/src/views/WafRules/FormFields/FormFieldsAllowed.vue
+++ b/src/views/WafRules/FormFields/FormFieldsAllowed.vue
@@ -55,11 +55,11 @@
   }
 
   const isField = (condition) => {
-    return condition?.match.includes('specific_')
+    return condition?.match?.includes('specific_') || false
   }
 
   const labelFieldCondition = (condition) => {
-    return condition.match.includes('_value') ? 'Value' : 'Name'
+    return condition?.match?.includes('_value') ? 'Value' : 'Name'
   }
 </script>
 


### PR DESCRIPTION
## Summary
- Add optional chaining to prevent `TypeError` on null `label` and `match` properties
- Addresses 2 Sentry issues (CONSOLE-K8, CONSOLE-8B)

## Root cause
- **chips-default-display.vue**: `filter.value` can be an object where `label` is `null`. The chain `filter?.value?.label.toLowerCase()` fails because optional chaining stops at `label` (which exists but is null) and `.toLowerCase()` is called on null.
- **FormFieldsAllowed.vue**: `condition.match` can be `null` when the condition has no match defined.

## Changes
- **chips-default-display.vue**: `filter?.value?.label?.toLowerCase()`
- **FormFieldsAllowed.vue**: `condition?.match?.includes('specific_') || false` and `condition?.match?.includes('_value')`

## Test plan
- [ ] Verify advanced filter chips display correctly when label is null
- [ ] Verify WAF Rules allowed fields handle missing match conditions
- [ ] Run existing test suite to confirm no regressions