### PR TITLE
SYNC DEPLOY (#3481)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,38 +1,47 @@
 name: Deploy Console Kit (PRODUCTION)
+
 on:
   push:
     branches:
       - main
+
 env:
   HUSKY: 0
   CLI_VERSION: 4.15.0
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     container:
       image: node:22-alpine
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        
       - name: Install SO deps
         run: apk add curl git bash jq
+        
       - name: Install dependencies
         run: yarn install
+
       - name: Download Azion CLI
         run: |
           wget https://github.com/aziontech/azion/releases/download/${CLI_VERSION}/azion_${CLI_VERSION}_linux_amd64.apk
           apk add --allow-untrusted azion_${CLI_VERSION}_linux_amd64.apk
+
       - name: Configure Azion CLI
         run: azion -t ${{ secrets.PLATFORM_KIT_TOKEN }}
+
       - name: Build & Deploy
         run: azion deploy --auto --local --debug --config-dir azion/production
         env:
+          NODE_ENV: production
+          VITE_ENVIRONMENT: production
           VITE_STRIPE_TOKEN_PROD: ${{ secrets.PROD_STRIPE_TOKEN }}
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.PROD_RECAPTCHA_SITE_KEY }}
           VITE_SEGMENT_TOKEN: ${{ secrets.PROD_SEGMENT_TOKEN }}
           CROSS_EDGE_SECRET: ${{ secrets.PROD_CROSS_EDGE_SECRET}}
-          NODE_ENV: production
-          VITE_ENVIRONMENT: production
           VITE_PROD_SENTRY: ${{ secrets.PROD_SENTRY }}
           VITE_SSO_GITHUB: ${{ secrets.PROD_SSO_GITHUB }}
           VITE_SSO_GOOGLE: ${{ secrets.PROD_SSO_GOOGLE }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,50 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'storybook/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+
+      - name: Install Azion CLI
+        run: |
+          curl -o azionlinux https://downloads.azion.com/linux/x86_64/azion
+          sudo mv azionlinux /usr/bin/azion
+          sudo chmod u+x /usr/bin/azion
+
+      - name: CLI version
+        run: azion --version
+        
+      - name: Configure token
+        run: |
+          azion -t ${{ secrets.AZION_PERSONAL_TOKEN }}  
+          azion whoami
+
+      - name: Install storybook dependencies
+        run: yarn install
+      
+      - name: Building Storybook
+        run: |
+          yarn storybook:build
+          
+      - name: Azion Deploy
+        run: |
+          yarn storybook:deploy

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ hooks/
 CLAUDE.md
 .opencode/
 .claude/
+
+storybook/yarn.lock

--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -527,7 +527,20 @@ const config = {
         name: 'Secure Headers - General',
         description:
           'Sets various security headers to enhance the security posture of responses, including protections against clickjacking, XSS, and other web vulnerabilities.',
-        match: '^\\/',
+        criteria: [
+          {
+            variable: '${uri}',
+            conditional: 'if',
+            operator: 'matches',
+            inputValue: '^\\/'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
+          }
+        ],
         behavior: {
           setHeaders: [
             'X-Frame-Options: SAMEORIGIN',
@@ -579,6 +592,12 @@ const config = {
             operator: 'does_not_match',
             inputValue:
               '^(?!.*workspace/storage).*.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4|json|xml)$'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
           }
         ],
         behavior: {

--- a/src/helpers/real-time-filters-rules.js
+++ b/src/helpers/real-time-filters-rules.js
@@ -63,7 +63,7 @@ const FILTERS_RULES = () => {
       'Upstream Cache Status',
       'Request Time'
     ],
-    httpEvents: [
+    workloadEvents: [
       TEXT_DOMAIN_WORKLOAD().singularTitle,
       'Status',
       'Upstream Status',
@@ -91,7 +91,7 @@ const FILTERS_RULES = () => {
       'Invocations',
       'Edge Functions Instance Id List'
     ],
-    edgeFunctionsEvents: [
+    functionEvents: [
       TEXT_DOMAIN_WORKLOAD().singularTitle,
       'Edge Function Id',
       'Compute Time',

--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -67,16 +67,8 @@ const adapt = ({ body, statusCode }) => {
 
   const productsGrouped = groupBy(filteredAccountingDetail, ['productSlug', 'metricSlug'])
 
-  const productsWithUsage = new Set(
-    productsGrouped
-      .filter((item) => Number(item.accounted || 0) > 0)
-      .map((item) => item.productSlug)
-  )
-
   const filteredProducts = productsGrouped.filter((item) => {
-    return [BOT_MANAGER_SLUG].includes(item.productSlug)
-      ? false
-      : productsWithUsage.has(item.productSlug)
+    return ![BOT_MANAGER_SLUG].includes(item.productSlug)
   })
 
   const productsGroupedByRegion = groupBy(filteredAccountingDetail, [

--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -299,23 +299,13 @@ const adapt = ({ body, statusCode }) => {
     'metricSlug'
   ])
 
-  const productsWithUsage = new Set(
-    groupedMetrics
-      .filter((metric) => Number(metric.accounted || 0) > 0 || Number(metric.value || 0) > 0)
-      .map((metric) => metric.productSlug)
-  )
-
   const groupedRegionMetrics = groupBy(
     metricsRegionValueFilteredByFlag,
     metricsRegionAccountedFilteredByFlag,
     ['productSlug', 'metricSlug', 'regionName']
   )
 
-  const productsToShow = filteredProducts.filter((product) =>
-    productsWithUsage.has(product.productSlug)
-  )
-
-  const data = mapProducts(productsToShow, groupedMetrics, groupedRegionMetrics)
+  const data = mapProducts(filteredProducts, groupedMetrics, groupedRegionMetrics)
 
   return { body: data, statusCode }
 }

--- a/src/services/real-time-events-service/edge-functions-console/list-edge-functions-console.js
+++ b/src/services/real-time-events-service/edge-functions-console/list-edge-functions-console.js
@@ -30,7 +30,7 @@ export const listEdgeFunctionsConsole = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     limit: 10000,
     fields: ['configurationId', 'functionId', 'id', 'level', 'lineSource', 'ts', 'line'],
     orderBy: 'ts_DESC'
@@ -39,15 +39,15 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (body) => {
-  const cellsConsoleEventsList = body.data?.cellsConsoleEvents
-  const parser = cellsConsoleEventsList?.length
-    ? cellsConsoleEventsList.map((cellsConsoleEvents) => ({
-        summary: buildSummary(cellsConsoleEvents, shouldLimitRequestUri, shouldShowTsColumn),
-        configurationId: cellsConsoleEvents.configurationId,
-        line: cellsConsoleEvents.line,
+  const functionConsoleEventsList = body.data?.functionConsoleEvents
+  const parser = functionConsoleEventsList?.length
+    ? functionConsoleEventsList.map((functionConsoleEvent) => ({
+        summary: buildSummary(functionConsoleEvent, shouldLimitRequestUri, shouldShowTsColumn),
+        configurationId: functionConsoleEvent.configurationId,
+        line: functionConsoleEvent.line,
         id: generateCurrentTimestamp(),
-        tsFormat: getCurrentTimezone(cellsConsoleEvents.ts),
-        ts: cellsConsoleEvents.ts
+        tsFormat: getCurrentTimezone(functionConsoleEvent.ts),
+        ts: functionConsoleEvent.ts
       }))
     : []
 

--- a/src/services/real-time-events-service/edge-functions-console/load-edge-functions-console.js
+++ b/src/services/real-time-events-service/edge-functions-console/load-edge-functions-console.js
@@ -23,7 +23,7 @@ export const loadEdgeFunctionsConsole = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     limit: 10000,
     fields: [
       'lineSource',
@@ -83,12 +83,12 @@ const levelMap = {
 
 const adaptResponse = (response) => {
   const { body } = response
-  const [cellsConsoleEvents = {}] = body.data.cellsConsoleEvents
+  const [functionConsoleEvents = {}] = body.data.functionConsoleEvents
 
   return {
-    lineSource: cellsConsoleEvents.lineSource,
-    level: levelMap[cellsConsoleEvents.level],
-    ts: getCurrentTimezone(cellsConsoleEvents.ts),
-    data: buildSummary(cellsConsoleEvents, false, shouldShowTsColumn)
+    lineSource: functionConsoleEvents.lineSource,
+    level: levelMap[functionConsoleEvents.level],
+    ts: getCurrentTimezone(functionConsoleEvents.ts),
+    data: buildSummary(functionConsoleEvents, false, shouldShowTsColumn)
   }
 }

--- a/src/services/real-time-events-service/edge-functions/list-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/list-edge-functions.js
@@ -30,7 +30,7 @@ export const listEdgeFunctions = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     limit: 10000,
     fields: [
       'configurationId',
@@ -48,12 +48,12 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (response) => {
-  const data = response.data.edgeFunctionsEvents?.map((edgeFunctionsEvents) => ({
+  const data = response.data.functionEvents?.map((functionEventItem) => ({
     id: generateCurrentTimestamp(),
-    summary: buildSummary(edgeFunctionsEvents, shouldLimitRequestUri, shouldShowTsColumn),
-    ts: edgeFunctionsEvents.ts,
-    tsFormat: getCurrentTimezone(edgeFunctionsEvents.ts),
-    configurationId: edgeFunctionsEvents.configurationId
+    summary: buildSummary(functionEventItem, shouldLimitRequestUri, shouldShowTsColumn),
+    ts: functionEventItem.ts,
+    tsFormat: getCurrentTimezone(functionEventItem.ts),
+    configurationId: functionEventItem.configurationId
   }))
 
   return {

--- a/src/services/real-time-events-service/edge-functions/load-edge-functions.js
+++ b/src/services/real-time-events-service/edge-functions/load-edge-functions.js
@@ -23,7 +23,7 @@ export const loadEdgeFunctions = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     limit: 10000,
     fields: [
       'functionLanguage',
@@ -51,13 +51,13 @@ const adapt = (filter) => {
 
 const adaptResponse = (response) => {
   const { body } = response
-  const [edgeFunctionsEvents = {}] = body.data.edgeFunctionsEvents
-  edgeFunctionsEvents.edgeFunctionsList = edgeFunctionsEvents.edgeFunctionsList?.split(';')
+  const [functionEvents = {}] = body.data.functionEvents
+  functionEvents.edgeFunctionsList = functionEvents.edgeFunctionsList?.split(';')
 
   return {
-    id: edgeFunctionsEvents.ts + edgeFunctionsEvents.configurationId,
-    data: buildSummary(edgeFunctionsEvents, false, shouldShowTsColumn),
-    functionLanguage: edgeFunctionsEvents.functionLanguage,
-    ts: getCurrentTimezone(edgeFunctionsEvents.ts)
+    id: functionEvents.ts + functionEvents.configurationId,
+    data: buildSummary(functionEvents, false, shouldShowTsColumn),
+    functionLanguage: functionEvents.functionLanguage,
+    ts: getCurrentTimezone(functionEvents.ts)
   }
 }

--- a/src/services/real-time-events-service/http-request/list-http-request.js
+++ b/src/services/real-time-events-service/http-request/list-http-request.js
@@ -29,7 +29,7 @@ export const listHttpRequest = async (filter) => {
 
 const adapt = (filter) => {
   const table = {
-    dataset: 'httpEvents',
+    dataset: 'workloadEvents',
     limit: 1000,
     fields: [
       'configurationId',
@@ -61,12 +61,12 @@ const adapt = (filter) => {
 }
 
 const adaptResponse = (httpResponse) => {
-  const data = httpResponse.data.httpEvents?.map((httpEventItem) => ({
+  const data = httpResponse.data.workloadEvents?.map((workloadEventItem) => ({
     id: generateCurrentTimestamp(),
-    requestId: httpEventItem.requestId,
-    summary: buildSummary(httpEventItem, shouldLimitRequestUri, shouldShowTsColumn),
-    ts: httpEventItem.ts,
-    tsFormat: getCurrentTimezone(httpEventItem.ts)
+    requestId: workloadEventItem.requestId,
+    summary: buildSummary(workloadEventItem, shouldLimitRequestUri, shouldShowTsColumn),
+    ts: workloadEventItem.ts,
+    tsFormat: getCurrentTimezone(workloadEventItem.ts)
   }))
 
   return {

--- a/src/services/real-time-events-service/http-request/load-http-request.js
+++ b/src/services/real-time-events-service/http-request/load-http-request.js
@@ -50,7 +50,7 @@ const fieldsByRequest = [
 
 const mergeHttpEvents = (responses) => {
   return responses
-    .flatMap((res) => res.body?.data?.httpEvents || [])
+    .flatMap((res) => res.body?.data?.workloadEvents || [])
     .reduce((acc, event) => {
       Object.entries(event).forEach(([key, value]) => {
         acc[key] = acc[key] ? [].concat(acc[key], value) : value
@@ -66,7 +66,7 @@ const createPayload = (filter, fields) => {
       and: { tsEq: filter.ts, requestIdEq: filter.requestId }
     },
     {
-      dataset: 'httpEvents',
+      dataset: 'workloadEvents',
       limit: 10000,
       fields,
       orderBy: 'ts_ASC'

--- a/src/templates/home-cards-block/monthly-usage-card.vue
+++ b/src/templates/home-cards-block/monthly-usage-card.vue
@@ -129,11 +129,11 @@
 
   const DEFAULT_USAGE_LIST = [{ label: 'No usage data available', value: '---', key: 'no_data' }]
 
-  const DEFAULT_SELECTED_KEYS = [
-    'edge_dns_hosted_zones',
-    'edge_storage_edge_storage_data_stored',
-    'edge_application_requests',
-    'edge_application_data_transferred'
+  const DEFAULT_SELECTED_KEY_GROUPS = [
+    ['edge_dns_hosted_zones', 'edge_dns_edge_dns_zones'],
+    ['edge_storage_edge_storage_data_stored', 'object_storage_edge_storage_data_stored'],
+    ['edge_application_requests', 'application_application_requests'],
+    ['edge_application_data_transferred', 'application_data_transferred']
   ]
 
   const accountStore = useAccountStore()
@@ -145,6 +145,7 @@
   const columnSelectorPanel = ref(null)
 
   const MAX_SELECTIONS = 6
+  const LOCAL_STORAGE_KEY = 'monthly_usage_selected_keys'
 
   const toggleColumnSelector = (event) => {
     columnSelectorPanel.value.toggle(event)
@@ -161,6 +162,7 @@
   const handleSelectionChange = (newSelection) => {
     if (newSelection.length <= MAX_SELECTIONS) {
       selectedOptions.value = newSelection
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newSelection))
     }
   }
 
@@ -168,6 +170,14 @@
     if (!selectedOptions.value.length) return DEFAULT_USAGE_LIST
     return allUsageOptions.value.filter((option) => selectedOptions.value.includes(option.key))
   })
+
+  const buildDefaultSelection = (availableOptionKeys) => {
+    const defaultKeys = DEFAULT_SELECTED_KEY_GROUPS.map((group) =>
+      group.find((key) => availableOptionKeys.includes(key))
+    ).filter(Boolean)
+
+    return [...new Set(defaultKeys)].slice(0, MAX_SELECTIONS)
+  }
 
   const listServiceAndProductsChanges = async () => {
     isLoading.value = true
@@ -186,9 +196,39 @@
 
       if (products?.length) {
         allUsageOptions.value = buildAllUsageOptions(products)
-        selectedOptions.value = DEFAULT_SELECTED_KEYS.filter((key) =>
-          allUsageOptions.value.some((opt) => opt.key === key)
-        )
+
+        let storedKeys = null
+        let hasStoredConfig = false
+        try {
+          const storedData = localStorage.getItem(LOCAL_STORAGE_KEY)
+          hasStoredConfig = storedData !== null
+          if (hasStoredConfig) storedKeys = JSON.parse(storedData)
+        } catch {
+          //eslint-disable-next-line no-console
+          console.warn('[MonthlyUsageCard] No keys found in localstorage')
+        }
+
+        const availableOptionKeys = allUsageOptions.value.map((opt) => opt.key)
+        const defaultSelection = buildDefaultSelection(availableOptionKeys)
+        const fallbackSelection =
+          defaultSelection.length > 0
+            ? defaultSelection
+            : availableOptionKeys.slice(0, MAX_SELECTIONS)
+
+        if (hasStoredConfig && Array.isArray(storedKeys)) {
+          const validStoredSelection = storedKeys
+            .filter((key) => availableOptionKeys.includes(key))
+            .slice(0, MAX_SELECTIONS)
+
+          selectedOptions.value =
+            storedKeys.length === 0
+              ? []
+              : validStoredSelection.length > 0
+                ? validStoredSelection
+                : fallbackSelection
+        } else {
+          selectedOptions.value = fallbackSelection
+        }
       } else {
         allUsageOptions.value = DEFAULT_USAGE_LIST
       }
@@ -209,13 +249,13 @@
         if (!desc.service) return
 
         const key = `${product.slug}_${desc.slug}`
-        const label =
-          product.service === desc.service ? product.service : `${product.service} ${desc.service}`
+        const isIncluded = desc.service.toLowerCase().includes(product.service.toLowerCase())
+        const label = isIncluded ? desc.service : `${product.service} ${desc.service}`
 
         options.push({
           key,
           label,
-          value: desc.quantity || '---'
+          value: desc.quantity ?? '---'
         })
       })
     })

--- a/src/tests/helpers/realt-time-filter-rules.test.js
+++ b/src/tests/helpers/realt-time-filter-rules.test.js
@@ -63,7 +63,7 @@ describe('RealTimeMetricsModule', () => {
             'Upstream Cache Status',
             'Request Time'
           ],
-          httpEvents: [
+          workloadEvents: [
             handleTextDomainWorkload.singularTitle,
             'Status',
             'Upstream Status',
@@ -91,7 +91,7 @@ describe('RealTimeMetricsModule', () => {
             'Invocations',
             'Edge Functions Instance Id List'
           ],
-          edgeFunctionsEvents: [
+          functionEvents: [
             handleTextDomainWorkload.singularTitle,
             'Edge Function Id',
             'Compute Time',

--- a/src/tests/modules/real-time-events/constants/tabs-events.test.js
+++ b/src/tests/modules/real-time-events/constants/tabs-events.test.js
@@ -52,7 +52,7 @@ describe('RealTimeEventsModule', () => {
       expect(httpRequests.panel).toBe('httpRequests')
       expect(httpRequests.index).toBe(0)
       expect(httpRequests.title).toBe('HTTP Requests')
-      expect(httpRequests.dataset).toBe('httpEvents')
+      expect(httpRequests.dataset).toBe('workloadEvents')
       expect(httpRequests.tabRouter).toBe('http-requests')
       expect(httpRequests.columns.length).toBe(2)
     })

--- a/src/tests/services/billing-services/list-service-and-products-changes.test.js
+++ b/src/tests/services/billing-services/list-service-and-products-changes.test.js
@@ -195,6 +195,42 @@ const fixtures = {
             ]
           }
         ]
+      },
+      {
+        service: 'Data Stream',
+        value: formatCurrencyString('BRL', 0),
+        slug: 'data_stream',
+        currency: 'BRL',
+        descriptions: [
+          {
+            service: 'Data Streamed',
+            slug: 'data_stream_data_streamed',
+            quantity: '0 GB',
+            price: formatCurrencyString('BRL', 0),
+            data: [
+              {
+                country: 'Brazil',
+                quantity: '0 GB',
+                price: formatCurrencyString('BRL', 0),
+                slug: 'data_stream_data_streamed'
+              }
+            ]
+          },
+          {
+            service: 'Data Stream Requests',
+            slug: 'data_stream_requests',
+            quantity: '0',
+            price: formatCurrencyString('BRL', 0),
+            data: [
+              {
+                country: 'Brazil',
+                quantity: '0',
+                price: formatCurrencyString('BRL', 0),
+                slug: 'data_stream_requests'
+              }
+            ]
+          }
+        ]
       }
     ]
   },
@@ -220,7 +256,7 @@ describe('BillingServices', () => {
     const result = await sut()
 
     expect(result).toEqual(fixtures.formattedResponse.data)
-    expect(result.some((item) => item.slug === 'data_stream')).toBe(false)
+    expect(result.some((item) => item.slug === 'data_stream')).toBe(true)
   })
 
   it('should return an error if the request fails', async () => {

--- a/src/tests/services/real-time-events-service/edge-functions-console/list-edge-functions-console.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions-console/list-edge-functions-console.test.js
@@ -33,10 +33,10 @@ describe('EdgeFunctionsConsoleServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctions: [] } }
+      body: { data: { functionConsoleEvents: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'cellsConsoleEvents'
+    const datasetName = 'functionConsoleEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -84,7 +84,7 @@ describe('EdgeFunctionsConsoleServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [fixtures.edgeFunctionConsole] } }
+      body: { data: { functionConsoleEvents: [fixtures.edgeFunctionConsole] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions-console/load-edge-functions-console.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions-console/load-edge-functions-console.test.js
@@ -37,7 +37,7 @@ describe('EdgeFunctionsConsoleServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [] } }
+      body: { data: { functionConsoleEvents: [] } }
     })
     const { sut } = makeSut()
     await sut(fixtures.filter)
@@ -62,7 +62,7 @@ describe('EdgeFunctionsConsoleServices', () => {
     localeMock()
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { cellsConsoleEvents: [fixtures.edgeFunctionConsole] } }
+      body: { data: { functionConsoleEvents: [fixtures.edgeFunctionConsole] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions/list-edge-functions.test.js
@@ -33,10 +33,10 @@ describe('EdgeFunctionsServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctions: [] } }
+      body: { data: { functionEvents: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'edgeFunctionsEvents'
+    const datasetName = 'functionEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -85,7 +85,7 @@ describe('EdgeFunctionsServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [fixtures.edgeFunction] } }
+      body: { data: { functionEvents: [fixtures.edgeFunction] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/edge-functions/load-edge-functions.test.js
+++ b/src/tests/services/real-time-events-service/edge-functions/load-edge-functions.test.js
@@ -36,7 +36,7 @@ describe('DataStreamingServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [] } }
+      body: { data: { functionEvents: [] } }
     })
     const { sut } = makeSut()
     await sut(fixtures.filter)
@@ -61,7 +61,7 @@ describe('DataStreamingServices', () => {
     localeMock()
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { edgeFunctionsEvents: [fixtures.edgeFunction] } }
+      body: { data: { functionEvents: [fixtures.edgeFunction] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/get-total-records.test.js
+++ b/src/tests/services/real-time-events-service/get-total-records.test.js
@@ -74,9 +74,9 @@ describe('getTotalRecords', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpEvents: [fixtures.httpRequest] } }
+      body: { data: { workloadEvents: [fixtures.httpRequest] } }
     })
-    const datasetName = 'httpEvents'
+    const datasetName = 'workloadEvents'
 
     const { sut } = makeSut()
     const response = await sut({ filter: fixtures.filter, dataset: datasetName })

--- a/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
+++ b/src/tests/services/real-time-events-service/http-request/list-http-request.test.js
@@ -34,10 +34,10 @@ describe('HttpRequestServices', () => {
   it('should call GraphQL with correct filter', async () => {
     const requestSpy = vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpRequest: [] } }
+      body: { data: { workloadEvents: [] } }
     })
     const { sut } = makeSut()
-    const datasetName = 'httpEvents'
+    const datasetName = 'workloadEvents'
     await sut(fixtures.filter)
 
     const query = [
@@ -100,7 +100,7 @@ describe('HttpRequestServices', () => {
     }))
     vi.spyOn(AxiosHttpClientAdapter, 'request').mockResolvedValueOnce({
       statusCode: 200,
-      body: { data: { httpEvents: [fixtures.httpRequest] } }
+      body: { data: { workloadEvents: [fixtures.httpRequest] } }
     })
 
     const { sut } = makeSut()

--- a/src/tests/services/real-time-events-service/http-request/load-http-request.test.js
+++ b/src/tests/services/real-time-events-service/http-request/load-http-request.test.js
@@ -67,11 +67,11 @@ describe('HttpRequestServices', () => {
       .spyOn(AxiosHttpClientAdapter, 'request')
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [] } }
+        body: { data: { workloadEvents: [] } }
       })
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [] } }
+        body: { data: { workloadEvents: [] } }
       })
 
     const { sut } = makeSut()
@@ -99,11 +99,11 @@ describe('HttpRequestServices', () => {
     vi.spyOn(AxiosHttpClientAdapter, 'request')
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [fixtures.httpRequestFirst] } }
+        body: { data: { workloadEvents: [fixtures.httpRequestFirst] } }
       })
       .mockResolvedValueOnce({
         statusCode: 200,
-        body: { data: { httpEvents: [fixtures.httpRequestSecond] } }
+        body: { data: { workloadEvents: [fixtures.httpRequestSecond] } }
       })
 
     const { sut } = makeSut()

--- a/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
+++ b/src/views/RealTimeEvents/Blocks/constants/tabs-events.js
@@ -6,7 +6,7 @@ const TABS_EVENTS = {
     index: 0,
     title: 'HTTP Requests',
     description: 'Logs of events from requests made to your applications and firewalls.',
-    dataset: 'httpEvents',
+    dataset: 'workloadEvents',
     tabRouter: 'http-requests',
     columns: [
       {
@@ -33,7 +33,7 @@ const TABS_EVENTS = {
     index: 1,
     title: 'Functions',
     description: 'Logs of events from requests made to your functions.',
-    dataset: 'edgeFunctionsEvents',
+    dataset: 'functionEvents',
     tabRouter: 'edge-functions',
     columns: [
       {
@@ -60,7 +60,7 @@ const TABS_EVENTS = {
     index: 2,
     title: 'Functions Console',
     description: 'Logs of events from applications using Edge Runtime returned by Cells Console.',
-    dataset: 'cellsConsoleEvents',
+    dataset: 'functionConsoleEvents',
     tabRouter: 'edge-functions-console',
     columns: [
       {

--- a/storybook/src/stories/components/AdvancedFilterSystem.stories.js
+++ b/storybook/src/stories/components/AdvancedFilterSystem.stories.js
@@ -1,0 +1,35 @@
+import AdvancedFilterSystem from '@/components/base/advanced-filter-system/index.vue';
+
+export default {
+  title: 'Components/Base/AdvancedFilterSystem',
+  component: AdvancedFilterSystem,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Advanced filtering system component that provides date range selection and field-based filtering capabilities. This component integrates with the application store and requires account context for timezone handling.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  render: () => ({
+    template: `
+      <div class="p-4">
+        <p class="text-sm text-gray-600">
+          The AdvancedFilterSystem component is a complex filtering interface that requires:
+        </p>
+        <ul class="list-disc list-inside mt-2 text-sm text-gray-600">
+          <li>Account store context for timezone information</li>
+          <li>Field definitions for available filters</li>
+          <li>Date range configuration</li>
+        </ul>
+        <p class="text-sm text-gray-600 mt-2">
+          Due to these dependencies, a full demonstration requires the application context.
+          Use this component in your application where the store and services are available.
+        </p>
+      </div>
+    `
+  })
+};

--- a/storybook/src/stories/components/DataTimeRange.stories.js
+++ b/storybook/src/stories/components/DataTimeRange.stories.js
@@ -1,0 +1,36 @@
+import DataTimeRange from '@/components/base/dataTimeRange/index.vue';
+
+export default {
+  title: 'Components/Base/DataTimeRange',
+  component: DataTimeRange,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Date and time range picker component with quick select options and absolute/relative date modes. Provides an overlay panel with tabbed interface for different selection modes.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  render: () => ({
+    template: `
+      <div class="p-4">
+        <p class="text-sm text-gray-600">
+          The DataTimeRange component provides a sophisticated date/time range selection interface with:
+        </p>
+        <ul class="list-disc list-inside mt-2 text-sm text-gray-600">
+          <li>Quick select presets (Today, Last 7 days, etc.)</li>
+          <li>Absolute date range picker with calendar</li>
+          <li>Relative date range picker (e.g., "last 2 hours")</li>
+          <li>Auto-refresh capabilities</li>
+        </ul>
+        <p class="text-sm text-gray-600 mt-2">
+          This component requires proper timezone context from the account store for accurate date handling.
+          Use in application context where store dependencies are available.
+        </p>
+      </div>
+    `
+  })
+};

--- a/storybook/src/stories/components/DescriptionText.stories.js
+++ b/storybook/src/stories/components/DescriptionText.stories.js
@@ -1,0 +1,87 @@
+import DescriptionText from '@/components/description-text/descriptionText.vue';
+
+export default {
+  title: 'Components/DescriptionText',
+  component: DescriptionText,
+  tags: ['autodocs'],
+  argTypes: {
+    description: {
+      control: 'text',
+      description: 'The text content to display as description'
+    },
+    size: {
+      control: 'select',
+      options: ['normal', 'small'],
+      description: 'Size variant: normal (text-sm) or small (text-xs)'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A simple text component for displaying descriptions with two size variants. Supports both plain text and raw HTML content through slots.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  args: {
+    description: 'This is a default description text that demonstrates the normal size variant. It can span multiple lines and maintains proper spacing.',
+    size: 'normal'
+  }
+};
+
+export const SmallSize = {
+  args: {
+    description: 'This is a small description text variant, useful for compact UIs or secondary information.',
+    size: 'small'
+  }
+};
+
+export const MultiLine = {
+  args: {
+    description: 'First line of description\nSecond line of description\nThird line of description',
+    size: 'normal'
+  }
+};
+
+export const WithRawHtml = {
+  render: (args) => ({
+    components: { DescriptionText },
+    setup() {
+      return { args };
+    },
+    template: `
+      <DescriptionText v-bind="args">
+        <template #rawHtml>
+          <strong>Bold text</strong>, <em>italic text</em>, and
+          <a href="#" class="text-blue-500 hover:underline">links</a> can be used here.
+        </template>
+      </DescriptionText>
+    `
+  }),
+  args: {
+    description: 'This description will be ignored when rawHtml slot is provided',
+    size: 'normal'
+  }
+};
+
+export const SmallWithRawHtml = {
+  render: (args) => ({
+    components: { DescriptionText },
+    setup() {
+      return { args };
+    },
+    template: `
+      <DescriptionText v-bind="args">
+        <template #rawHtml>
+          <span class="text-xs">Small size with <strong>HTML content</strong></span>
+        </template>
+      </DescriptionText>
+    `
+  }),
+  args: {
+    description: 'Ignored when rawHtml slot is provided',
+    size: 'small'
+  }
+};

--- a/storybook/src/stories/components/ListTableSimple.stories.js
+++ b/storybook/src/stories/components/ListTableSimple.stories.js
@@ -1,0 +1,108 @@
+import ListTableSimple from '@/components/list-table/ListTableSimple.vue';
+
+export default {
+  title: 'Components/ListTableSimple',
+  component: ListTableSimple,
+  tags: ['autodocs'],
+  argTypes: {
+    data: {
+      control: 'object',
+      description: 'Array of data objects to display in the table'
+    },
+    columns: {
+      control: 'object',
+      description: 'Column definitions with field, header, and optional style/sortable properties'
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Shows loading state'
+    },
+    rowsLimit: {
+      control: 'number',
+      description: 'Maximum number of rows to display'
+    },
+    viewAllLabel: {
+      control: 'text',
+      description: 'Label for the "View all" footer link'
+    },
+    dataKey: {
+      control: 'text',
+      description: 'Property name to use as unique key for each row'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A simplified table component for displaying a limited number of rows with optional actions. Ideal for dashboards and summary views where you want to show recent items with a link to the full list.'
+      }
+    }
+  }
+};
+
+const sampleData = [
+  { id: 1, name: 'John Doe', email: 'john@example.com', status: 'Active', role: 'Admin' },
+  { id: 2, name: 'Jane Smith', email: 'jane@example.com', status: 'Active', role: 'User' },
+  { id: 3, name: 'Bob Johnson', email: 'bob@example.com', status: 'Inactive', role: 'User' },
+  { id: 4, name: 'Alice Williams', email: 'alice@example.com', status: 'Active', role: 'Editor' },
+  { id: 5, name: 'Charlie Brown', email: 'charlie@example.com', status: 'Pending', role: 'User' }
+];
+
+const sampleColumns = [
+  { field: 'name', header: 'Name', sortable: true },
+  { field: 'email', header: 'Email' },
+  { field: 'status', header: 'Status', sortable: true },
+  { field: 'role', header: 'Role' }
+];
+
+export const Default = {
+  args: {
+    data: sampleData,
+    columns: sampleColumns,
+    rowsLimit: 5,
+    dataKey: 'id'
+  }
+};
+
+export const WithViewAllLink = {
+  args: {
+    data: sampleData,
+    columns: sampleColumns,
+    rowsLimit: 3,
+    viewAllLink: '/users',
+    viewAllLabel: 'View all users...',
+    dataKey: 'id'
+  }
+};
+
+export const Loading = {
+  args: {
+    data: [],
+    columns: sampleColumns,
+    loading: true,
+    rowsLimit: 5,
+    dataKey: 'id'
+  }
+};
+
+export const LimitedRows = {
+  args: {
+    data: sampleData,
+    columns: sampleColumns,
+    rowsLimit: 3,
+    dataKey: 'id'
+  }
+};
+
+export const WithCustomColumnWidths = {
+  args: {
+    data: sampleData,
+    columns: [
+      { field: 'name', header: 'Name', style: 'width: 200px' },
+      { field: 'email', header: 'Email', style: 'width: 250px' },
+      { field: 'status', header: 'Status', style: 'width: 100px' },
+      { field: 'role', header: 'Role', style: 'width: 100px' }
+    ],
+    rowsLimit: 5,
+    dataKey: 'id'
+  }
+};

--- a/storybook/src/stories/components/ResizableSplitter.stories.js
+++ b/storybook/src/stories/components/ResizableSplitter.stories.js
@@ -1,0 +1,136 @@
+import ResizableSplitter from '@/components/ResizableSplitter.vue';
+
+export default {
+  title: 'Components/ResizableSplitter',
+  component: ResizableSplitter,
+  tags: ['autodocs'],
+  argTypes: {
+    panelSizes: {
+      control: 'object',
+      description: 'Initial sizes of the two panels as percentages [top, bottom]'
+    },
+    minSize: {
+      control: 'object',
+      description: 'Minimum sizes for each panel as percentages'
+    },
+    maxSize: {
+      control: 'object',
+      description: 'Maximum sizes for each panel as percentages'
+    },
+    initialTopPanelPercent: {
+      control: 'number',
+      description: 'Initial top panel size as percentage (alternative to panelSizes)'
+    },
+    initialTopPanelPixels: {
+      control: 'number',
+      description: 'Initial top panel size in pixels (takes priority over percentage)'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A vertical resizable splitter component that divides the viewport into top and bottom panels. Users can drag the divider to resize panels. Supports minimum/maximum size constraints and emits events for size changes.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-blue-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Top Panel (Panel A)</h3>
+                <p class="text-sm text-gray-600">Drag the divider below to resize</p>
+              </div>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-green-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Bottom Panel (Panel B)</h3>
+                <p class="text-sm text-gray-600">This panel will resize accordingly</p>
+              </div>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    panelSizes: [50, 50],
+    minSize: [10, 10],
+    maxSize: [90, 90]
+  }
+};
+
+export const InitialTopPanelSize = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-purple-50 h-full flex items-center justify-center">
+              <h3 class="font-semibold text-lg">Top Panel - 70% Height</h3>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-yellow-50 h-full flex items-center justify-center">
+              <h3 class="font-semibold text-lg">Bottom Panel - 30% Height</h3>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    initialTopPanelPercent: 70
+  }
+};
+
+export const ConstrainedSizes = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-red-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Top Panel (30-60%)</h3>
+                <p class="text-sm text-gray-600">Panel constrained between 30% and 60%</p>
+              </div>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-blue-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Bottom Panel</h3>
+                <p class="text-sm text-gray-600">Try to drag beyond constraints</p>
+              </div>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    panelSizes: [40, 60],
+    minSize: [30, 40],
+    maxSize: [60, 70]
+  }
+};

--- a/storybook/src/stories/components/SelectPanel.stories.js
+++ b/storybook/src/stories/components/SelectPanel.stories.js
@@ -1,0 +1,163 @@
+import SelectPanel from '@/components/select-panel/selectPanel.vue';
+import { ref } from 'vue';
+
+export default {
+  title: 'Components/SelectPanel',
+  component: SelectPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Title text displayed above the select button'
+    },
+    description: {
+      control: 'text',
+      description: 'Description text displayed below the title'
+    },
+    options: {
+      control: 'object',
+      description: 'Array of options for the select button (simple strings or objects with label/value)'
+    },
+    value: {
+      control: 'text',
+      description: 'Initial selected value'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A panel component that combines a title, description, and a select button. Emits update:modelValue when selection changes. Can display additional content via the content slot.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  render: (args) => ({
+    components: { SelectPanel },
+    setup() {
+      const selectedValue = ref(args.value);
+      return { args, selectedValue };
+    },
+    template: `
+      <SelectPanel
+        v-bind="args"
+        v-model="selectedValue"
+      >
+        <template #content>
+          <div class="p-6 border rounded-lg bg-surface-50">
+            <div class="flex items-center gap-3">
+              <div class="text-2xl">
+                {{ selectedValue === 'Grid' ? '📊' : selectedValue === 'List' ? '📝' : '📋' }}
+              </div>
+              <div>
+                <div class="font-semibold text-gray-800 text-lg">{{ selectedValue }} View</div>
+                <div class="text-sm text-gray-600">
+                  {{ selectedValue === 'Grid' ? 'Visual card-based layout' : selectedValue === 'List' ? 'Compact row display' : 'Detailed columnar format' }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+      </SelectPanel>
+    `
+  }),
+  args: {
+    title: 'View Mode',
+    description: 'Select how you want to view your data',
+    options: ['Grid', 'List', 'Table'],
+    value: 'Grid'
+  }
+};
+
+export const WithoutContent = {
+  render: (args) => ({
+    components: { SelectPanel },
+    setup() {
+      const selectedValue = ref(args.value);
+      return { args, selectedValue };
+    },
+    template: `
+      <SelectPanel
+        v-bind="args"
+        v-model="selectedValue"
+      />
+    `
+  }),
+  args: {
+    title: 'Sort Order',
+    description: 'Choose how to sort the items',
+    options: ['Ascending', 'Descending'],
+    value: 'Ascending'
+  }
+};
+
+export const NoTitleDescription = {
+  render: (args) => ({
+    components: { SelectPanel },
+    setup() {
+      const selectedValue = ref(args.value);
+      return { args, selectedValue };
+    },
+    template: `
+      <SelectPanel
+        v-bind="args"
+        v-model="selectedValue"
+      />
+    `
+  }),
+  args: {
+    title: '',
+    description: '',
+    options: ['Option 1', 'Option 2', 'Option 3'],
+    value: 'Option 1'
+  }
+};
+
+export const EdgeFunctionStyle = {
+  render: (args) => ({
+    components: { SelectPanel },
+    setup() {
+      const selectedValue = ref(args.value);
+      return { args, selectedValue };
+    },
+    template: `
+      <SelectPanel
+        v-bind="args"
+        v-model="selectedValue"
+      >
+        <template #content>
+          <div class="border rounded-lg overflow-hidden">
+            <div class="p-4 bg-surface-50 border-b">
+              <div class="text-sm font-medium text-gray-700 mb-1">{{ selectedValue }} Editor</div>
+              <div class="text-xs text-gray-500">
+                {{ selectedValue === 'Form' ? 'Configure using the visual form builder' : 'Edit raw JSON configuration' }}
+              </div>
+            </div>
+            <div class="p-4 min-h-[200px] bg-white">
+              <div v-if="selectedValue === 'Form'" class="space-y-3">
+                <div class="p-3 bg-blue-50 border border-blue-200 rounded">
+                  <div class="text-sm font-medium text-blue-800">Form Builder</div>
+                  <div class="text-xs text-blue-600 mt-1">Visual configuration interface</div>
+                </div>
+              </div>
+              <div v-else class="space-y-3">
+                <div class="p-3 bg-gray-50 border border-gray-200 rounded font-mono text-xs">
+                  <div class="text-gray-800">{</div>
+                  <div class="text-gray-600 pl-2">"args": "your_config"</div>
+                  <div class="text-gray-800">}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+      </SelectPanel>
+    `
+  }),
+  args: {
+    title: 'Arguments',
+    description: 'Configure the function arguments to customize its behavior.',
+    options: ['Form', 'JSON'],
+    value: 'Form'
+  }
+};

--- a/storybook/src/stories/components/Splitter.stories.js
+++ b/storybook/src/stories/components/Splitter.stories.js
@@ -1,0 +1,177 @@
+import ResizableSplitter from '@/components/Splitter/ResizableSplitter.vue';
+
+export default {
+  title: 'Components/Splitter',
+  component: ResizableSplitter,
+  tags: ['autodocs'],
+  argTypes: {
+    panelSizes: {
+      control: 'object',
+      description: 'Initial sizes of the two panels as percentages [primary, secondary]'
+    },
+    direction: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Split direction: horizontal (top-bottom) or vertical (left-right)'
+    },
+    minSize: {
+      control: 'object',
+      description: 'Minimum sizes for each panel as percentages'
+    },
+    maxSize: {
+      control: 'object',
+      description: 'Maximum sizes for each panel as percentages'
+    },
+    initialTopPanelPercent: {
+      control: 'number',
+      description: 'Initial primary panel size as percentage'
+    },
+    initialTopPanelPixels: {
+      control: 'number',
+      description: 'Initial primary panel size in pixels (takes priority)'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'Advanced resizable splitter supporting both horizontal (top-bottom) and vertical (left-right) layouts. Users can drag the divider to resize panels with constraints support.'
+      }
+    }
+  }
+};
+
+export const Horizontal = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-blue-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Top Panel (Panel A)</h3>
+                <p class="text-sm text-gray-600">Horizontal layout - Drag divider below</p>
+              </div>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-green-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Bottom Panel (Panel B)</h3>
+                <p class="text-sm text-gray-600">Resizes when you drag</p>
+              </div>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    direction: 'horizontal',
+    panelSizes: [50, 50]
+  }
+};
+
+export const Vertical = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-purple-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Left Panel (Panel A)</h3>
+                <p class="text-sm text-gray-600">Vertical layout - Drag divider right</p>
+              </div>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-yellow-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Right Panel (Panel B)</h3>
+                <p class="text-sm text-gray-600">Resizes when you drag</p>
+              </div>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    direction: 'vertical',
+    panelSizes: [50, 50]
+  }
+};
+
+export const ConstrainedVertical = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-red-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Left Panel (25-75%)</h3>
+                <p class="text-sm text-gray-600">Constrained between 25% and 75%</p>
+              </div>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-blue-50 h-full flex items-center justify-center">
+              <div class="text-center">
+                <h3 class="font-semibold text-lg mb-2">Right Panel</h3>
+                <p class="text-sm text-gray-600">Try to drag beyond constraints</p>
+              </div>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    direction: 'vertical',
+    panelSizes: [50, 50],
+    minSize: [25, 25],
+    maxSize: [75, 75]
+  }
+};
+
+export const InitialSizePixels = {
+  render: (args) => ({
+    components: { ResizableSplitter },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="height: 400px; border: 1px solid #e5e7eb; border-radius: 4px;">
+        <ResizableSplitter v-bind="args">
+          <template #panel-a>
+            <div class="p-4 bg-orange-50 h-full flex items-center justify-center">
+              <h3 class="font-semibold text-lg">Left Panel - 200px Initial</h3>
+            </div>
+          </template>
+          <template #panel-b>
+            <div class="p-4 bg-teal-50 h-full flex items-center justify-center">
+              <h3 class="font-semibold text-lg">Right Panel - Remaining Space</h3>
+            </div>
+          </template>
+        </ResizableSplitter>
+      </div>
+    `
+  }),
+  args: {
+    direction: 'vertical',
+    initialTopPanelPixels: 200
+  }
+};

--- a/storybook/src/stories/components/TitleDescriptionArea.stories.js
+++ b/storybook/src/stories/components/TitleDescriptionArea.stories.js
@@ -1,0 +1,51 @@
+import TitleDescriptionArea from '@/components/title-description-area/titleDescriptionArea.vue';
+
+export default {
+  title: 'Components/TitleDescriptionArea',
+  component: TitleDescriptionArea,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'The title text to display'
+    },
+    description: {
+      control: 'text',
+      description: 'Optional description text that appears below the title'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A compound component that combines TitleText and DescriptionText components. Useful for creating consistent header sections with both title and optional descriptive text.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  args: {
+    title: 'Section Title',
+    description: 'This is a description that provides additional context about the section below.'
+  }
+};
+
+export const TitleOnly = {
+  args: {
+    title: 'Section Without Description'
+  }
+};
+
+export const LongTitleAndDescription = {
+  args: {
+    title: 'This is a Longer Section Title That Demonstrates Text Wrapping Behavior',
+    description: 'This is a longer description that provides comprehensive context about the section. It can span multiple lines and will wrap naturally according to the container width. The description helps users understand what they can expect to find in this section.'
+  }
+};
+
+export const MultiLineDescription = {
+  args: {
+    title: 'Multi-line Description',
+    description: 'First point about this section\nSecond point with additional details\nThird point for clarity'
+  }
+};

--- a/storybook/src/stories/components/TitleText.stories.js
+++ b/storybook/src/stories/components/TitleText.stories.js
@@ -1,0 +1,38 @@
+import TitleText from '@/components/title-text/titleText.vue';
+
+export default {
+  title: 'Components/TitleText',
+  component: TitleText,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'The title text to display'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A simple title component that displays text with consistent styling (text-xl font-medium). Use this component for section headings and titles throughout the application.'
+      }
+    }
+  }
+};
+
+export const Default = {
+  args: {
+    title: 'Section Title'
+  }
+};
+
+export const LongTitle = {
+  args: {
+    title: 'This is a very long title that demonstrates how the component handles extended text content'
+  }
+};
+
+export const ShortTitle = {
+  args: {
+    title: 'Title'
+  }
+};

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@aziontech/theme/-/theme-1.8.0.tgz#5bf7b156cafc6bee1a3687b72edddcbf7132c82c"
   integrity sha512-D058F22F1W8QCZ8AulpZaMrchze6Sus1AG3Cvh3vIUA6smtOe/m4J3T2HV3G5GgPHf70BGYbxeobysyBRaKU2g==
 
-"@aziontech/webkit@^1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@aziontech/webkit/-/webkit-1.19.0.tgz#c957cd60fe14aeb21bb68d1b69ab0b9f4175c0ae"
-  integrity sha512-EBSXeNiLzhWwfFw68P87jI13Qzu5kktXd9WWHfFsi5rbWdyfD0vDl33bpHOOlW4m/N55NZu7hCyq6t9iz9U1ig==
+"@aziontech/webkit@^1.19.1":
+  version "1.19.4"
+  resolved "https://registry.yarnpkg.com/@aziontech/webkit/-/webkit-1.19.4.tgz#57b327b63172556a2bdf43fd3706775fbce05c76"
+  integrity sha512-rG/Mn13m+UOpETRJQQyTdox2d/mNJQzlfO6Wx/GejNex/pChm3zlO07FtFuR/NzBvtBSaGrLESsGYODCOYfE2Q==
   dependencies:
     "@vueuse/core" "^10.11.1"
     motion-v "^2.1.0"
@@ -1381,9 +1381,9 @@ find-package-json@^1.2.0:
   integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
 
 follow-redirects@^1.0.0:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.5:
   version "0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5929,9 +5929,9 @@ flatted@^3.2.7, flatted@^3.2.9:
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -8574,9 +8574,9 @@ proto-list@~1.2.1:
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 protocol-buffers-schema@^3.3.1:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz"
-  integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz#fd9a58a5c4e96385b964808f3ddd58f9ef18c3c8"
+  integrity sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==
 
 proxy-from-env@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* feat: set max width add popup support for resource name columns (#3389)

Wrap Teleport components in v-if template for proper conditional rendering in popup components. Integrate text-format-with-popup column builder for resourceName and parentResourceName fields to display truncated text with popup overlay. Add column width constraints and use useDataTable composable for shared table functionality.

* fix: correct default page size to 50 and use store value

* refactor: migrate copy-block to @aziontech/webkit

- Replace local copy-block component with @aziontech/webkit/copy-block
- Update imports in 12 files across views and table columns
- Remove src/templates/copy-block/ directory

* [36882] refactor: remove clipboardWrite prop drilling and migrate to CopyBlock (#3416)

* refactor: remove clipboardWrite prop drilling and migrate to CopyBlock

Replace manual PrimeButton + clipboardWrite helper pattern with CopyBlock component from @aziontech/webkit across 45 files. Remove clipboardWrite prop declarations and prop drilling chains that spanned 3-4 levels of components. The only remaining usages are 2 direct imports where clipboard is used as a service callback (menu action and toast callback), not as a UI button.

* refactor(real-time-events): remove toast notification on copy and fix scroll behavior

* chore: bump version to 1.55.4

* [ENG-37079] feat: unify datatable components and remove legacy templates (#3424)

* refactor: migrate DataTable to webkit and consolidate column renderers (ENG-37079)

- migrate DataTable compound component to @aziontech/webkit/list-data-table
- consolidate 17 column renderers into 4 webkit cells (CellDisplay, CellClipboard, CellExpand, CountryFlag)
- move columns and dialog into src/components/list-table
- remove src/components/DataTable (re-export from webkit via index.js)
- remove src/templates/list-table-block (moved to list-table)
- update copy-block imports to button-copy
- fix cursor-pointer on rows without action
- fix CopyBlock click not navigating to edit
- fix actions in RulesEngine (unwrap computed refs)
- fix empty-results-block with illustration slot
- fix column selector deselect with dataKey
- fix CellExpand empty state with "-"
- fix icon-with-tooltip when vendorData is falsy
- fix EdgeStorage multiselect checkbox deselect
- fix EdgeStorage file list loading on page reload
- remove vertical scroll from tables
- remove Payment History filter
- add frozenColumns to Variables key column and Object Storage Buckets name column
- add .npmrc for registry resolution

* chore: bump @aziontech/webkit to 1.14.1

* [ENG-37137] feat: migrate primevue imports to webkit wrappers (#3436)

* refactor: migrate primevue imports to webkit wrappers (ENG-37137)

Replace all direct primevue/* component imports with @aziontech/webkit/* equivalents across 277 files.

Migrated components: accordion, accordion-tab, avatar, badge, breadcrumb, button, calendar, card, carousel, checkbox, chip, chips, column, datatable, dialog, divider, dropdown, inline-message, inputnumber, inputswitch, inputtext, listbox, menu, message, multiselect, overlaypanel, paginator, password, picklist, progressbar, progressspinner, radiobutton, selectbutton, sidebar, skeleton, splitbutton, steps, tabmenu, tabpanel, tabview, tag, textarea, timeline, toolbar.

Kept as primevue direct imports (no webkit wrapper): useToast, useDialog, Toast, DynamicDialog, ConfirmDialog, FilterMatchMode, primevue/api, primevue/config, primevue/icons/*.

* chore: bump @aziontech/webkit to ^1.16.0

* fix: add missing PrimeButton webkit import in copy dialogs

* chore: bump @aziontech/webkit to ^1.17.0

* feat: adding console storybook components  (#3442)

* feat: storybook

* chore: ErrorPageBlock storie adjust

* fix: flex tailwind apply

* fix: ErrorPageBlock.stories.js replacing primevue/button to @aziontech/webkit/button

* feat: storybook adding action-bar-block

* feat: storybook adding action-bar-block

* chore: storybook added templates/DialogUnsaved.stories.js

* fix: yarn format

* refactor: remove ConsoleFeedback from info-drawer-block

* chore: yarn format

* feat: adding claude skill

* feat: add skills/storybook-update-component

* fixing storybook items

* chore: storybook skills complete with inject dependencie

* fix: InfoBanner, MessageNotification stories

* chore: removed TemplateEngineBlock.stories.js - deprecated, WIP new template page

* feat: enabling storybook router mock

* chore: remove storie ActivityHistoryBlock, DEPRECATED

* chore: Basic Search Block

* chore: remove storie LoadingBlock due deprecated component

* chore: addint DialogOnboardingScheduling.stories

* fix: compilation and theme import updates

* chore: sort storybook templates

* chore: solving pull request conflict

* chore: solving pull request conflict

* chore: solving pull request conflict

* fix: yarn.lock pr conflict

* fix: yarn.lock pr conflict

* chore: fix layout of dialog-copy-key

* chore: adding storybook/yarn.lock

* fix: header-actions to info-drawer/empty-drawer and update the ui of realtime events

* chore: delete src/views/PersonalTokens/Dialog/CopyTokenDialog and replace to templates/dialog-copy-key (#3444)

* fix: inlinemessage export name (#3456)

* fix: inlinemessage exportname

* chore: replace inline-message to inlinemessage

* chore: fix tabview render

* chore: change project version

* feat: adding components folder to storybook (#3467)

* chore: backup before EdgeSQL migration fix - broken state

* feat: storybook folder components

* chore: remove wrong plan

* chore: storybook -- azion sync

* chore: azion cli config update

* chore: storybook azion config

* fix: active default rule

* fix: azion deploy configuration

* chore: adjust debug response rules description

* chore: update azion cli

* chore: adding azion defineConfig and remote prefix rotation

* feat: adding deploy-storybook.yml

* fix: remove pnpm

* chore: using working-directory

* chore: syntax and storybook yml adjust

* fix: path of trigger storybook pipeline

* chore: update storybook readme.md

* chore: unify package.json of storybook dependencies and devDependencies

* chore: adding license to storybook packagejson

* fix: storybook cicd install dependencies

* chore: trigger storybook deploy

* fix: unify packagejson

* fix: branch main to publish storybook modification

* chore: storybook depoloy during dev merge

* fix: persist monthly usage card column selections in local storage and improve label formatting (#3469)

* fix: persist monthly usage card column selections in local storage and improve label formatting

* fix: add console warning for local storage parsing errors in monthly usage card

* fix: refactor monthly usage card default selection logic and improve local storage handling

* fix: exclude /sse endpoint from security headers rules (#3468)

* fix: update security headers to exclude /sse endpoint from specific rules

* fix: simplify oauth security headers configuration by replacing criteria with match patterns

* fix: remove exclusion rule for /sse endpoint in cookie rewrite configuration

* [ENG-37033] refactor: rename fields from edgeFunctionsEvents to functionEvents (#3427)

* feat: rename fields from edgeFunctionsEvents to functionEvents

* feat: rename httpEvents to workload events and function events across services and tests

* SYNC (#3478)

* Deploy - 13/04/2026 (#3455)

* chore(deps): bump immutable from 4.3.7 to 4.3.8

Bumps [immutable](https://github.com/immutable-js/immutable-js) from 4.3.7 to 4.3.8.
- [Release notes](https://github.com/immutable-js/immutable-js/releases)
- [Changelog](https://github.com/immutable-js/immutable-js/blob/main/CHANGELOG.md)
- [Commits](https://github.com/immutable-js/immutable-js/compare/v4.3.7...v4.3.8)

---
updated-dependencies:
- dependency-name: immutable dependency-version: 4.3.8 dependency-type: indirect ...



* SYNC (#3379)

* fix: general fixex in new home dashboard (#3380)

- Add delete dialog integration for workloads, edge-dns, buckets, and functions in resources block
- Enable dismiss button for communications card
- Fix CustomPages key name to 'Custom Page' in activity routing maps
- Add gap and height styling to monthly usage skeleton blocks
- Fix routing links for object-storage and functions

* fix: hide home changelog component (#3381)

* fix: add domain validation for Let's Encrypt HTTP-01 certificate (#3378)

* fix: add domain validation for Let's Encrypt HTTP-01 certificate

* fix: add domain validation for Let's Encrypt HTTP-01 certificate

* fix: fix OOM crash and reduce memory pressure in query cache encryption (#3369)

* perf: fix oom crash and reduce memory pressure in query cache encryption

- fix uint8ArrayToBase64 O(n^2) string concatenation with 32KB chunking
- memoize getEncryptionKey to avoid 100k PBKDF2 iterations per encrypt call
- throttle persistClient writes to 2s to prevent write storm during prefetch
- replace uncontrolled Promise.allSettled batches with schedulePrefetch
- call resetCacheSync on switchAccount to stop background intervals

* perf(encryption): replace PBKDF2 key with non-extractable CryptoKey in IDB

- store non-extractable AES-GCM key in IndexedDB (extractable: false), key material is never exposed to JS or DevTools
- encrypt/decrypt payloads as ArrayBuffer instead of base64, eliminating all string conversion overhead
- fallback to ephemeral in-memory key if IDB is unavailable (private browsing, quota exceeded) — encryption still works within the session
- guard decryptSensitiveData to reject non-ArrayBuffer input, discarding legacy base64 entries from the old PBKDF2 format on first load
- guard filterNullValues to pass ArrayBuffer/TypedArray through unchanged instead of treating them as empty objects
- remove deriveKey, getEncryptionSecret, uint8ArrayToBase64, base64ToUint8Array

* style: fix prettier formatting on sessionManager.js

* fix: improve navigation performance and navbar UX (ENG-36926) (#3382)

- Optimize route guards: remove unnecessary async from billingGuard, cliGuard, and flagGuard; apply theme only once via module-level flag
- Decouple navbar visibility from loading state to prevent flash/collapse during route transitions
- Add responsive skeleton loading state to navbar for initial page load
- Fix profile menu not closing when clicking Personal Token/Your Settings

* feat: add routing support for dns zone and purge variants in activity history

* feat: add routing support for dns zone records

* fix: make resource labels domain-specific (#3383)

Replace generic 'Name' column headers with specific labels (Zone Name, Bucket Name, Function Name) for better clarity. Update empty state messages to use handleTextDomainWorkload helper for dynamic labeling based on domain context.

* fix: remove unecessary code - formfieldshome

* feat: set max width add popup support for resource name columns (#3389)

Wrap Teleport components in v-if template for proper conditional rendering in popup components. Integrate text-format-with-popup column builder for resourceName and parentResourceName fields to display truncated text with popup overlay. Add column width constraints and use useDataTable composable for shared table functionality.

* fix: cleanning FielText flex div to label and input align

* fix: fix navbar flash on navigation and workload protocol error (ENG-36926) (#3388)

- logoutGuard: only call startLoading for logout routes instead of every navigation, eliminating the navbar flash
- layout: use isBootstrapping computed (hasSession + route meta) to control navbar skeleton and footer visibility, replacing loading store
- layout: wrap router-view to prevent footer from sticking to header
- workload form: add optional chaining to protocols.http access

* [ENG-36889] feat: add skeleton loading states for cached edit views (#3387)

* feat: add skeleton loading states for cached edit views

Add EditViewSkeleton components for EdgeFirewall, EdgeServices, and WafRules edit views that use cached listing data without proper skeleton loading states during data fetch.

ENG-36889

* fix: only show navbar skeleton when navigating between authenticated routes

Prevents the navbar skeleton from flashing during login, MFA, additional-data, and other auth screens by checking that the user has an active session and is not coming from an auth route.

* fix: update sort and filter paths to use active field (#3392)

* chore: azion-theme to @aziontech/theme

* fix: upgrade theme version

* fix: theme version upgrade with fixed export

* chore: bump project version (#3397)

* refactor: migrate jsonform renderers to webkit components and fix prop typos

- rename fieldTextPassword to fieldPassword from @aziontech/webkit/field-password
- fix aditionalError typo to additionalError across all custom renderers
- replace inline Password component with FieldPasswordStrength from webkit
- update migration plan to reflect correct component names

* fix: refactoring error page to reusable ErrorPage.vue

* fix: webkit bump dep

* chore(deps): bump flatted from 3.3.3 to 3.4.2

Bumps [flatted](https://github.com/WebReflection/flatted) from 3.3.3 to 3.4.2.
- [Commits](https://github.com/WebReflection/flatted/compare/v3.3.3...v3.4.2)

---
updated-dependencies:
- dependency-name: flatted dependency-version: 3.4.2 dependency-type: indirect ...



* fix: errorpage buttons default props

* chore: country flag from webkit

* chore: remove flag.css

* chore: remove compare with azion, not used more 2 years

* chore: remove /views/Playground/PlaygroundView.vue

* [ENG-36879] feat: use webkit testimonials-carousel component (#3398)

* feat: replace local testimonials component with webkit testimonials-carousel

- Remove local client-testimonials-block.vue template
- Use @aziontech/webkit/testimonials-carousel component instead
- Move testimonials data to SignupView

* feat: bump @aziontech/webkit to ^1.6.0 for testimonials-carousel support

* chore: update yarn.lock for @aziontech/webkit ^1.6.0

* feat: bump @aziontech/webkit to ^1.7.1

* feat: rename table columns and update default values

* feat: hide parent resource columns in last activities block

* fix: extend date filter range from 1 to 2 years

* fix: correct default page size to 50 and use store value

* feat: change the page size from 200 to 100 (#3407)

* feat: add support for larger data volume units (#3393)

Extend data volume formatting to support petabytes, exabytes, zettabytes, and yottabytes. Use manual formatting for these larger units since Intl.NumberFormat does not support them natively.

* feat: include inactive certificates in mTLS filter (#3411)

Adds 'inactive' to the list of filtered status values in the mutual authentication settings, allowing users to select certificates with inactive status

* refactor: migrate copy-block to @aziontech/webkit

- Replace local copy-block component with @aziontech/webkit/copy-block
- Update imports in 12 files across views and table columns
- Remove src/templates/copy-block/ directory

* chore: bump version

* [ENG-36878] feat: migrate password fields to unified FieldPassword from webkit (#3415)

* feat: migrate password fields to unified FieldPassword from webkit

Replace all PrimeVue Password and FieldPasswordStrength usages with the unified FieldPassword component. Use showStrength prop and @strength emit for password validation in signup, reset-password, your-settings and sign-in.

* chore: bump version to 1.55.3

* [36882] refactor: remove clipboardWrite prop drilling and migrate to CopyBlock (#3416)

* refactor: remove clipboardWrite prop drilling and migrate to CopyBlock

Replace manual PrimeButton + clipboardWrite helper pattern with CopyBlock component from @aziontech/webkit across 45 files. Remove clipboardWrite prop declarations and prop drilling chains that spanned 3-4 levels of components. The only remaining usages are 2 direct imports where clipboard is used as a service callback (menu action and toast callback), not as a UI button.

* refactor(real-time-events): remove toast notification on copy and fix scroll behavior

* chore: bump version to 1.55.4

* chore: fix conflict

* fix: unify button action-bar-block

* chore: removing select theme from footer

* chore: yarn format

* chore: fix conflict

* fix: fix button contact sales size

* [ENG-37079] feat: unify datatable components and remove legacy templates (#3424)

* refactor: migrate DataTable to webkit and consolidate column renderers (ENG-37079)

- migrate DataTable compound component to @aziontech/webkit/list-data-table
- consolidate 17 column renderers into 4 webkit cells (CellDisplay, CellClipboard, CellExpand, CountryFlag)
- move columns and dialog into src/components/list-table
- remove src/components/DataTable (re-export from webkit via index.js)
- remove src/templates/list-table-block (moved to list-table)
- update copy-block imports to button-copy
- fix cursor-pointer on rows without action
- fix CopyBlock click not navigating to edit
- fix actions in RulesEngine (unwrap computed refs)
- fix empty-results-block with illustration slot
- fix column selector deselect with dataKey
- fix CellExpand empty state with "-"
- fix icon-with-tooltip when vendorData is falsy
- fix EdgeStorage multiselect checkbox deselect
- fix EdgeStorage file list loading on page reload
- remove vertical scroll from tables
- remove Payment History filter
- add frozenColumns to Variables key column and Object Storage Buckets name column
- add .npmrc for registry resolution

* chore: bump @aziontech/webkit to 1.14.1

* refactor: removing unused code

* chore: remove extra left padding classes in switch uses

* [ENG-37137] feat: migrate primevue imports to webkit wrappers (#3436)

* refactor: migrate primevue imports to webkit wrappers (ENG-37137)

Replace all direct primevue/* component imports with @aziontech/webkit/* equivalents across 277 files.

Migrated components: accordion, accordion-tab, avatar, badge, breadcrumb, button, calendar, card, carousel, checkbox, chip, chips, column, datatable, dialog, divider, dropdown, inline-message, inputnumber, inputswitch, inputtext, listbox, menu, message, multiselect, overlaypanel, paginator, password, picklist, progressbar, progressspinner, radiobutton, selectbutton, sidebar, skeleton, splitbutton, steps, tabmenu, tabpanel, tabview, tag, textarea, timeline, toolbar.

Kept as primevue direct imports (no webkit wrapper): useToast, useDialog, Toast, DynamicDialog, ConfirmDialog, FilterMatchMode, primevue/api, primevue/config, primevue/icons/*.

* chore: bump @aziontech/webkit to ^1.16.0

* fix: add missing PrimeButton webkit import in copy dialogs

* chore: bump @aziontech/webkit to ^1.17.0

* [ENG-37137] refactor: migrate all primevue imports to @aziontech/webkit (#3440)

* refactor: migrate all primevue imports to @aziontech/webkit (ENG-37137)

Replace all direct primevue imports with @aziontech/webkit equivalents across ~90 files. Use WebkitPlugin for centralized PrimeVue setup in main.js. Remove primevue from direct dependencies. Add webkitViteConfig for optimizeDeps. Replace ChevronRightIcon with pi icon class.

* chore: remove .npmrc from tracked files

* chore: revert yarn.lock changes

* chore: add .npmrc to gitignore

* chore: bump @aziontech/webkit to ^1.19.0

* feat: adding console storybook components  (#3442)

* feat: storybook

* chore: ErrorPageBlock storie adjust

* fix: flex tailwind apply

* fix: ErrorPageBlock.stories.js replacing primevue/button to @aziontech/webkit/button

* feat: storybook adding action-bar-block

* feat: storybook adding action-bar-block

* chore: storybook added templates/DialogUnsaved.stories.js

* fix: yarn format

* refactor: remove ConsoleFeedback from info-drawer-block

* chore: yarn format

* feat: adding claude skill

* feat: add skills/storybook-update-component

* fixing storybook items

* chore: storybook skills complete with inject dependencie

* fix: InfoBanner, MessageNotification stories

* chore: removed TemplateEngineBlock.stories.js - deprecated, WIP new template page

* feat: enabling storybook router mock

* chore: remove storie ActivityHistoryBlock, DEPRECATED

* chore: Basic Search Block

* chore: remove storie LoadingBlock due deprecated component

* chore: addint DialogOnboardingScheduling.stories

* fix: compilation and theme import updates

* chore: sort storybook templates

* chore: solving pull request conflict

* chore: solving pull request conflict

* chore: solving pull request conflict

* fix: yarn.lock pr conflict

* fix: yarn.lock pr conflict

* chore: fix layout of dialog-copy-key

* chore: adding storybook/yarn.lock

* fix: header-actions to info-drawer/empty-drawer and update the ui of realtime events

* chore(deps): bump lodash from 4.17.23 to 4.18.1 (#3439)

Bumps [lodash](https://github.com/lodash/lodash) from 4.17.23 to 4.18.1.
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.23...4.18.1)

---
updated-dependencies:
- dependency-name: lodash dependency-version: 4.18.1 dependency-type: indirect ...




* chore(deps): bump lodash-es from 4.17.23 to 4.18.1 (#3438)

Bumps [lodash-es](https://github.com/lodash/lodash) from 4.17.23 to 4.18.1.
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.23...4.18.1)

---
updated-dependencies:
- dependency-name: lodash-es dependency-version: 4.18.1 dependency-type: indirect ...




* chore: delete src/views/PersonalTokens/Dialog/CopyTokenDialog and replace to templates/dialog-copy-key (#3444)

* feat: add theme (#3418)

* feat: add theme

* fix: fix imports

* chore: adjust storybook details (#3448)

* chore(deps-dev): bump vite from 6.4.1 to 6.4.2 in /storybook (#3446)

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.4.1 to 6.4.2.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/v6.4.2/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.4.2/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 6.4.2 dependency-type: direct:development ...




* fix: theme test (#3453)

* fix: adjust column widths on last activities home and surface tokens on home blocks (#3452)

* fix: column size activity home

* fix: temporary fixes surfaces at home

* fix: rename API field and improve domain error styling (#3449)

* fix: inlinemessage export name (#3456)

* fix: inlinemessage exportname

* chore: replace inline-message to inlinemessage

* chore: fix tabview render

* chore: storybook azion deploy, replace Dialog/CopyTokenDialog.vue to templates/dialog-copy-key (#3450)

* chore: delete src/views/PersonalTokens/Dialog/CopyTokenDialog and replace to templates/dialog-copy-key

* feat: storybook azion deploy

* fix: storybook npm script

* chore: storybook final azion config

* fix: replace @aziontech/webkit/accordion to primevue/accordion (#3458)

* fix: rules engine #groupheader="slotProps" (#3459)

* fix: correct variable reference in onRowEditCancel (#3460)

* chore: @aziontech/webkit bump version (#3461)

* chore(deps): bump axios from 1.13.6 to 1.15.0 (#3462)

Bumps [axios](https://github.com/axios/axios) from 1.13.6 to 1.15.0.
- [Release notes](https://github.com/axios/axios/releases)
- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v1.13.6...v1.15.0)

---
updated-dependencies:
- dependency-name: axios dependency-version: 1.15.0 dependency-type: direct:production ...




* fix: fix sync main (#3464)

* fix: fix sync main

* fix: reorder import statements in sessionManager.js

* SYNC Main (#3463)

* feat: update product names and metric slugs mappings

* feat: update metric slugs to use separate unit property

* chore: change project version

* feat: implement SSE client and related cache synchronization features (#3457)

- Add useSSE composable for managing SSE connection state in Vue components.
- Introduce CacheInvalidator class to handle cache invalidation based on SSE activity events.
- Create PrefetchExecutor to manage prefetching of stale queries.
- Implement PrefetchScheduler for aggregating prefetch operations within a fixed time window.
- Develop Prefetch Query Function Registry to map query key patterns to their fetch functions.
- Register various query functions for prefetching across different services.
- Add SSEClient class for managing SSE connections with automatic reconnection and event handling.
- Establish a structured approach for handling server and network errors during SSE communication.

---------




* fix: user-flag  add null safety checks to prevent TypeError (#3465)

* chore: change project version

* chore(deps-dev): bump vite from 5.4.21 to 6.4.2 (#3451)

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 5.4.21 to 6.4.2.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/v6.4.2/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.4.2/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 6.4.2 dependency-type: direct:development ...




---------











* hotfix: EmptyResults miss create click (#3472)

* refactor: replace EmptyResultsBlock  webkit usage
- Replace from templates to webkit usage
- createPagePath replaced to the usage of click-to-create event to router.push

* fix: replace createPagePath to click event

* fix: param removed createPagePath of ListTable

* chore: remove createPagePath of ListTable

* chore: backup before EdgeSQL migration fix - broken state

* chore: remove EdgeSQL_*.md files

---------











* chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 (#3473)

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.11 to 1.16.0.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.11...v1.16.0)

---
updated-dependencies:
- dependency-name: follow-redirects dependency-version: 1.16.0 dependency-type: indirect ...




* chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 in /storybook (#3480)

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.11 to 1.16.0.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.11...v1.16.0)

---
updated-dependencies:
- dependency-name: follow-redirects dependency-version: 1.16.0 dependency-type: indirect ...




* chore: backup before EdgeSQL migration fix - broken state

* chore: fix merge

* chore: remove files

* chore: remove EmptyResultsBlock.stories.js

* chore(deps): bump protocol-buffers-schema from 3.6.0 to 3.6.1 (#3484)

Bumps [protocol-buffers-schema](https://github.com/mafintosh/protocol-buffers-schema) from 3.6.0 to 3.6.1.
- [Commits](https://github.com/mafintosh/protocol-buffers-schema/compare/v3.6.0...v3.6.1)

---
updated-dependencies:
- dependency-name: protocol-buffers-schema dependency-version: 3.6.1 dependency-type: indirect ...




---------

## Change the tab to `preview mode` and select the template to your PR


| Type of PR                       | Template                        |
|:---------------------------------|:-------------------------------:|
| Feature, refactoring, tests, etc | [Default](?template=default.md) |
| Bug fix                           | [Bug](?template=bug.md)         |
| Deploy                           | [Deploy](?template=deploy.md)   |

[ENG-37079]: https://aziontech.atlassian.net/browse/ENG-37079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ