### PR TITLE
fix: normalize non-Error exceptions in Sentry and reduce rage click false positives

### DIFF
--- a/src/plugins/sentry/index.js
+++ b/src/plugins/sentry/index.js
@@ -14,6 +14,23 @@ export default {
       app,
       sendDefaultPii: true,
       enableLogs: true,
+      beforeSend(event, hint) {
+        const exception = hint?.originalException
+
+        if (typeof exception === 'string') {
+          event.exception = {
+            values: [
+              {
+                type: 'NonErrorException',
+                value: exception || '<empty string>'
+              }
+            ]
+          }
+          event.tags = { ...event.tags, nonErrorException: true }
+        }
+
+        return event
+      },
       integrations: [
         ...(router ? [Sentry.browserTracingIntegration({ router })] : []),
 
@@ -28,7 +45,18 @@ export default {
             'input[name*="hmacSecretKey"]',
             'div[data-sentry-mask] input'
           ],
-          unmask: ['[data-sentry-unmask]']
+          unmask: ['[data-sentry-unmask]'],
+          slowClickIgnoreSelectors: [
+            '.p-button',
+            '.p-row-toggler',
+            '.p-menuitem-link',
+            '.p-tabview-nav-link',
+            '.p-paginator-page',
+            '.p-checkbox',
+            '.p-radiobutton',
+            'a[download]',
+            'a[target="_blank"]'
+          ]
         })
       ]
     })


### PR DESCRIPTION
## Summary
- Add `beforeSend` hook to normalize string exceptions as `NonErrorException` with preserved message
- Add `slowClickIgnoreSelectors` to reduce rage click false positives on PrimeVue interactive elements
- Addresses 5 Sentry issues (CONSOLE-C, CONSOLE-MA, CONSOLE-M2, CONSOLE-D, CONSOLE-7F)

## Root cause
- **CONSOLE-C, M2, D, 7F**: `AxiosHttpClientAdapter.parseHttpResponse()` throws strings via `throw new Error().message` instead of Error objects. Sentry can't classify these and shows `<unknown>` or `captureException`. The `beforeSend` normalizes them so Sentry displays the actual error message.
- **CONSOLE-MA**: Sentry Replay detects rage clicks (3+ clicks in 7s) on interactive elements. False positives occur on buttons and menus that trigger async operations.

## Changes
- **sentry/index.js**: Added `beforeSend` that detects `typeof exception === 'string'` and wraps as `NonErrorException` with tag `nonErrorException: true` for dashboard filtering
- **sentry/index.js**: Added `slowClickIgnoreSelectors` for `.p-button`, `.p-menuitem-link`, `.p-tabview-nav-link`, `.p-paginator-page`, `.p-checkbox`, `.p-radiobutton`, `.p-row-toggler`, `a[download]`, `a[target="_blank"]`

## Test plan
- [ ] Verify Sentry captures errors normally (no events dropped)
- [ ] Verify string exceptions now appear with readable titles in Sentry instead of `<unknown>`
- [ ] Verify rage clicks on PrimeVue buttons/menus no longer trigger Sentry issues
- [ ] Run existing test suite to confirm no regressions