### PR TITLE
chore: remove extra left padding classes in switch uses

### DIFF
--- a/src/views/DataStream/FormFields/blocks/TransformSection.vue
+++ b/src/views/DataStream/FormFields/blocks/TransformSection.vue
@@ -61,7 +61,7 @@
 
         <div
           v-if="hasSampling"
-          class="flex flex-col sm:max-w-xs w-full gap-2 pl-14"
+          class="flex flex-col sm:max-w-xs w-full gap-2"
         >
           <FieldNumber
             :disabled="hasNoPermissionToEditDataStream"

--- a/src/views/EdgeApplicationsCacheSettings/FormFields/blocks/EdgeCache.vue
+++ b/src/views/EdgeApplicationsCacheSettings/FormFields/blocks/EdgeCache.vue
@@ -107,7 +107,7 @@
           />
 
           <div
-            class="flex flex-col w-full sm:max-w-xs gap-1 pl-14"
+            class="flex flex-col w-full sm:max-w-xs gap-1"
             v-if="tieredCache"
           >
             <FieldDropdown

--- a/src/views/Workload/FormFields/blocks/protocolSettingsBlock.vue
+++ b/src/views/Workload/FormFields/blocks/protocolSettingsBlock.vue
@@ -198,7 +198,7 @@
         />
       </div>
       <div
-        class="flex gap-6 flex-col md:pl-12"
+        class="flex gap-6 flex-col"
         v-if="protocols?.http?.useHttps"
       >
         <div class="flex flex-col w-full sm:max-w-xs gap-2">
@@ -282,7 +282,7 @@
         </div>
       </div>
       <div
-        class="flex gap-6 max-sm:flex-col md:pl-12"
+        class="flex gap-6 max-sm:flex-col"
         v-if="showTlsAndCipherDropdown"
       >
         <div class="flex flex-col w-full sm:max-w-xs gap-2">
@@ -329,7 +329,7 @@
         />
       </div>
       <div
-        class="flex gap-6 max-sm:flex-col md:pl-12"
+        class="flex gap-6 max-sm:flex-col"
         v-if="protocols?.http?.useHttp3"
       >
         <div class="flex flex-col w-full sm:max-w-xs gap-2">


### PR DESCRIPTION
https://aziontech.atlassian.net/browse/ENG-37179

## Context

A pattern introduced during the v4 war-room added left padding to fields displayed after a `switch`.

This approach created visual noise, reduced readability in complex forms (especially with nested switches), and broke alignment consistency across the Console. The pattern was also flagged for removal.

<img width="1668" height="882" alt="image" src="https://github.com/user-attachments/assets/85d199b0-14d4-491c-bb85-e4de80e9c51c" />

---

## Changes

- Removed left padding from conditional fields triggered by `switch`
- Standardized field alignment across forms

---

## Affected Screens

- Create / Edit Cache Settings  
- Create / Edit Workload  
- Create / Edit Data Stream  

---

## How to Test

1. Open any affected screen  
2. Enable switches that reveal additional fields  
3. Validate:
   - No left indentation is applied  
   - Fields remain aligned  
   - Layout is clean even with multiple/nested switches  