### PR TITLE
[ENG-37350] fix: skeleton and form overlap on edit views

### DIFF
--- a/src/views/Workload/EditView.vue
+++ b/src/views/Workload/EditView.vue
@@ -18,11 +18,15 @@
         @on-edit-fail="handleTrackFailEditEvent"
       >
         <template #form="{ loading }">
-          <FormSkeleton v-if="loading" />
-          <FormFieldsWorkload
-            v-show="!loading"
-            isEdit
-          />
+          <div class="relative flex flex-col gap-8 max-md:gap-6">
+            <FormFieldsWorkload isEdit />
+            <div
+              v-if="loading"
+              class="absolute inset-0 z-10 bg-[var(--surface-ground)]"
+            >
+              <FormSkeleton />
+            </div>
+          </div>
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/YourSettings/EditView.vue
+++ b/src/views/YourSettings/EditView.vue
@@ -18,13 +18,19 @@
         @loaded-service-object="isFormLoading = false"
       >
         <template #form="{ loading }">
-          <FormSkeleton v-if="loading || isFormLoading" />
-          <FormFieldsYourSettings
-            v-show="!loading && !isFormLoading"
-            :timezoneOptions="optionsTimezone"
-            :listCountriesPhoneService="listCountriesPhoneService"
-            @password-strength="onPasswordStrengthChange"
-          />
+          <div class="relative flex flex-col gap-8 max-md:gap-6">
+            <FormFieldsYourSettings
+              :timezoneOptions="optionsTimezone"
+              :listCountriesPhoneService="listCountriesPhoneService"
+              @password-strength="onPasswordStrengthChange"
+            />
+            <div
+              v-if="loading || isFormLoading"
+              class="absolute inset-0 z-10 bg-[var(--surface-ground)]"
+            >
+              <FormSkeleton />
+            </div>
+          </div>
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading, values }">
           <ActionBarBlockWithTeleport


### PR DESCRIPTION
## Summary
- Fixed a bug where the real form became visible under the loading skeleton on the Workload and Your Settings edit views, creating a visual overlap (the user could see the form by scrolling while the skeleton was still shown).

## Root cause
`FormFieldsWorkload` and `FormFieldsYourSettings` are fragment components (multiple root elements in their `<template>`). In Vue 3, `v-show` does not propagate to components with multiple root nodes, so the `v-show="!loading"` used to hide the form during loading had no effect, and the form rendered as its async children (dropdowns, etc.) mounted.

## Changes
- `src/views/Workload/EditView.vue`: adopt the overlay pattern from `Domains/EditView.vue` — always render the form and overlay the skeleton absolutely (`absolute inset-0 z-10`) while loading.
- `src/views/YourSettings/EditView.vue`: same fix, preserving the existing `isFormLoading` condition.

## Test plan
- [ ] Workload edit view: skeleton visible during load, no form visible below when scrolling
- [ ] Your Settings edit view: same behavior
- [ ] Throttle network (Slow 3G) to validate the loading transition
- [ ] Confirm form data loads correctly and unsaved-changes detection still works
- [ ] Submit edits on both views and verify the flow remains unchanged