### PR TITLE
[NO-ISSUE] fix: user-flag  add null safety checks to prevent TypeError

### DIFF
--- a/src/composables/user-flag.js
+++ b/src/composables/user-flag.js
@@ -4,11 +4,11 @@ const _flags = ref([])
 const BLOCK_INCOMPATIBLE_ENDPOINT_V4 = 'block_apiv4_incompatible_endpoints'
 
 const setFeatureFlags = (flagsArray = []) => {
-  _flags.value = flagsArray
+  _flags.value = Array.isArray(flagsArray) ? flagsArray : []
 }
 
 const useFlag = (flagName) => {
-  return computed(() => _flags.value.includes(flagName))
+  return computed(() => _flags.value?.includes(flagName) ?? false)
 }
 
 const hasFlagBlockApiV4 = () => {

--- a/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
+++ b/src/views/EdgeFirewallRulesEngine/FormFields/FormFieldsEdgeFirewallRulesEngine.vue
@@ -577,7 +577,7 @@
           </div>
 
           <div class="flex items-top gap-x-2 items-top mt-2 mb-4 flex-col gap-2 sm:flex-row">
-            <div class="flex flex-col h-fit sm:max-w-[15.625rem] w-full">
+            <div class="flex flex-col sm:w-[15.625rem] w-full overflow-hidden">
               <FieldDropdownIcon
                 :data-testid="`edge-firewall-rules-form__variable[${criteriaInnerRowIndex}]`"
                 :value="criteria[criteriaIndex].value[criteriaInnerRowIndex].variable"
@@ -599,7 +599,7 @@
               />
             </div>
 
-            <div class="flex flex-col sm:max-w-[15.625rem] w-full gap-2">
+            <div class="flex flex-col sm:w-[15.625rem] w-full gap-2">
               <FieldDropdown
                 :options="
                   getOperatorsOptionsByCriteriaVariable({
@@ -617,7 +617,7 @@
               />
             </div>
 
-            <div class="flex flex-col sm:max-w-[15.625rem] w-full gap-2">
+            <div class="flex flex-col sm:w-[15.625rem] w-full gap-2">
               <FieldText
                 v-if="showArgumentBySelectedOperator({ criteriaIndex, criteriaInnerRowIndex })"
                 :name="`criteria[${criteriaIndex}][${criteriaInnerRowIndex}].argument`"

--- a/src/views/EdgeSQL/CodeEditor.vue
+++ b/src/views/EdgeSQL/CodeEditor.vue
@@ -135,7 +135,7 @@
                 <template #header>
                   <DataTable.Header :showDivider="!!sqlAppliedFilters.length">
                     <template #first-line>
-                      <div class="flex flex-col gap-2 w-full">
+                      <div class="flex flex-col gap-2 w-full py-2">
                         <div class="flex items-center gap-2 justify-between">
                           <div class="text-color text-lg font-medium">Results</div>
 

--- a/src/views/Variables/ListView.vue
+++ b/src/views/Variables/ListView.vue
@@ -102,7 +102,7 @@
             size="small"
             label="Variable"
             @click="handleTrackEvent"
-            createPagePath="variables/create"
+            createPagePath="/variables/create"
             data-testid="create_Variable_button"
           />
         </template>
@@ -116,7 +116,7 @@
         :actions="actions"
         :frozenColumns="['key']"
         editPagePath="/variables/edit"
-        createPagePath="variables/create"
+        createPagePath="/variables/create"
         exportFileName="Variables"
         :lazy="false"
         emptyListMessage="No variables found."
@@ -125,7 +125,7 @@
           description:
             'Create your first variable to define reusable configuration values for platform resources.',
           createButtonLabel: 'Variable',
-          createPagePath: 'variables/create',
+          createPagePath: '/variables/create',
           documentationService: documentationCatalog.variables
         }"
         @on-before-go-to-edit="checkIfIsEditable"

--- a/storybook/azion.config.mjs
+++ b/storybook/azion.config.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 /**
  * This file was automatically generated based on your preset configuration.
  *


### PR DESCRIPTION
## Feature
# Description

Este PR corrige um `TypeError: Cannot read properties of null (reading 'includes')` que ocorria no composable de feature flags quando `_flags.value` era `null` ou `undefined`.

## Changes

- **`setFeatureFlags`**: Adicionada validação de array para garantir que `_flags.value` seja sempre um array, mesmo quando `null` ou `undefined` é passado
- **`useFlag`**: Adicionado optional chaining (`?.`) e nullish coalescing (`?? false`) para tratar referências nulas com segurança

## Root Cause

O erro ocorria porque:

1. `setFeatureFlags` podia receber `null` ou `undefined` como parâmetro, definindo `_flags.value` como um valor não-array
2. `useFlag` chamava `.includes()` diretamente em `_flags.value` sem verificações de nulo

## Fix

```javascript
// Before
const setFeatureFlags = (flagsArray = []) => {
  _flags.value = flagsArray
}

const useFlag = (flagName) => {
  return computed(() => _flags.value.includes(flagName))
}

// After
const setFeatureFlags = (flagsArray = []) => {
  _flags.value = Array.isArray(flagsArray) ? flagsArray : []
}

const useFlag = (flagName) => {
  return computed(() => _flags.value?.includes(flagName) ?? false)
}
```
### Description

### How to test

### UI Changes (if applicable)
