### PR TITLE
 [MM-15386] refactor: prevent undefined/null values in analytics events

### DIFF
--- a/src/plugins/analytics/AnalyticsTrackerAdapter.js
+++ b/src/plugins/analytics/AnalyticsTrackerAdapter.js
@@ -6,6 +6,7 @@ import {
   WafRulesTracker,
   RealTimeMetricsTracker
 } from './trackers'
+import { cleanObject } from '../../utils/cleanObject.js'
 
 /**
  * @typedef {Object} TrackerEvent
@@ -16,29 +17,6 @@ import {
 /**
  * @typedef {'Edge Application'|'Origins'|'Domains'|'Edge Functions'} AzionProductsNames
  */
-
-/**
- * Recursively removes undefined, null, and empty string values from an object
- * @param {Object} obj - The object to clean
- * @returns {Object} - Cleaned object with only valid values
- */
-function cleanObject(obj) {
-  if (!obj || typeof obj !== 'object') return {}
-  return Object.fromEntries(
-    Object.entries(obj)
-      .filter(([, value]) => {
-        if (value === undefined || value === null) return false
-        if (typeof value === 'string' && value.trim() === '') return false
-        return true
-      })
-      .map(([key, value]) => {
-        if (typeof value === 'object' && !Array.isArray(value)) {
-          return [key, cleanObject(value)]
-        }
-        return [key, value]
-      })
-  )
-}
 
 export class AnalyticsTrackerAdapter {
   /** @type {TrackerEvent[]} */

--- a/src/plugins/analytics/AnalyticsTrackerAdapter.js
+++ b/src/plugins/analytics/AnalyticsTrackerAdapter.js
@@ -18,18 +18,25 @@ import {
  */
 
 /**
- * Removes undefined, null, and empty string values from an object
+ * Recursively removes undefined, null, and empty string values from an object
  * @param {Object} obj - The object to clean
  * @returns {Object} - Cleaned object with only valid values
  */
 function cleanObject(obj) {
   if (!obj || typeof obj !== 'object') return {}
   return Object.fromEntries(
-    Object.entries(obj).filter(([, value]) => {
-      if (value === undefined || value === null) return false
-      if (typeof value === 'string' && value.trim() === '') return false
-      return true
-    })
+    Object.entries(obj)
+      .filter(([, value]) => {
+        if (value === undefined || value === null) return false
+        if (typeof value === 'string' && value.trim() === '') return false
+        return true
+      })
+      .map(([key, value]) => {
+        if (typeof value === 'object' && !Array.isArray(value)) {
+          return [key, cleanObject(value)]
+        }
+        return [key, value]
+      })
   )
 }
 
@@ -90,8 +97,7 @@ export class AnalyticsTrackerAdapter {
     if (!this.#hasAnalytics()) return
     this.#events.forEach(async (action) => {
       const { eventName, props } = action
-      const cleanedProps = cleanObject({ ...props, application: 'console-kit' })
-      const propsWithTraits = cleanObject({ ...cleanedProps, ...this.#traits })
+      const propsWithTraits = cleanObject({ ...props, ...this.#traits, application: 'console-kit' })
       await this.#analyticsClient.track(eventName, propsWithTraits)
     })
     this.#events = []
@@ -104,7 +110,7 @@ export class AnalyticsTrackerAdapter {
    * @return {Promise<void>}
    */
   async identify(id) {
-    if (!id || !this.#hasAnalytics()) return
+    if (id === undefined || id === null || id === '' || !this.#hasAnalytics()) return
 
     const cleanedTraits = cleanObject(this.#traits)
     await this.#analyticsClient.identify(String(id), cleanedTraits)

--- a/src/plugins/analytics/AnalyticsTrackerAdapter.js
+++ b/src/plugins/analytics/AnalyticsTrackerAdapter.js
@@ -17,6 +17,22 @@ import {
  * @typedef {'Edge Application'|'Origins'|'Domains'|'Edge Functions'} AzionProductsNames
  */
 
+/**
+ * Removes undefined, null, and empty string values from an object
+ * @param {Object} obj - The object to clean
+ * @returns {Object} - Cleaned object with only valid values
+ */
+function cleanObject(obj) {
+  if (!obj || typeof obj !== 'object') return {}
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => {
+      if (value === undefined || value === null) return false
+      if (typeof value === 'string' && value.trim() === '') return false
+      return true
+    })
+  )
+}
+
 export class AnalyticsTrackerAdapter {
   /** @type {TrackerEvent[]} */
   #events = []
@@ -74,8 +90,8 @@ export class AnalyticsTrackerAdapter {
     if (!this.#hasAnalytics()) return
     this.#events.forEach(async (action) => {
       const { eventName, props } = action
-      props.application = 'console-kit'
-      const propsWithTraits = { ...props, ...this.#traits }
+      const cleanedProps = cleanObject({ ...props, application: 'console-kit' })
+      const propsWithTraits = cleanObject({ ...cleanedProps, ...this.#traits })
       await this.#analyticsClient.track(eventName, propsWithTraits)
     })
     this.#events = []
@@ -88,10 +104,10 @@ export class AnalyticsTrackerAdapter {
    * @return {Promise<void>}
    */
   async identify(id) {
-    const userId = `${id}`
-    if (!userId || !this.#hasAnalytics()) return
+    if (!id || !this.#hasAnalytics()) return
 
-    await this.#analyticsClient.identify(userId, this.#traits)
+    const cleanedTraits = cleanObject(this.#traits)
+    await this.#analyticsClient.identify(String(id), cleanedTraits)
   }
 
   /**
@@ -111,10 +127,10 @@ export class AnalyticsTrackerAdapter {
    */
   assignGroupTraits(traitsToAssign) {
     if (!this.#hasAnalytics()) return
-    if (!traitsToAssign) {
+    if (!traitsToAssign || typeof traitsToAssign !== 'object') {
       throw new Error('Invalid traits provided')
     }
-    this.#traits = { ...traitsToAssign }
+    this.#traits = cleanObject(traitsToAssign)
   }
 
   /**

--- a/src/utils/cleanObject.js
+++ b/src/utils/cleanObject.js
@@ -1,0 +1,22 @@
+/**
+ * Recursively removes undefined, null, and empty string values from an object
+ * @param {Object} obj - The object to clean
+ * @returns {Object} - Cleaned object with only valid values
+ */
+export function cleanObject(obj) {
+  if (!obj || typeof obj !== 'object') return {}
+  return Object.fromEntries(
+    Object.entries(obj)
+      .filter(([, value]) => {
+        if (value === undefined || value === null) return false
+        if (typeof value === 'string' && value.trim() === '') return false
+        return true
+      })
+      .map(([key, value]) => {
+        if (typeof value === 'object' && !Array.isArray(value)) {
+          return [key, cleanObject(value)]
+        }
+        return [key, value]
+      })
+  )
+}


### PR DESCRIPTION
 ## Feature      
  MM-15386 refactor: prevent undefined/null values in analytics events
                                                                                          
  ## Description
  - Added `cleanObject()` utility that recursively removes `undefined`, `null`, and empty 
  string values from objects (including nested ones)                                    
  - Fixed `identify()` method that was converting `undefined` to string `"undefined"`
  before validation
  - Fixed `identify()` to accept `0` as a valid ID (was rejected by `!id` check)
  - Ensured `application: 'console-kit'` is not overwritten by traits in `track()` method
  - Extracted `cleanObject` function to `src/utils/cleanObject.js` for reusability across
  the codebase

  ## How to test
  1. Trigger analytics events with missing or invalid data (undefined, null, empty
  strings)
  2. Verify that no event is sent with `"userId": "undefined"` or similar invalid values
  3. Test `identify(0)` to ensure it correctly identifies user with ID 0
  4. Check that nested objects like `{ user: { id: undefined } }` are properly cleaned

  ## UI Changes (if applicable)
  N/A - Internal analytics tracking fix