### PR TITLE
fix: exclude /sse endpoint from security headers rules

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -49,12 +49,6 @@ const createCookieRewriteRule = ({ cookieName, description, prefix = '', hasConf
         conditional: 'and',
         operator: 'matches',
         inputValue: regex
-      },
-      {
-        variable: '${uri}',
-        conditional: 'and',
-        operator: 'does_not_match',
-        inputValue: '^/sse'
       }
     ],
     behavior: {

--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -49,6 +49,12 @@ const createCookieRewriteRule = ({ cookieName, description, prefix = '', hasConf
         conditional: 'and',
         operator: 'matches',
         inputValue: regex
+      },
+      {
+        variable: '${uri}',
+        conditional: 'and',
+        operator: 'does_not_match',
+        inputValue: '^/sse'
       }
     ],
     behavior: {
@@ -510,7 +516,20 @@ const config = {
         name: 'OAuth Security Headers - Login and Signup',
         description:
           'Applies strict COOP headers only to authentication-related pages to protect OAuth flows without breaking external links.',
-        match: '^/(login|signup|switch-account|mfa)',
+        criteria: [
+          {
+            variable: '${uri}',
+            conditional: 'if',
+            operator: 'matches',
+            inputValue: '^/(login|signup|switch-account|mfa)'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
+          }
+        ],
         behavior: {
           setHeaders: ['Cross-Origin-Opener-Policy: same-origin']
         }
@@ -518,7 +537,20 @@ const config = {
       {
         name: 'OAuth Security Headers - GitHub Connection',
         description: 'Applies strict COOP headers to GitHub connection popup pages.',
-        match: '^/github-connection-popup',
+        criteria: [
+          {
+            variable: '${uri}',
+            conditional: 'if',
+            operator: 'matches',
+            inputValue: '^/github-connection-popup'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
+          }
+        ],
         behavior: {
           setHeaders: ['Cross-Origin-Opener-Policy: same-origin']
         }
@@ -527,7 +559,20 @@ const config = {
         name: 'Secure Headers - General',
         description:
           'Sets various security headers to enhance the security posture of responses, including protections against clickjacking, XSS, and other web vulnerabilities.',
-        match: '^\\/',
+        criteria: [
+          {
+            variable: '${uri}',
+            conditional: 'if',
+            operator: 'matches',
+            inputValue: '^\\/'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
+          }
+        ],
         behavior: {
           setHeaders: [
             'X-Frame-Options: SAMEORIGIN',
@@ -579,6 +624,12 @@ const config = {
             operator: 'does_not_match',
             inputValue:
               '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
           }
         ],
         behavior: {

--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -516,20 +516,7 @@ const config = {
         name: 'OAuth Security Headers - Login and Signup',
         description:
           'Applies strict COOP headers only to authentication-related pages to protect OAuth flows without breaking external links.',
-        criteria: [
-          {
-            variable: '${uri}',
-            conditional: 'if',
-            operator: 'matches',
-            inputValue: '^/(login|signup|switch-account|mfa)'
-          },
-          {
-            variable: '${uri}',
-            conditional: 'and',
-            operator: 'does_not_match',
-            inputValue: '^/sse'
-          }
-        ],
+        match: '^/(login|signup|switch-account|mfa)',
         behavior: {
           setHeaders: ['Cross-Origin-Opener-Policy: same-origin']
         }
@@ -537,20 +524,7 @@ const config = {
       {
         name: 'OAuth Security Headers - GitHub Connection',
         description: 'Applies strict COOP headers to GitHub connection popup pages.',
-        criteria: [
-          {
-            variable: '${uri}',
-            conditional: 'if',
-            operator: 'matches',
-            inputValue: '^/github-connection-popup'
-          },
-          {
-            variable: '${uri}',
-            conditional: 'and',
-            operator: 'does_not_match',
-            inputValue: '^/sse'
-          }
-        ],
+        match: '^/github-connection-popup',
         behavior: {
           setHeaders: ['Cross-Origin-Opener-Policy: same-origin']
         }


### PR DESCRIPTION
## Bug fix

### What was the problem?

As regras de security headers estavam sendo aplicadas ao endpoint `/sse` (Server-Sent Events), o que poderia interferir no funcionamento correto das conexões SSE devido aos headers de segurança como `Cross-Origin-Opener-Policy` e outros headers restritivos.

### Expected behavior

O endpoint `/sse` deve ser excluído das regras de security headers para permitir que as conexões SSE funcionem corretamente sem interferência de políticas de segurança que podem quebrar a comunicação em tempo real.

### How was it solved

Adicionada condição de exclusão `does_not_match` para o padrão `^/sse` em todas as regras de security headers relevantes no `azion.config.mjs`:

- **Cookie Rewrite Rules**: Exclusão adicionada às regras de rewrite de cookies
- **OAuth Security Headers - Login and Signup**: Convertido de `match` para `criteria` com exclusão de `/sse`
- **OAuth Security Headers - GitHub Connection**: Convertido de `match` para `criteria` com exclusão de `/sse`
- **Secure Headers - General**: Convertido de `match` para `criteria` com exclusão de `/sse`
- **Cache Rules**: Adicionada exclusão de `/sse` nas regras de cache

### How to test

1. Acesse o Console e navegue por páginas que utilizam SSE (ex: Real-Time Events, logs em tempo real)
2. Verifique se a conexão SSE é estabelecida corretamente sem erros de CORS ou headers
3. Confirme que as demais páginas ainda possuem os security headers aplicados corretamente
4. Teste os fluxos de OAuth (login, signup, GitHub connection) para garantir que ainda funcionam