### PR TITLE
[ENG-36690] fix: add Array.isArray guard before .map() in dropdown adapters

### DIFF
--- a/src/services/v2/edge-app/edge-app-adapter.js
+++ b/src/services/v2/edge-app/edge-app-adapter.js
@@ -43,6 +43,7 @@ export const EdgeAppAdapter = {
     return adaptServiceDataResponse(data, fields, transformMap)
   },
   transformListDropdownEdgeApp(data) {
+    if (!Array.isArray(data)) return []
     return data.map((edgeApplication) => ({
       id: edgeApplication.id,
       name: edgeApplication.name

--- a/src/services/v2/edge-firewall/edge-firewall-adapter.js
+++ b/src/services/v2/edge-firewall/edge-firewall-adapter.js
@@ -23,6 +23,7 @@ export const EdgeFirewallAdapter = {
     return adaptServiceDataResponse(data, fields, transformMap)
   },
   transformListEdgeFirewallDropdown(data) {
+    if (!Array.isArray(data)) return []
     return data.map((edgeFirewall) => ({
       id: edgeFirewall.id,
       name: edgeFirewall.name

--- a/src/services/v2/edge-firewall/edge-firewall-function-adapter.js
+++ b/src/services/v2/edge-firewall/edge-firewall-function-adapter.js
@@ -31,6 +31,7 @@ export const EdgeFirewallFunctionAdapter = {
   },
 
   transformListFunctionsDropdown(data) {
+    if (!Array.isArray(data)) return []
     return data.map((item) => ({
       name: item.name,
       id: item.id


### PR DESCRIPTION
## Summary
- Add `Array.isArray` guard before `.map()` calls in 3 dropdown adapters to prevent `TypeError: e.map is not a function`
- Addresses 1 Sentry issue (CONSOLE-6Y)

## Root cause
The adapters `transformListDropdownEdgeApp`, `transformListEdgeFirewallDropdown`, and `transformListFunctionsDropdown` call `data.map()` directly without verifying `data` is an array. When the API returns an unexpected format (error object, null, undefined), `.map()` doesn't exist and throws TypeError.

## Changes
- **edge-app-adapter.js**: `if (!Array.isArray(data)) return []` before `.map()`
- **edge-firewall-adapter.js**: Same guard
- **edge-firewall-function-adapter.js**: Same guard

## Test plan
- [ ] Verify Edge Application dropdown loads correctly
- [ ] Verify Edge Firewall dropdown loads correctly
- [ ] Verify Edge Firewall Function dropdown loads correctly
- [ ] Verify dropdowns return empty array when API returns unexpected data
- [ ] Run existing test suite to confirm no regressions