### PR TITLE
[NO-ISSSUE] fix: difference between linked packaged durig dev or preview compilation

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,1 +1,0 @@
-import '@aziontech/theme'

--- a/vite.config.js
+++ b/vite.config.js
@@ -63,6 +63,7 @@ const getConfig = () => {
     optimizeDeps: webkitViteConfig.optimizeDeps,
     resolve: {
       preserveSymlinks: true, // Vite doesn't follow the symlink (@aziontech/icons in dev mode)
+      dedupe: ['vee-validate', 'vue'],
       extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
# fix: difference between linked packaged durig dev or preview compilation

Added `resolve.dedupe: ['vee-validate', 'vue']` to force Vite to use a single instance of these packages across the main app and the linked webkit package.

##  Why This Fixes It

  - **resolve.dedupe:** Forces Vite to deduplicate these dependencies, ensuring only one instance exists even when yarn
  link creates separate node_modules
  
 > https://vite.dev/config/shared-options#resolve-dedupe