### PR TITLE
[ENG-37265] refactor: remove vertical scroll from listing tables

### DIFF
--- a/src/components/list-table/ListTable.vue
+++ b/src/components/list-table/ListTable.vue
@@ -149,9 +149,6 @@
       type: String,
       default: ''
     },
-    scrollHeight: {
-      type: String
-    },
     /**
      * When set, renders a single inline action button per row instead of the ellipsis menu.
      * Accepts an object: { icon: 'pi pi-trash', label: 'Delete', command: fn(rowData), disabled: boolean|fn(rowData) }
@@ -324,7 +321,6 @@
       v-model:sortField="sortFieldValue"
       v-model:sortOrder="sortOrderValue"
       :rowsPerPageOptions="rowsPerPageOptions"
-      :scrollHeight="scrollHeight"
       :reorderableRows="reorderableRows"
       :emptyListMessage="emptyListMessage"
       :emptyBlock="emptyBlock"

--- a/src/components/list-table/ListTableGraphic.vue
+++ b/src/components/list-table/ListTableGraphic.vue
@@ -22,7 +22,7 @@
     },
     scrollHeight: {
       type: String,
-      default: undefined
+      default: ''
     }
   })
 </script>

--- a/src/components/list-table/ListTableGraphic.vue
+++ b/src/components/list-table/ListTableGraphic.vue
@@ -19,6 +19,10 @@
     emptyListMessage: {
       type: String,
       default: 'No registers found.'
+    },
+    scrollHeight: {
+      type: String,
+      default: undefined
     }
   })
 </script>
@@ -33,6 +37,8 @@
       :data="data"
       :paginator="false"
       :columns="columns"
+      :scrollable="!!scrollHeight"
+      :scrollHeight="scrollHeight"
       :emptyListMessage="emptyListMessage"
       :rowHover="false"
       :resizableColumns="false"

--- a/src/components/list-table/ListTableGraphic.vue
+++ b/src/components/list-table/ListTableGraphic.vue
@@ -19,9 +19,6 @@
     emptyListMessage: {
       type: String,
       default: 'No registers found.'
-    },
-    scrollHeight: {
-      type: String
     }
   })
 </script>
@@ -36,7 +33,6 @@
       :data="data"
       :paginator="false"
       :columns="columns"
-      :scrollHeight="scrollHeight"
       :emptyListMessage="emptyListMessage"
       :rowHover="false"
       :resizableColumns="false"

--- a/src/components/list-table/ListTableSimple.vue
+++ b/src/components/list-table/ListTableSimple.vue
@@ -75,7 +75,6 @@
       :columns="columns"
       :dataKey="dataKey"
       :emptyBlock="emptyBlock"
-      scrollHeight="auto"
       class="w-full overflow-hidden"
       :resizableColumns="false"
       :pt="{

--- a/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
+++ b/src/views/RealTimeEvents/Blocks/tab-panel-block.vue
@@ -247,7 +247,6 @@
         <DataTable
           ref="dataTableRef"
           class="overflow-clip rounded-md"
-          scrollable
           removableSort
           :data="data"
           :columns="selectedColumns"
@@ -264,7 +263,6 @@
           :exportFunction="exportFunctionMapper"
           :loading="isLoading"
           :notShowEmptyBlock="true"
-          scrollHeight="auto"
           :pt="{ bodyRow: { 'data-testid': 'table-body-row' } }"
           data-testid="table-tab-panel-block"
           :first="firstItemIndex"


### PR DESCRIPTION
## Summary
- Remove `scrollHeight` from console-kit listing-table wrappers (`ListTable`, `ListTableSimple`) so listing tables grow with content and the page handles scroll.
- Remove `scrollable` and `scrollHeight="auto"` from `RealTimeEvents/tab-panel-block.vue`, where they produced an actual internal scroll.
- Keep `scrollHeight` on `ListTableGraphic` (chart widget needs internal scroll), but normalize its default to `''` for consistency with `type: String`.
- Special cases preserved by design: EdgeSQL (`TablesView.vue`, `CodeEditor.vue`) and the fixed-height widget `templates/graphs-card-block/components/chart/list-chart.vue`.

## Root cause
Default `scrollable: true` and `scrollHeight: 'calc(100vh - 300px)'` in the webkit base table, plus several call sites passing `scrollHeight`, created internal vertical scroll on listing tables instead of letting the page scroll.

## Changes
- `src/components/list-table/ListTable.vue` — remove `scrollHeight` prop and binding
- `src/components/list-table/ListTableSimple.vue` — remove `scrollHeight="auto"`
- `src/components/list-table/ListTableGraphic.vue` — keep `scrollHeight` prop (chart widget), default `''`
- `src/views/RealTimeEvents/Blocks/tab-panel-block.vue` — remove `scrollable` and `scrollHeight="auto"`

> Companion change in webkit: aziontech/webkit#541. Once published and bumped here, the new defaults (`scrollable: false`, `scrollHeight: ''`) will apply across all consumers.

## Test plan
- [ ] `RealTimeEvents` — tab-panel table grows with the page; no internal scroll.
- [ ] Listing pages (Edge Applications, Domains, Workloads, etc.) — page scrolls instead of the table.
- [ ] Regression — EdgeSQL `TablesView`/`CodeEditor` split editor still scrolls internally.
- [ ] Regression — `list-chart` graph widget still respects its 375px height with internal scroll.
- [ ] `yarn test` and `yarn lint` pass.