### PR TITLE
Deploy - 08/05/2026

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azion-console-kit",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "private": false,
   "type": "module",
   "repository": {

--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -172,7 +172,9 @@ const METRIC_SLUGS = {
   waf_requests: { title: 'WAF - Requests' },
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
-  workload_workloads: { title: 'Workload - Workloads', unit: 'Unit' }
+  workload_workloads: { title: 'Workload - Workloads', unit: 'Unit' },
+  workload_requests: { title: 'Workload - Requests', unit: 'Unit'},
+  application_requets: { title: 'Application Requests', unit: 'Unit'}
 }
 
 const mapProducts = (productsGrouped, productsGroupedByRegion) => {

--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -173,8 +173,8 @@ const METRIC_SLUGS = {
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
   workload_workloads: { title: 'Workload - Workloads' },
-  workload_requests: { title: 'Workload - Requests'  },
-  application_requets: { title: 'Application Requests'  }
+  workload_requests: { title: 'Workload - Requests' },
+  application_requets: { title: 'Application Requests' }
 }
 
 const mapProducts = (productsGrouped, productsGroupedByRegion) => {

--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -172,9 +172,9 @@ const METRIC_SLUGS = {
   waf_requests: { title: 'WAF - Requests' },
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
-  workload_workloads: { title: 'Workload - Workloads', unit: 'Unit' },
-  workload_requests: { title: 'Workload - Requests', unit: 'Unit' },
-  application_requets: { title: 'Application Requests', unit: 'Unit' }
+  workload_workloads: { title: 'Workload - Workloads' },
+  workload_requests: { title: 'Workload - Requests'  },
+  application_requets: { title: 'Application Requests'  }
 }
 
 const mapProducts = (productsGrouped, productsGroupedByRegion) => {

--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -173,8 +173,8 @@ const METRIC_SLUGS = {
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
   workload_workloads: { title: 'Workload - Workloads', unit: 'Unit' },
-  workload_requests: { title: 'Workload - Requests', unit: 'Unit'},
-  application_requets: { title: 'Application Requests', unit: 'Unit'}
+  workload_requests: { title: 'Workload - Requests', unit: 'Unit' },
+  application_requets: { title: 'Application Requests', unit: 'Unit' }
 }
 
 const mapProducts = (productsGrouped, productsGroupedByRegion) => {

--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -206,7 +206,9 @@ const METRIC_SLUGS = {
   waf_requests: { title: 'WAF - Requests' },
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
-  workload_workloads: { title: 'Workload - Workloads ', unit: 'Unit' }
+  workload_workloads: { title: 'Workload - Workloads ', unit: 'Unit' },
+  workload_requests: { title: 'Workload - Requests', unit: 'Unit'},
+  application_requets: { title: 'Application Requests', unit: 'Unit'}
 }
 
 const mapRegionMetrics = (metric, regionMetricsGrouped, currency, unit) => {

--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -206,9 +206,9 @@ const METRIC_SLUGS = {
   waf_requests: { title: 'WAF - Requests' },
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
-  workload_workloads: { title: 'Workload - Workloads ', unit: 'Unit' },
-  workload_requests: { title: 'Workload - Requests', unit: 'Unit' },
-  application_requets: { title: 'Application Requests', unit: 'Unit' }
+  workload_workloads: { title: 'Workload - Workloads ' },
+  workload_requests: { title: 'Workload - Requests' },
+  application_requets: { title: 'Application Requests' }
 }
 
 const mapRegionMetrics = (metric, regionMetricsGrouped, currency, unit) => {

--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -207,8 +207,8 @@ const METRIC_SLUGS = {
   waf_rule_sets: { title: 'WAF - Rule Sets' },
   workload_data_transfer: { title: 'Workload - Data Transfer', unit: 'GB' },
   workload_workloads: { title: 'Workload - Workloads ', unit: 'Unit' },
-  workload_requests: { title: 'Workload - Requests', unit: 'Unit'},
-  application_requets: { title: 'Application Requests', unit: 'Unit'}
+  workload_requests: { title: 'Workload - Requests', unit: 'Unit' },
+  application_requets: { title: 'Application Requests', unit: 'Unit' }
 }
 
 const mapRegionMetrics = (metric, regionMetricsGrouped, currency, unit) => {


### PR DESCRIPTION
## Feature
Add new metric slugs to billing services for Workload Requests and Application Requests.

## Description
This PR extends the `METRIC_SLUGS` constant in both billing service files to support two new metrics:

1. **`workload_requests`** - Workload Requests with unit 'Unit' - 
2. **`application_requets`** - Application Requests with unit 'Unit' - only v3

### Files Changed
- [`src/services/billing-services/list-service-and-products-changes-accounting-service.js`](src/services/billing-services/list-service-and-products-changes-accounting-service.js:175) - Added metric slugs for accounting service
- [`src/services/billing-services/list-service-and-products-changes.js`](src/services/billing-services/list-service-and-products-changes.js:209) - Added metric slugs for billing service
- [`package.json`](package.json) - Version bump

## How to Test
1. Navigate to the Billing section in Azion Console
2. Access a bill detail page that contains Workload or Application usage data
3. Verify that the new metrics appear correctly in the product list:
   - "Workload - Requests" should display with the appropriate quantity
   - "Application Requests" should display with the appropriate quantity
4. Check that the metrics are correctly grouped by region when applicable
5. Verify that the data is correctly formatted with the 'Unit' suffix

## UI Changes (if applicable)
**No UI component changes** - This change only affects data mapping in the billing services. The new metrics will automatically appear in the existing billing detail tables and product lists when the API returns data for these metric slugs.