### PR TITLE
fix: theme test

### DIFF
--- a/src/tests/helpers/themeApply.test.js
+++ b/src/tests/helpers/themeApply.test.js
@@ -43,7 +43,8 @@ describe('themeApply', () => {
 
       sut('system')
 
-      expect(rootElementMock.className).toBe(result)
+      expect(rootElementMock.classList.contains('azion')).toBe(true)
+      expect(rootElementMock.classList.contains(result)).toBe(true)
     }
   )
 
@@ -76,7 +77,8 @@ describe('themeApply', () => {
       })
       sut(selectedTheme)
 
-      expect(rootElementMock.className).toBe(result)
+      expect(rootElementMock.classList.contains('azion')).toBe(true)
+      expect(rootElementMock.classList.contains(result)).toBe(true)
     }
   )
 })


### PR DESCRIPTION
### O que foi alterado
- Atualizados os testes de themeApply em src/tests/helpers/themeApply.test.js para refletir o comportamento atual da função.
- Substituída a validação por igualdade exata de className pela validação de presença de classes com classList.contains(...).
- Agora os testes validam explicitamente:
  - presença da classe base azion;
  - presença da classe de tema esperada (azion-dark ou azion-light).
### Por que
A implementação atual de themeApply sempre mantém a classe base azion no :root, além da classe de tema.  
Os testes antigos assumiam apenas uma classe no elemento e, por isso, não representavam corretamente o comportamento real.
### Como testar
- Executar: pnpm vitest --run src/tests/helpers/themeApply.test.js
- Confirmar que:
  - todos os cenários de tema (system, dark, light, undefined) passam;
  - a classe base azion continua presente;
  - a classe de tema aplicada corresponde ao resultado esperado.