### PR TITLE
fix: exibir botao para adicionar mfa na tela de gerenciamento

### DIFF
--- a/src/templates/mfa-setup-block/index.vue
+++ b/src/templates/mfa-setup-block/index.vue
@@ -33,11 +33,11 @@
         <!-- QR Code -->
         <div class="flex flex-wrap justify-center items-center">
           <Skeleton
-            v-show="!qrCode.url"
+            v-if="!qrCode.url"
             class="w-[10rem] h-[10rem] sm:w-[12.5rem] sm:h-[12.5rem]"
           />
           <QrcodeVue
-            v-show="qrCode.url"
+            v-else-if="qrCode.url"
             :value="qrCode?.url"
             level="H"
             :size="250"

--- a/src/views/MFAManagement/ListView.vue
+++ b/src/views/MFAManagement/ListView.vue
@@ -4,9 +4,11 @@
   import EmptyResultsBlock from '@aziontech/webkit/empty-results-block'
   import Illustration from '@/assets/svg/illustration-layers.vue'
   import { columnBuilder } from '@/components/list-table/columns/column-builder'
+  import { DataTableActionsButtons } from '@/components/list-table'
   import { computed, ref } from 'vue'
   import ListTable from '@/components/list-table'
   import { mfaService } from '@/services/v2/mfa/mfa-service'
+  import { useRouter } from 'vue-router'
 
   const props = defineProps({
     documentationService: {
@@ -19,6 +21,7 @@
 
   const hasContentToList = ref(true)
   const listTableRef = ref()
+  const router = useRouter()
 
   const actions = [
     {
@@ -74,6 +77,10 @@
   const handleLoadData = (event) => {
     hasContentToList.value = event
   }
+
+  const handleNavigateToCreate = () => {
+    router.push('/mfa/setup')
+  }
 </script>
 
 <template>
@@ -82,7 +89,16 @@
       <PageHeadingBlock
         pageTitle="Multi-Factor Authentication Management"
         description="Define and manage multi-factor authentication settings for account security."
-      />
+      >
+        <template #default>
+          <DataTableActionsButtons
+            size="small"
+            label="MFA"
+            createPagePath="/mfa/setup"
+            data-testid="create_MFA_button"
+          />
+        </template>
+      </PageHeadingBlock>
     </template>
     <template #content>
       <ListTable
@@ -103,6 +119,8 @@
         v-else
         title="No MFA configurations yet"
         description="Create your first MFA configuration to enhance account security."
+        createButtonLabel="MFA"
+        @click-to-create="handleNavigateToCreate"
         :documentationService="props.documentationService"
       >
         <template #illustration>


### PR DESCRIPTION
## Bug fix

### What was the problem?

Na tela de gerenciamento de MFA (`src/views/MFAManagement/ListView.vue`), o botão para adicionar/criar MFA não estava sendo exibido, impedindo o acesso direto ao fluxo de criação pela interface da listagem e pelo estado vazio.

### Expected behavior

A tela deve exibir o botão de criação de MFA no header da página e também no estado sem resultados, permitindo navegação para a tela de setup (`/mfa/setup`).

### How was it solved

A view de gerenciamento de MFA foi alinhada ao padrão das outras listagens:
- inclusão do `DataTableActionsButtons` no `PageHeadingBlock` com `createPagePath="/mfa/setup"`;
- adição de `createButtonLabel` e evento `@click-to-create` no `EmptyResultsBlock`;
- criação do handler de navegação com `router.push('/mfa/setup')`.

Também foi ajustado o comportamento de renderização do QR code em `src/templates/mfa-setup-block/index.vue` para evitar inconsistência visual durante carregamento.

### How to test

1. Acesse `/mfa-management`.
2. Verifique se o botão **MFA** aparece no topo da página.
3. Clique no botão e confirme navegação para `/mfa/setup`.
4. Em cenário sem itens na listagem, valide que o estado vazio também exibe o botão de criação.
5. Clique no botão do estado vazio e confirme navegação para `/mfa/setup`.