### PR TITLE
[ENG-36691] fix: complete optional chaining for modules and edgeFunction data access

### DIFF
--- a/src/services/v2/edge-app/edge-app-adapter.js
+++ b/src/services/v2/edge-app/edge-app-adapter.js
@@ -53,10 +53,10 @@ export const EdgeAppAdapter = {
     return {
       id: data?.id,
       name: data?.name,
-      edgeCacheEnabled: data?.modules?.cache.enabled,
-      edgeFunctionsEnabled: data?.modules?.functions.enabled,
-      applicationAcceleratorEnabled: data?.modules?.application_accelerator.enabled,
-      imageProcessorEnabled: data?.modules?.image_processor.enabled,
+      edgeCacheEnabled: data?.modules?.cache?.enabled,
+      edgeFunctionsEnabled: data?.modules?.functions?.enabled,
+      applicationAcceleratorEnabled: data?.modules?.application_accelerator?.enabled,
+      imageProcessorEnabled: data?.modules?.image_processor?.enabled,
       tieredCacheEnabled: data?.modules?.tiered_cache?.enabled,
 
       isActive: data?.active,

--- a/src/services/v2/edge-function/edge-function-adapter.js
+++ b/src/services/v2/edge-function/edge-function-adapter.js
@@ -83,11 +83,11 @@ export const EdgeFunctionsAdapter = {
     return {
       id: edgeApplicationFunction.id,
       name: edgeApplicationFunction.name,
-      functionInstanced: edgeFunction.data.name,
+      functionInstanced: edgeFunction?.data?.name,
       lastEditor: edgeApplicationFunction.lastEditor,
       lastModified: formatDateToDayMonthYearHour(edgeApplicationFunction.lastModified),
       lastModify: convertToRelativeTime(edgeApplicationFunction.lastModified),
-      version: edgeFunction.data.version
+      version: edgeFunction?.data?.version
     }
   },
 


### PR DESCRIPTION
## Summary
- Complete optional chaining in `edge-app-adapter.js` and `edge-function-adapter.js` to prevent TypeError on undefined properties
- Addresses 1 Sentry issue (CONSOLE-90)

## Root cause
- **edge-app-adapter.js**: `data?.modules?.cache.enabled` uses optional chaining up to `modules` but accesses `.cache.enabled` without guard — if `cache` is undefined, throws TypeError. Same for `functions`, `application_accelerator`, and `image_processor`.
- **edge-function-adapter.js**: `edgeFunction.data.name` assumes both `edgeFunction` and `data` exist, but the object can be undefined when the edge function is not found.

## Changes
- **edge-app-adapter.js**: `data?.modules?.cache?.enabled`, `functions?.enabled`, `application_accelerator?.enabled`, `image_processor?.enabled`
- **edge-function-adapter.js**: `edgeFunction?.data?.name`, `edgeFunction?.data?.version`

## Test plan
- [ ] Verify Edge Application edit view loads correctly with incomplete module data
- [ ] Verify Edge Function instances handle missing function data gracefully
- [ ] Run existing test suite to confirm no regressions