### PR TITLE
[ENG-34762] fix: Rename API field workload_hostname_allow_access to workload_domain_allow_access

### DIFF
--- a/src/services/v2/workload/workload-adapter.js
+++ b/src/services/v2/workload/workload-adapter.js
@@ -101,7 +101,7 @@ export const WorkloadAdapter = {
         }
       },
       domains,
-      workload_hostname_allow_access: payload.workloadHostnameAllowAccess
+      workload_domain_allow_access: payload.workloadHostnameAllowAccess
     }
     if (payloadResquest.tls === null) {
       delete payloadResquest.tls

--- a/src/services/workloads-services/edit-workloads-service.js
+++ b/src/services/workloads-services/edit-workloads-service.js
@@ -56,7 +56,7 @@ const adapt = (payload) => {
         certificate: payload.mtlsTrustedCertificate
       }
     },
-    workload_hostname_allow_access: payload.workloadHostnameAllowAccess,
+    workload_domain_allow_access: payload.workloadHostnameAllowAccess,
     domains: payload.domains,
     network_map: payload.environment
   }

--- a/src/services/workloads-services/load-workloads-service.js
+++ b/src/services/workloads-services/load-workloads-service.js
@@ -67,7 +67,7 @@ const adapt = (httpResponse) => {
         domain: match ? match[2] : domain
       }
     }),
-    workloadHostnameAllowAccess: body?.workload_hostname_allow_access,
+    workloadHostnameAllowAccess: body?.workload_domain_allow_access,
     customHostname: body?.domains[0] ? stripAzionDomain(body?.domains[0]) : '',
     edgeCertificate: body?.tls.certificate ?? 0,
     active: body.active,

--- a/src/views/Workload/Config/validation.js
+++ b/src/views/Workload/Config/validation.js
@@ -110,7 +110,7 @@ export const validationSchema = yup.object({
       then: (schema) =>
         schema.test(
           'has-filled-domain',
-          'When "Workload Allow Access" switch is off at least one domain is required.',
+          'When "Workload Domain Allow Access" switch is off at least one domain is required.',
           (value) => value?.some((domain) => domain.subdomain || domain.domain)
         )
     })

--- a/src/views/Workload/FormFields/blocks/domainsBlock.vue
+++ b/src/views/Workload/FormFields/blocks/domainsBlock.vue
@@ -219,12 +219,16 @@
               title="Remove domain"
             />
           </div>
-          <small
-            v-if="domainsErrorMessage"
-            class="p-error text-xs font-normal leading-tight"
-          >
-            {{ domainsErrorMessage }}
-          </small>
+          <div class="max-w-lg">
+            <div class="!w-1/2">
+              <small
+                v-if="domainsErrorMessage"
+                class="p-error text-xs font-normal leading-tight"
+              >
+                {{ domainsErrorMessage }}
+              </small>
+            </div>
+          </div>
           <div class="flex max-w-lg gap-2 w-full max-sm:hidden">
             <div class="flex w-1/2">
               <small class="text-xs text-color-secondary font-normal leading-5">


### PR DESCRIPTION
## Feature
[ENG-34762] fix: Rename API field workload_hostname_allow_access to workload_domain_allow_access
### Description

### How to test

### UI Changes (if applicable)


[ENG-34762]: https://aziontech.atlassian.net/browse/ENG-34762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ