### PR TITLE
fix: adjust column widths on last activities home and surface tokens on home blocks

### DIFF
--- a/src/components/list-table/ListTableSimple.vue
+++ b/src/components/list-table/ListTableSimple.vue
@@ -125,7 +125,7 @@
       <template #footer>
         <div
           v-if="viewAllLink"
-          class="flex justify-center items-center py-3 cursor-pointer bg-[var(--surface-section)] border-[var(--surface-border)]"
+          class="flex justify-center items-center py-3 cursor-pointer bg-[var(--surface-ground)] border-[var(--surface-border)]"
           @click="navigateToViewAll"
           data-testid="list-table-simple-view-all"
           @mouseover="isHoverFooter = true"

--- a/src/templates/home-cards-block/last-activities-block.vue
+++ b/src/templates/home-cards-block/last-activities-block.vue
@@ -16,12 +16,15 @@
   const columns = [
     {
       field: 'date',
-      header: 'Date'
+      header: 'Date',
+      style: 'width: 13rem; max-width: 13rem',
+      truncate: true
     },
     {
       field: 'operation',
       header: 'Operation',
       type: 'component',
+      style: 'width: 8rem; max-width: 8rem',
       component: (value) => {
         if (!value) return null
         return h(OperationTag, { operation: value })
@@ -29,16 +32,22 @@
     },
     {
       field: 'resourceType',
-      header: 'Type'
+      header: 'Type',
+      style: 'width: 12rem; max-width: 10rem',
+      truncate: true
     },
     {
       field: 'resourceName',
       header: 'Resource',
-      enableClick: true
+      style: 'width: 14rem; max-width: 14rem',
+      enableClick: true,
+      truncate: true
     },
     {
       field: 'authorEmail',
-      header: 'Author Email'
+      header: 'Author Email',
+      style: 'width: 14rem; max-width: 14rem',
+      truncate: true
     }
   ]
 
@@ -151,7 +160,9 @@
             <component :is="col.component(getFieldValue(rowData, col.field))" />
           </template>
           <template v-else>
-            <span>{{ getFieldValue(rowData, col.field) }}</span>
+            <span :class="{ 'block truncate': col.truncate }">{{
+              getFieldValue(rowData, col.field)
+            }}</span>
           </template>
         </div>
       </template>

--- a/src/templates/home-cards-block/monthly-usage-card.vue
+++ b/src/templates/home-cards-block/monthly-usage-card.vue
@@ -64,7 +64,7 @@
       </div>
     </template>
     <template #content>
-      <div class="p-4 flex flex-col gap-2.5 bg-[var(--card-content-bg)]]">
+      <div class="p-4 flex flex-col gap-2.5 bg-[var(--card-content-bg)]">
         <template v-if="isLoading">
           <div
             v-for="index in 4"

--- a/src/views/Home/components/HomeCard.vue
+++ b/src/views/Home/components/HomeCard.vue
@@ -3,7 +3,7 @@
     class="border border-[var(--surface-border)] rounded-md bg-[var(--card-content-bg))] flex flex-col"
   >
     <div
-      class="group bg-[var(--card-header-bg))] border-b rounded-t-md border-[var(--surface-border)] px-4 py-1.5 h-11 flex items-center justify-between overflow-visible"
+      class="group bg-[var(--card-header-bg)] border-b rounded-t-md border-[var(--surface-border)] px-4 py-1.5 h-11 flex items-center justify-between overflow-visible"
     >
       <h2 class="text-base font-semibold var(--text-color-primary)">{{ title }}</h2>
       <div
@@ -14,13 +14,13 @@
       </div>
     </div>
 
-    <div class="flex-1 bg-[var(--card-content-bg)]">
+    <div class="flex-1 bg-[var(--surface-section)]">
       <slot name="content" />
     </div>
 
     <div
       v-if="hasFooterSlot"
-      class="border-t border-[var(--surface-border)] bg-[var(--card-footer-bg))] h-11 flex items-center justify-center px-4"
+      class="border-t border-[var(--surface-border)] bg-[var(--card-footer-bg)] h-11 flex items-center justify-center px-4"
     >
       <slot name="footer" />
     </div>


### PR DESCRIPTION
## O que foi alterado

- Definidas larguras fixas para as colunas Date, Operation, Type e Author Email na tabela de Last Activities (last-activities-block.vue), impedindo que o conteúdo ultrapasse os limites e gere rolagem horizontal no componente
- A coluna Resource não possui largura fixa, permitindo que ocupe o espaço restante disponível de forma proporcional
- Aplicado truncamento de texto (overflow: hidden; text-overflow: ellipsis) nas colunas com tamanho fixo para tratar conteúdos longos de forma adequada
- Atualizados tokens de superfície para alinhar com os layouts propostos, garantindo consistência visual entre os temas

## Por que

A tabela de Last Activities estava causando rolagem horizontal devido a larguras de colunas sem restrição. Além disso, alguns tokens de superfície estavam fora de sincronia com as propostas de design, gerando inconsistências visuais na interface.

## Como testar

1. Acesse a página Home  
2. Localize o bloco Last Activities  
3. Verifique que a tabela não gera rolagem horizontal independente do tamanho do conteúdo  
4. Verifique que valores longos nas colunas Type, Date, Operation e Author Email são truncados com ... ao invés de estourar e causar rolagem
5. Verifique que a coluna Resource se expande para preencher o espaço restante quando disponível  
6. Confira nos temas claro e escuro que as cores de superfície estão consistentes com os layouts propostos