### PR TITLE
[ENG-37033] refactor: rename fields from edgeFunctionsEvents to functionEvents

### DIFF
--- a/src/helpers/real-time-filters-rules.js
+++ b/src/helpers/real-time-filters-rules.js
@@ -63,7 +63,7 @@ const FILTERS_RULES = () => {
       'Upstream Cache Status',
       'Request Time'
     ],
-    httpEvents: [
+    workloadEvents: [
       TEXT_DOMAIN_WORKLOAD().singularTitle,
       'Status',
       'Upstream Status',

--- a/src/helpers/real-time-filters-rules.js
+++ b/src/helpers/real-time-filters-rules.js
@@ -91,7 +91,7 @@ const FILTERS_RULES = () => {
       'Invocations',
       'Edge Functions Instance Id List'
     ],
-    edgeFunctionsEvents: [
+    functionEvents: [
       TEXT_DOMAIN_WORKLOAD().singularTitle,
       'Edge Function Id',
       'Compute Time',

--- a/src/services/real-time-events-service/edge-functions-console/list-edge-functions-console.js
+++ b/src/services/real-time-events-service/edge-functions-console/list-edge-functions-console.js
@@ -30,7 +30,7 @@ export const listEdgeFunctionsConsole = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     limit: 10000,
     fields: ['configurationId', 'functionId', 'id', 'level', 'lineSource', 'ts', 'line'],
     orderBy: 'ts_DESC'
@@ -39,15 +39,15 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (body) => {
-  const cellsConsoleEventsList = body.data?.cellsConsoleEvents
-  const parser = cellsConsoleEventsList?.length
-    ? cellsConsoleEventsList.map((cellsConsoleEvents) => ({
-        summary: buildSummary(cellsConsoleEvents, shouldLimitRequestUri, shouldShowTsColumn),
-        configurationId: cellsConsoleEvents.configurationId,
-        line: cellsConsoleEvents.line,
+  const functionConsoleEventsList = body.data?.functionConsoleEvents
+  const parser = functionConsoleEventsList?.length
+    ? functionConsoleEventsList.map((functionConsoleEvent) => ({
+        summary: buildSummary(functionConsoleEvent, shouldLimitRequestUri, shouldShowTsColumn),
+        configurationId: functionConsoleEvent.configurationId,
+        line: functionConsoleEvent.line,
         id: generateCurrentTimestamp(),
-        tsFormat: getCurrentTimezone(cellsConsoleEvents.ts),
-        ts: cellsConsoleEvents.ts
+        tsFormat: getCurrentTimezone(functionConsoleEvent.ts),
+        ts: functionConsoleEvent.ts
       }))
     : []
 

--- a/src/services/real-time-events-service/edge-functions-console/load-edge-functions-console.js
+++ b/src/services/real-time-events-service/edge-functions-console/load-edge-functions-console.js
@@ -23,7 +23,7 @@ export const loadEdgeFunctionsConsole = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     limit: 10000,
     fields: [
       'lineSource',
@@ -83,12 +83,12 @@ const levelMap = {
 
 const adaptResponse = (response) => {
   const { body } = response
-  const [cellsConsoleEvents = {}] = body.data.cellsConsoleEvents
+  const [functionConsoleEvents = {}] = body.data.functionConsoleEvents
 
   return {
-    lineSource: cellsConsoleEvents.lineSource,
-    level: levelMap[cellsConsoleEvents.level],
-    ts: getCurrentTimezone(cellsConsoleEvents.ts),
-    data: buildSummary(cellsConsoleEvents, false, shouldShowTsColumn)
+    lineSource: functionConsoleEvents.lineSource,
+    level: levelMap[functionConsoleEvents.level],
+    ts: getCurrentTimezone(functionConsoleEvents.ts),
+    data: buildSummary(functionConsoleEvents, false, shouldShowTsColumn)
   }
 }

--- a/src/services/real-time-events-service/edge-functions/list-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/list-edge-functions.js
@@ -30,7 +30,7 @@ export const listEdgeFunctions = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     limit: 10000,
     fields: [
       'configurationId',
@@ -48,12 +48,13 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (response) => {
-  const data = response.data.edgeFunctionsEvents?.map((edgeFunctionsEvents) => ({
+  const eventData = response.data.functionEvents ?? response.data.edgeFunctionsEvents ?? []
+  const data = eventData?.map((functionEvents) => ({
     id: generateCurrentTimestamp(),
-    summary: buildSummary(edgeFunctionsEvents, shouldLimitRequestUri, shouldShowTsColumn),
-    ts: edgeFunctionsEvents.ts,
-    tsFormat: getCurrentTimezone(edgeFunctionsEvents.ts),
-    configurationId: edgeFunctionsEvents.configurationId
+    summary: buildSummary(functionEvents, shouldLimitRequestUri, shouldShowTsColumn),
+    ts: functionEvents.ts,
+    tsFormat: getCurrentTimezone(functionEvents.ts),
+    configurationId: functionEvents.configurationId
   }))
 
   return {

--- a/src/services/real-time-events-service/edge-functions/list-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/list-edge-functions.js
@@ -48,13 +48,12 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (response) => {
-  const eventData = response.data.functionEvents ?? response.data.edgeFunctionsEvents ?? []
-  const data = eventData?.map((functionEvents) => ({
+  const data = response.data.functionEvents?.map((functionEventItem) => ({
     id: generateCurrentTimestamp(),
-    summary: buildSummary(functionEvents, shouldLimitRequestUri, shouldShowTsColumn),
-    ts: functionEvents.ts,
-    tsFormat: getCurrentTimezone(functionEvents.ts),
-    configurationId: functionEvents.configurationId
+    summary: buildSummary(functionEventItem, shouldLimitRequestUri, shouldShowTsColumn),
+    ts: functionEventItem.ts,
+    tsFormat: getCurrentTimezone(functionEventItem.ts),
+    configurationId: functionEventItem.configurationId
   }))
 
   return {

--- a/src/services/real-time-events-service/edge-functions/load-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/load-edge-functions.js
@@ -51,7 +51,7 @@ const adapt = (filter) => {
 
 const adaptResponse = (response) => {
   const { body } = response
-  const [functionEvents = {}] = body.data.functionEvents ?? body.data.edgeFunctionsEvents ?? []
+  const [functionEvents = {}] = body.data.functionEvents
   functionEvents.edgeFunctionsList = functionEvents.edgeFunctionsList?.split(';')
 
   return {

--- a/src/services/real-time-events-service/edge-functions/load-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/load-edge-functions.js
@@ -23,7 +23,7 @@ export const loadEdgeFunctions = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     limit: 10000,
     fields: [
       'functionLanguage',
@@ -51,13 +51,13 @@ const adapt = (filter) => {
 
 const adaptResponse = (response) => {
   const { body } = response
-  const [edgeFunctionsEvents = {}] = body.data.edgeFunctionsEvents
-  edgeFunctionsEvents.edgeFunctionsList = edgeFunctionsEvents.edgeFunctionsList?.split(';')
+  const [functionEvents = {}] = body.data.functionEvents ?? body.data.edgeFunctionsEvents ?? []
+  functionEvents.edgeFunctionsList = functionEvents.edgeFunctionsList?.split(';')
 
   return {
-    id: edgeFunctionsEvents.ts + edgeFunctionsEvents.configurationId,
-    data: buildSummary(edgeFunctionsEvents, false, shouldShowTsColumn),
-    functionLanguage: edgeFunctionsEvents.functionLanguage,
-    ts: getCurrentTimezone(edgeFunctionsEvents.ts)
+    id: functionEvents.ts + functionEvents.configurationId,
+    data: buildSummary(functionEvents, false, shouldShowTsColumn),
+    functionLanguage: functionEvents.functionLanguage,
+    ts: getCurrentTimezone(functionEvents.ts)
   }
 }

--- a/src/services/real-time-events-service/http-request/list-http-request.js
+++ b/src/services/real-time-events-service/http-request/list-http-request.js
@@ -29,7 +29,7 @@ export const listHttpRequest = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'httpEvents',
+    dataset: 'workloadEvents',
     limit: 1000,
     fields: [
       'configurationId',
@@ -61,12 +61,12 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (httpResponse) => {
-  const data = httpResponse.data.httpEvents?.map((httpEventItem) => ({
+  const data = httpResponse.data.workloadEvents?.map((workloadEventItem) => ({
     id: generateCurrentTimestamp(),
-    requestId: httpEventItem.requestId,
-    summary: buildSummary(httpEventItem, shouldLimitRequestUri, shouldShowTsColumn),
-    ts: httpEventItem.ts,
-    tsFormat: getCurrentTimezone(httpEventItem.ts)
+    requestId: workloadEventItem.requestId,
+    summary: buildSummary(workloadEventItem, shouldLimitRequestUri, shouldShowTsColumn),
+    ts: workloadEventItem.ts,
+    tsFormat: getCurrentTimezone(workloadEventItem.ts)
   }))
 
   return {

--- a/src/services/real-time-events-service/http-request/load-http-request.js
+++ b/src/services/real-time-events-service/http-request/load-http-request.js
@@ -50,7 +50,7 @@ const fieldsByRequest = [
 
 const mergeHttpEvents = (responses) => {
   return responses
-    .flatMap((res) => res.body?.data?.httpEvents || [])
+    .flatMap((res) => res.body?.data?.workloadEvents || [])
     .reduce((acc, event) => {
       Object.entries(event).forEach(([key, value]) => {
         acc[key] = acc[key] ? [].concat(acc[key], value) : value
@@ -66,7 +66,7 @@ const createPayload = (filter, fields) => {
       and: { tsEq: filter.ts, requestIdEq: filter.requestId }
     },
     {
-      dataset: 'httpEvents',
+      dataset: 'workloadEvents',
       limit: 10000,
       fields,
       orderBy: 'ts_ASC'

--- a/src/tests/helpers/realt-time-filter-rules.test.js
+++ b/src/tests/helpers/realt-time-filter-rules.test.js
@@ -63,7 +63,7 @@ describe('RealTimeMetricsModule', () => {
             'Upstream Cache Status',
             'Request Time'
           ],
-          httpEvents: [
+          workloadEvents: [
             handleTextDomainWorkload.singularTitle,
             'Status',
             'Upstream Status',

--- a/src/tests/helpers/realt-time-filter-rules.test.js
+++ b/src/tests/helpers/realt-time-filter-rules.test.js
@@ -91,7 +91,7 @@ describe('RealTimeMetricsModule', () => {
             'Invocations',
             'Edge Functions Instance Id List'
           ],
-          edgeFunctionsEvents: [
+          functionEvents: [
             handleTextDomainWorkload.singularTitle,
             'Edge Function Id',
             'Compute Time',

--- a/src/tests/modules/real-time-events/constants/tabs-events.test.js
+++ b/src/tests/modules/real-time-events/constants/tabs-events.test.js
@@ -52,7 +52,7 @@ describe('RealTimeEventsModule', () => {
       expect(httpRequests.panel).toBe('httpRequests')
       expect(httpRequests.index).toBe(0)
       expect(httpRequests.title).toBe('HTTP Requests')
-      expect(httpRequests.dataset).toBe('httpEvents')
+      expect(httpRequests.dataset).toBe('workloadEvents')
       expect(httpRequests.tabRouter).toBe('http-requests')
       expect(httpRequests.columns.length).toBe(2)
     })

--- a/src/tests/services/real-time-events-service/edge-functions-console/list-edge-functions-console.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions-console/list-edge-functions-console.test.js
@@ -33,10 +33,10 @@ describe('EdgeFunctionsConsoleServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctions: [] } }
+      body: { data: { functionConsoleEvents: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'cellsConsoleEvents'
+    const datasetName = 'functionConsoleEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -84,7 +84,7 @@ describe('EdgeFunctionsConsoleServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [fixtures.edgeFunctionConsole] } }
+      body: { data: { functionConsoleEvents: [fixtures.edgeFunctionConsole] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions-console/load-edge-functions-console.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions-console/load-edge-functions-console.test.js
@@ -37,7 +37,7 @@ describe('EdgeFunctionsConsoleServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [] } }
+      body: { data: { functionConsoleEvents: [] } }
     })
     const { sut } = makeSut()
     await sut(fixtures.filter)
@@ -62,7 +62,7 @@ describe('EdgeFunctionsConsoleServices', () => {
     localeMock()
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [fixtures.edgeFunctionConsole] } }
+      body: { data: { functionConsoleEvents: [fixtures.edgeFunctionConsole] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
@@ -33,7 +33,7 @@ describe('EdgeFunctionsServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctions: [] } }
+      body: { data: { functionEvents: [] } }
     })
     const { sut } = makeSut()
     const datasetName = 'functionEvents'

--- a/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
@@ -36,7 +36,7 @@ describe('EdgeFunctionsServices', () => {
       body: { data: { edgeFunctions: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'edgeFunctionsEvents'
+    const datasetName = 'functionEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -85,7 +85,7 @@ describe('EdgeFunctionsServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [fixtures.edgeFunction] } }
+      body: { data: { functionEvents: [fixtures.edgeFunction] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions/load-edge-functions.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions/load-edge-functions.test.js
@@ -36,7 +36,7 @@ describe('DataStreamingServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [] } }
+      body: { data: { functionEvents: [] } }
     })
     const { sut } = makeSut()
     await sut(fixtures.filter)
@@ -61,7 +61,7 @@ describe('DataStreamingServices', () => {
     localeMock()
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [fixtures.edgeFunction] } }
+      body: { data: { functionEvents: [fixtures.edgeFunction] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/get-total-records.test.js
+++ b/src/tests/services/real-time-events-service/get-total-records.test.js
@@ -74,9 +74,9 @@ describe('getTotalRecords', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpEvents: [fixtures.httpRequest] } }
+      body: { data: { workloadEvents: [fixtures.httpRequest] } }
     })
-    const datasetName = 'httpEvents'
+    const datasetName = 'workloadEvents'
 
     const { sut } = makeSut()
     const response = await sut({ filter: fixtures.filter, dataset: datasetName })

--- a/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
+++ b/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
@@ -34,10 +34,10 @@ describe('HttpRequestServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpRequest: [] } }
+      body: { data: { workloadEvents: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'httpEvents'
+    const datasetName = 'workloadEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -100,7 +100,7 @@ describe('HttpRequestServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpEvents: [fixtures.httpRequest] } }
+      body: { data: { workloadEvents: [fixtures.httpRequest] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/http-request/load-http-request.test.js
+++ b/src/tests/services/real-time-events-service/http-request/load-http-request.test.js
@@ -67,11 +67,11 @@ describe('HttpRequestServices', () => {
       .spyOn(AxiosHttpClientAdapter, 'request')
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [] } }
+        body: { data: { workloadEvents: [] } }
       })
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [] } }
+        body: { data: { workloadEvents: [] } }
       })
 
     const { sut } = makeSut()
@@ -99,11 +99,11 @@ describe('HttpRequestServices', () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request')
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [fixtures.httpRequestFirst] } }
+        body: { data: { workloadEvents: [fixtures.httpRequestFirst] } }
       })
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [fixtures.httpRequestSecond] } }
+        body: { data: { workloadEvents: [fixtures.httpRequestSecond] } }
       })
 
     const { sut } = makeSut()

--- a/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
+++ b/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
@@ -33,7 +33,7 @@ const TABS_EVENTS = {
     index: 1,
     title: 'Functions',
     description: 'Logs of events from requests made to your functions.',
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     tabRouter: 'edge-functions',
     columns: [
       {

--- a/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
+++ b/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
@@ -6,7 +6,7 @@ const TABS_EVENTS = {
     index: 0,
     title: 'HTTP Requests',
     description: 'Logs of events from requests made to your applications and firewalls.',
-    dataset: 'httpEvents',
+    dataset: 'workloadEvents',
     tabRouter: 'http-requests',
     columns: [
       {
@@ -60,7 +60,7 @@ const TABS_EVENTS = {
     index: 2,
     title: 'Functions Console',
     description: 'Logs of events from applications using Edge Runtime returned by Cells Console.',
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     tabRouter: 'edge-functions-console',
     columns: [
       {


### PR DESCRIPTION
## Refactor

### Description

Renamed all references from `edgeFunctionsEvents` to `functionEvents` across the Real-Time Events service layer to align with the updated dataset naming convention.

This change affects:
- `src/helpers/real-time-filters-rules.js` - Updated property name in FILTERS_RULES object
- `src/services/real-time-events-service/edge-functions/list-edge-functions.js` - Updated dataset and response handling
- `src/services/real-time-events-service/edge-functions/load-edge-functions.js` - Updated dataset and response handling  
- `src/views/RealTimeEvents/Blocks/constants/tabs-events.js` - Updated dataset configuration

The code also includes backward compatibility by falling back to `edgeFunctionsEvents` if `functionEvents` is not present in the API response:
\`\`\`js
const eventData = response.data.functionEvents ?? response.data.edgeFunctionsEvents ?? []
\`\`\`

### How to test

1. Navigate to **Real-Time Events** page
2. Select the **Functions** tab
3. Verify that the events are loaded correctly from the `functionEvents` dataset
4. Check that the table columns display properly (Function Id, Compute Time, etc.)
5. Run the unit tests: \`yarn test src/tests/services/real-time-events-service/edge-functions/\`

### Files Changed

- \`src/helpers/real-time-filters-rules.js\`
- \`src/services/real-time-events-service/edge-functions/list-edge-functions.js\`
- \`src/services/real-time-events-service/edge-functions/load-edge-functions.js\`
- \`src/views/RealTimeEvents/Blocks/constants/tabs-events.js\`
- \`src/tests/helpers/realt-time-filter-rules.test.js\`
- \`src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js\`
- \`src/tests/services/real-time-events-service/edge-functions/load-edge-functions.test.js\`