### PR TITLE
[ENG-36645] feat: update name sent during let encrypt certificate creation

### DIFF
--- a/src/services/v2/digital-certificates/digital-certificates-adapter.js
+++ b/src/services/v2/digital-certificates/digital-certificates-adapter.js
@@ -47,7 +47,7 @@ export const DigitalCertificatesAdapter = {
 
   transformCreateDigitalCertificateLetEncrypt(payload, sourceCertificate) {
     const payloadRequest = {
-      name: `Let's Encrypt - ${payload.name} - ${getCurrentDateTimeIntl()}`,
+      name: `Lets Encrypt - ${payload.name} - ${getCurrentDateTimeIntl()}`,
       certificate: null,
       private_key: null,
       type: 'edge_certificate',


### PR DESCRIPTION
## Feature
[ENG-36645] feat: update name sent during let encrypt certificate creation
### Description
Alterando o nome do certificado Let's Encrypt para Lets Encrypt porque a API não está aceitando caracteres " ' " 
### How to test

### UI Changes (if applicable)


[ENG-36645]: https://aziontech.atlassian.net/browse/ENG-36645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ