### PR TITLE
[ENG-36942] fix: update edge storage cache invalidation and bucket fallback

### DIFF
--- a/src/services/v2/edge-storage/edge-storage-service.js
+++ b/src/services/v2/edge-storage/edge-storage-service.js
@@ -67,7 +67,7 @@ export class EdgeStorageService extends BaseService {
       body
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.buckets.all() })
+    this.queryClient.invalidateQueries({ queryKey: queryKeys.edgeStorage.buckets.all() })
 
     return data
   }
@@ -99,7 +99,23 @@ export class EdgeStorageService extends BaseService {
       body: { workloads_access: bucket.workloads_access }
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.buckets.all() })
+    // Update cache with new value from API response
+    this.queryClient.setQueriesData({ queryKey: queryKeys.edgeStorage.buckets.all() }, (cached) => {
+      if (!cached?.body) return cached
+      return {
+        ...cached,
+        body: cached.body.map((cachedBucket) =>
+          cachedBucket.name === bucket.name
+            ? { ...cachedBucket, workloadsAccess: bucket.workloads_access }
+            : cachedBucket
+        )
+      }
+    })
+
+    // Invalidate to trigger refetch if needed
+    this.queryClient.invalidateQueries({
+      queryKey: queryKeys.edgeStorage.buckets.all()
+    })
 
     return data
   }
@@ -110,7 +126,7 @@ export class EdgeStorageService extends BaseService {
       url: `${this.baseURL}/buckets/${bucketName}`
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.buckets.all() })
+    await this.queryClient.invalidateQueries({ queryKey: queryKeys.edgeStorage.buckets.all() })
 
     return `Bucket "${bucketName}" has been deleted successfully`
   }
@@ -384,6 +400,15 @@ export class EdgeStorageService extends BaseService {
       { persist: firstPage && !skipCache, skipCache }
     )
   }
+
+  getBucketFromCache = (bucketName) => {
+    return super.getFromCache({
+      queryKey: queryKeys.edgeStorage.buckets.all(),
+      id: bucketName,
+      fieldName: 'name',
+      listPath: 'body'
+    })
+  }
   createCredential = async (credential = {}) => {
     const body = this.adapter?.transformCreateEdgeStorageCredential?.(credential)
     const { data } = await this.http.request({
@@ -392,7 +417,7 @@ export class EdgeStorageService extends BaseService {
       body
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
+    this.queryClient.invalidateQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
 
     return data
   }
@@ -402,7 +427,7 @@ export class EdgeStorageService extends BaseService {
       url: `${this.baseURL}/credentials/${credentialId}`
     })
 
-    this.queryClient.removeQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
+    this.queryClient.invalidateQueries({ queryKey: queryKeys.edgeStorage.credentials.all() })
   }
 }
 export const edgeStorageService = new EdgeStorageService()

--- a/src/views/EdgeStorage/ListView.vue
+++ b/src/views/EdgeStorage/ListView.vue
@@ -583,11 +583,11 @@
   })
 
   const totalRecords = computed(() => {
-    return fileData.value.length
+    return fileData.value?.length
   })
 
   const filterData = computed(() => {
-    let filteredData = fileData.value.filter((item) => {
+    let filteredData = fileData.value?.filter((item) => {
       return item.name.toLowerCase().includes(fileSearchTerm.value.toLowerCase())
     })
 

--- a/src/views/EdgeStorage/View.vue
+++ b/src/views/EdgeStorage/View.vue
@@ -135,6 +135,13 @@
   }
 
   const loadService = ({ id }) => {
+    const cachedBucket = edgeStorageService.getBucketFromCache(id)
+    if (cachedBucket) {
+      return {
+        name: cachedBucket.name,
+        workloads_access: cachedBucket.workloadsAccess
+      }
+    }
     const bucket = findBucketById(id)
 
     return {


### PR DESCRIPTION
## Bug fix

### What was the problem?

After edge storage mutations, cached bucket and credential queries were removed instead of being invalidated, causing stale UI states and making bucket detail loading fragile when list data was still available only in cache.

### Expected behavior

Edge storage lists and details should stay consistent after create/update/delete actions, with cache updates and proper refetch behavior without breaking UI rendering.

### How was it solved

Replaced query removals with query invalidation for buckets and credentials, added optimistic cache update for bucket workloads access, introduced cache fallback in bucket detail loading (`getBucketFromCache`), and added null-safe handling in file list computed properties to avoid runtime failures.

### How to test

1. Open Edge Storage list and update a bucket workload access value.
2. Confirm the updated value is reflected and list/detail remains consistent.
3. Create and delete buckets/credentials and confirm data refreshes correctly.
4. Open a bucket detail page after list navigation and confirm it loads correctly using cached data when applicable.
5. Check file search/list rendering with empty or not-yet-loaded file data.