### PR TITLE
[ENG-37160] fix: billing/SO follow-up credit, downgrade routing and onboarding refresh

### DIFF
--- a/docs/CONTRACTING_FLOW.md
+++ b/docs/CONTRACTING_FLOW.md
@@ -104,7 +104,7 @@ sequenceDiagram
     API-->>F: Success
 
     F->>V: Return plan selection
-    V->>O: submitServiceOrder({accountId, planId, planPricingId})
+    V->>O: submitServiceOrder({planId, planPricingId})
     O->>API: createServiceOrder()
     API-->>O: { serviceOrder, payment.clientSecret }
     O-->>V: Service Order created
@@ -321,13 +321,34 @@ const isSubmitting = ref(false)
 const error = ref(null)
 
 // Actions
-loadServiceOrder(accountId) // Fetch existing service order
-createServiceOrder(payload) // Create new service order
-updateServiceOrder(id, payload) // Update existing service order
+loadServiceOrder(accountId) // Fetch current service order (accountId is only a local cache scope)
+createServiceOrder(payload) // Create new service order; backend resolves account from auth
+updateServiceOrder(id, payload) // Update DRAFT service order; backend resolves account from auth
 submitServiceOrder(params) // Create or update based on existence
+upgrade({ id, newPlanId, priceId }) // Upgrade plan or immediate same-plan monthly→yearly cycle change
+downgrade({ id, newPlanId, priceId }) // Schedule downgrade or same-plan yearly→monthly cycle change
+cancelDowngrade({ id }) // Cancel a scheduled downgrade before its effective date
 updatePlanPricing(planPricingId) // Update just the pricing
 reset() // Clear all state
 ```
+
+### Current Account Subscription State (useCurrentSubscription)
+
+Subscription state is resolved from authenticated current-account endpoints instead of inferring from the generic Service Order list and `account.has_service_order_plan`:
+
+```javascript
+// Sources
+useCurrentAccountServiceOrder(accountId) // GET /api/v1/account/service_order
+useCurrentAccountPlan(accountId)         // GET /api/v1/account/plan
+
+// Entitled statuses (treated as "has an active plan")
+const ENTITLED_STATUSES = new Set(['ACTIVE', 'PAST_DUE', 'BLOCKED'])
+
+// hasContractedPlan = there is a current SO OR the legacy onboarding flag is truthy
+// activePricing is resolved against the current account plan, not the generic plans list
+```
+
+`reloadFromBackend()` first refreshes the current SO; only if an active SO exists, it chains a refresh of the current plan.
 
 ### Plan Params State (usePlans)
 
@@ -367,12 +388,28 @@ termsAccepted: boolean
 
 **Base URL:** `/edge_api/api/v1/service_orders`
 
-| Method | Endpoint | Purpose                            |
-| ------ | -------- | ---------------------------------- |
-| GET    | `/`      | List service orders (with filters) |
-| GET    | `/:id`   | Get single service order           |
-| POST   | `/`      | Create service order               |
-| PATCH  | `/:id`   | Update service order               |
+| Method | Endpoint                | Purpose                                                              |
+| ------ | ----------------------- | -------------------------------------------------------------------- |
+| GET    | `/`                     | List service orders (filters: `limit`, `offset`, `status`, `type`)   |
+| GET    | `/:id`                  | Get single service order                                             |
+| POST   | `/`                     | Create service order (DRAFT)                                         |
+| PATCH  | `/:id`                  | Update DRAFT service order                                           |
+| PATCH  | `/:id/upgrade`          | Upgrade plan or immediate same-plan monthly→yearly price change      |
+| PATCH  | `/:id/downgrade`        | Schedule downgrade or same-plan yearly→monthly price change          |
+| DELETE | `/:id/cancel_downgrade` | Cancel scheduled downgrade before its effective date                 |
+
+> All Service Order requests derive the account from authentication. Public requests **must not** send `accountId` in body or query params.
+
+### Current Account Service Order API
+
+**Base URL:** `/edge_api/api/v1/account`
+
+| Method | Endpoint          | Purpose                                                                     |
+| ------ | ----------------- | --------------------------------------------------------------------------- |
+| GET    | `/service_order`  | Get the current non-terminal SO of the authenticated account (`null` if none)|
+| GET    | `/plan`           | Get the currently entitled plan of the authenticated account (`null` if none)|
+
+A `404` response on either endpoint is normalized to `{ data: null }` by the service layer; other non-2xx responses propagate as errors.
 
 ### Plans API
 
@@ -418,17 +455,17 @@ sequenceDiagram
     participant A as service-orders-adapter
     participant API as API Server
 
-    V->>C: submitServiceOrder({accountId, planId, planPricingId})
+    V->>C: submitServiceOrder({planId, planPricingId})
 
     alt Service Order Exists
         C->>S: updateServiceOrder(id, payload)
         S->>A: toUpdatePayload(payload)
-        A-->>S: {accountId, planId, priceId, ...}
+        A-->>S: {planId, priceId}
         S->>API: PATCH /service_orders/:id
     else No Service Order
         C->>S: createServiceOrder(payload)
         S->>A: toCreatePayload(payload)
-        A-->>S: {accountId, planId, priceId}
+        A-->>S: {planId, priceId}
         S->>API: POST /service_orders
     end
 
@@ -438,6 +475,50 @@ sequenceDiagram
     S-->>C: {success, data, payment}
     C->>C: serviceOrder.value = response.data
     C-->>V: {serviceOrder, payment}
+```
+
+---
+
+## Submit Strategy: Plan and Cycle Changes
+
+`resolveSubmitStrategy({ currentSO, planId, planPricingId })` decides which endpoint to call based on the current Service Order and the target plan/pricing:
+
+| Current SO state | Target vs. current             | Action  | Endpoint                              |
+| ---------------- | ------------------------------ | ------- | ------------------------------------- |
+| none / DRAFT     | any                            | CREATE  | `POST /service_orders`                |
+| ACTIVE/entitled  | different `planId`             | UPGRADE | `PATCH /service_orders/:id/upgrade`   |
+| ACTIVE/entitled  | same plan, **monthly → yearly**| UPGRADE | `PATCH /service_orders/:id/upgrade`   |
+| ACTIVE/entitled  | same plan, **yearly → monthly**| DOWNGRADE| `PATCH /service_orders/:id/downgrade` (scheduled) |
+| ACTIVE/entitled  | same plan and same pricing     | NOOP    | —                                     |
+
+Notes:
+
+- A same-plan price change is **never** a `CREATE`. It is always routed through `upgrade` or `downgrade` so the API can keep the Service Order continuous.
+- `downgrade` (plan or yearly→monthly) is scheduled by the API and stays pending until the effective date. The current SO remains entitled until then.
+- A scheduled downgrade can be canceled via `DELETE /service_orders/:id/cancel_downgrade` before the effective date.
+
+### Cancel Scheduled Downgrade
+
+```mermaid
+sequenceDiagram
+    participant V as BillsView
+    participant C as useServiceOrders
+    participant S as service-orders-service
+    participant A as service-orders-adapter
+    participant Q as TanStack Query
+    participant API as API Server
+
+    V->>C: cancelDowngrade({ id })
+    C->>S: cancelDowngradeServiceOrder(id)
+    S->>API: DELETE /service_orders/:id/cancel_downgrade
+    API-->>S: { serviceOrder, transition }
+    S->>Q: invalidateQueries(serviceOrders.all)
+    S->>A: transformCancelDowngradeResponse(response)
+    A-->>S: { serviceOrder, transition, success }
+    S-->>C: result
+    C-->>V: result
+    V->>V: subscription.refetchUntil(so => so.metadata?.status !== 'downgrade_pending')
+    V->>V: trackBilling('downgradeCancelled')
 ```
 
 ---

--- a/src/composables/useCheckoutSessionPreparer.js
+++ b/src/composables/useCheckoutSessionPreparer.js
@@ -58,7 +58,6 @@ export function useCheckoutSessionPreparer() {
       }
 
       const updateResponse = await updateServiceOrder(currentSO.serviceOrderId, {
-        accountId,
         planId,
         planPricingId
       })
@@ -75,7 +74,7 @@ export function useCheckoutSessionPreparer() {
             newPlanId: planId,
             priceId: planPricingId
           })
-        : await createServiceOrder({ accountId, planId, planPricingId })
+        : await createServiceOrder({ planId, planPricingId })
 
     const secret = extractSecret(response)
     if (!secret) {

--- a/src/composables/useCurrentSubscription.js
+++ b/src/composables/useCurrentSubscription.js
@@ -22,7 +22,9 @@ const isRefetching = ref(false)
 const isPollingForActive = ref(false)
 let postPaymentPollAttempted = false
 const POST_PAYMENT_POLL_INTERVAL = 2000
-const POST_PAYMENT_POLL_MAX_ATTEMPTS = 6
+const POST_PAYMENT_POLL_MAX_ATTEMPTS = 10
+
+const isActivePopulated = (so) => Boolean(so?.priceId && so?.currentPeriodEnd)
 
 export function useCurrentSubscription() {
   const accountStore = useAccountStore()
@@ -44,11 +46,11 @@ export function useCurrentSubscription() {
 
   const pollForActiveAfterPayment = async () => {
     if (isPollingForActive.value) return
-    if (activeServiceOrder.value) {
+    if (isActivePopulated(activeServiceOrder.value)) {
       clearAwaitingActiveServiceOrder()
       return
     }
-    if (!draftServiceOrder.value?.priceId) {
+    if (!activeServiceOrder.value && !draftServiceOrder.value?.priceId) {
       clearAwaitingActiveServiceOrder()
       return
     }
@@ -58,7 +60,7 @@ export function useCurrentSubscription() {
       for (let attempt = 0; attempt < POST_PAYMENT_POLL_MAX_ATTEMPTS; attempt += 1) {
         await new Promise((resolve) => setTimeout(resolve, POST_PAYMENT_POLL_INTERVAL))
         await refetchServiceOrders().catch(Sentry.captureException)
-        if (activeServiceOrder.value) {
+        if (isActivePopulated(activeServiceOrder.value)) {
           clearAwaitingActiveServiceOrder()
           return
         }
@@ -77,11 +79,11 @@ export function useCurrentSubscription() {
       if (!id || !finishedOnboarding) return
       if (!isAwaitingActiveServiceOrder()) return
       postPaymentPollAttempted = true
-      if (activeServiceOrder.value) {
+      if (isActivePopulated(activeServiceOrder.value)) {
         clearAwaitingActiveServiceOrder()
         return
       }
-      if (!draftServiceOrder.value?.priceId) {
+      if (!activeServiceOrder.value && !draftServiceOrder.value?.priceId) {
         clearAwaitingActiveServiceOrder()
         return
       }
@@ -91,7 +93,7 @@ export function useCurrentSubscription() {
   )
 
   watch(activeServiceOrder, (active) => {
-    if (active) clearAwaitingActiveServiceOrder()
+    if (isActivePopulated(active)) clearAwaitingActiveServiceOrder()
   })
 
   watch(accountId, (newId, oldId) => {

--- a/src/composables/useCurrentSubscription.js
+++ b/src/composables/useCurrentSubscription.js
@@ -29,7 +29,7 @@ export function useCurrentSubscription() {
   const { accountData } = storeToRefs(accountStore)
 
   const accountId = computed(() => accountData.value?.id ?? null)
-  const hasFinishedOnboarding = computed(() => accountData.value?.has_service_order_plan !== false)
+  const hasFinishedOnboarding = computed(() => accountData.value?.hasAccountPlan !== false)
   const hasContractedPlan = hasFinishedOnboarding
 
   const {
@@ -149,6 +149,13 @@ export function useCurrentSubscription() {
     }
   })
 
+  const currentInvoiceAmountCharged = computed(() => {
+    const metadata = activeServiceOrder.value?.metadata
+    if (!metadata || typeof metadata !== 'object') return null
+    const raw = metadata.amountCharged ?? metadata.amount_charged
+    return toFiniteNumber(raw, null)
+  })
+
   const isDowngradePending = computed(() => Boolean(scheduledDowngrade.value))
 
   const hasResolvedOnce = ref(false)
@@ -220,6 +227,7 @@ export function useCurrentSubscription() {
     isLoading,
     isDowngradePending,
     scheduledDowngrade,
+    currentInvoiceAmountCharged,
     refetch,
     refetchUntil
   }

--- a/src/composables/useServiceOrders.js
+++ b/src/composables/useServiceOrders.js
@@ -94,6 +94,16 @@ export function useServiceOrders() {
     )
   }
 
+  const cancelDowngrade = async ({ id, accountId } = {}) => {
+    const targetAccountId = accountId ?? accountIdRef.value
+    const serviceOrderId = id || getCurrentServiceOrder(targetAccountId)?.serviceOrderId
+    if (!serviceOrderId) {
+      throw new Error(SO_MESSAGES.MISSING_SERVICE_ORDER_ID)
+    }
+
+    return runSubmission(() => serviceOrdersService.cancelDowngradeServiceOrder(serviceOrderId))
+  }
+
   const submitServiceOrder = async ({ accountId, planId, planPricingId }) => {
     const targetAccountId = accountId ?? accountIdRef.value
     const currentSO = getCurrentServiceOrder(targetAccountId)
@@ -147,6 +157,7 @@ export function useServiceOrders() {
     updateServiceOrder,
     submitServiceOrder,
     upgrade,
-    downgrade
+    downgrade,
+    cancelDowngrade
   }
 }

--- a/src/composables/useServiceOrders.js
+++ b/src/composables/useServiceOrders.js
@@ -60,7 +60,7 @@ export function useServiceOrders() {
     return runSubmission(async () => {
       const response = await serviceOrdersService.upgradeServiceOrder({
         id: serviceOrderId,
-        payload: { accountId: targetAccountId, newPlanId, priceId }
+        payload: { newPlanId, priceId }
       })
 
       if (targetAccountId) {
@@ -79,8 +79,9 @@ export function useServiceOrders() {
     })
   }
 
-  const downgrade = async ({ id, newPlanId }) => {
-    const serviceOrderId = id || getCurrentServiceOrder(accountIdRef.value)?.serviceOrderId
+  const downgrade = async ({ id, accountId, newPlanId, priceId }) => {
+    const targetAccountId = accountId ?? accountIdRef.value
+    const serviceOrderId = id || getCurrentServiceOrder(targetAccountId)?.serviceOrderId
     if (!serviceOrderId) {
       throw new Error(SO_MESSAGES.MISSING_SERVICE_ORDER_ID)
     }
@@ -88,7 +89,7 @@ export function useServiceOrders() {
     return runSubmission(() =>
       serviceOrdersService.downgradeServiceOrder({
         id: serviceOrderId,
-        payload: { newPlanId }
+        payload: { newPlanId, priceId }
       })
     )
   }
@@ -105,7 +106,6 @@ export function useServiceOrders() {
     switch (action) {
       case SUBMIT_ACTIONS.PATCH:
         return updateServiceOrder(currentSO.serviceOrderId, {
-          accountId: targetAccountId,
           planId,
           planPricingId
         })
@@ -119,7 +119,7 @@ export function useServiceOrders() {
         })
 
       case SUBMIT_ACTIONS.CREATE:
-        return createServiceOrder({ accountId: targetAccountId, planId, planPricingId })
+        return createServiceOrder({ planId, planPricingId })
 
       case SUBMIT_ACTIONS.NOOP:
       default:

--- a/src/helpers/account-data.js
+++ b/src/helpers/account-data.js
@@ -6,6 +6,7 @@ import {
 } from '@/services/v2/account'
 import { DEFAULT_JOB_ROLE } from '@/services/v2/account/account-settings-adapter'
 import { billingGqlService } from '@/services/v2/billing/billing-gql-service'
+import { serviceOrdersService } from '@/services/v2/service-orders/service-orders-service'
 import { queryClient } from '@/services/v2/base/query/queryClient'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
 import { useAccountStore } from '@/stores/account'
@@ -47,8 +48,8 @@ const pickAddressSnapshot = (settings) => {
 /**
  * Refresh the account + user + settings caches. Pass `force: true` to drop
  * the Vue Query entries first so the next fetch hits the network — used
- * after plan changes/downgrades where stale cached values (e.g.
- * `has_service_order_plan`) would mislead the billing UI.
+ * after plan changes/downgrades where stale cached values would mislead the
+ * billing UI.
  *
  * @param {Object} [options]
  * @param {boolean} [options.force=false] - Skip cached payloads.
@@ -58,15 +59,17 @@ export const loadUserAndAccountInfo = async ({ force = false } = {}) => {
 
   if (force) invalidateAccountCaches()
 
-  const [accountInfo, userInfo, accountSettingsInfo] = await Promise.all([
+  const [accountInfo, userInfo, accountSettingsInfo, hasAccountPlan] = await Promise.all([
     accountService.getAccountInfo(),
     userService.getUserInfo(),
-    accountSettingsService.getAccountSettingsInfo().catch(() => null)
+    accountSettingsService.getAccountSettingsInfo().catch(() => null),
+    serviceOrdersService.getAccountPlanStatus()
   ])
 
   Object.assign(accountInfo, pickUserSnapshot(userInfo), pickAddressSnapshot(accountSettingsInfo), {
     jobRole: accountSettingsInfo?.jobRole ?? DEFAULT_JOB_ROLE,
-    isDeveloperSupportPlan: true
+    isDeveloperSupportPlan: true,
+    hasAccountPlan
   })
 
   accountStore.setAccountData(accountInfo)

--- a/src/helpers/account-data.js
+++ b/src/helpers/account-data.js
@@ -18,6 +18,21 @@ const invalidateAccountCaches = () => {
   queryClient.removeQueries({ queryKey: queryKeys.accountSettings.all })
 }
 
+const invalidateBillingDerivedCaches = () => {
+  queryClient.removeQueries({ queryKey: queryKeys.billing.all })
+  queryClient.removeQueries({ queryKey: queryKeys.contract.all })
+}
+
+const clearBillingDerivedFields = (accountStore) => {
+  accountStore.setAccountData({
+    credit: undefined,
+    formatCredit: undefined,
+    days: undefined,
+    yourServicePlan: undefined,
+    isDeveloperSupportPlan: undefined
+  })
+}
+
 const pickUserSnapshot = (userInfo) => {
   const results = userInfo.results || userInfo
   return {
@@ -57,7 +72,11 @@ const pickAddressSnapshot = (settings) => {
 export const loadUserAndAccountInfo = async ({ force = false } = {}) => {
   const accountStore = useAccountStore()
 
-  if (force) invalidateAccountCaches()
+  if (force) {
+    invalidateAccountCaches()
+    invalidateBillingDerivedCaches()
+    clearBillingDerivedFields(accountStore)
+  }
 
   const [accountInfo, userInfo, accountSettingsInfo, hasAccountPlan] = await Promise.all([
     accountService.getAccountInfo(),
@@ -76,12 +95,14 @@ export const loadUserAndAccountInfo = async ({ force = false } = {}) => {
   setFeatureFlags(accountInfo.client_flags)
 }
 
-export const loadBillingData = async () => {
+export const loadBillingData = async ({ force = false } = {}) => {
   const accountStore = useAccountStore()
   const { account, accountIsNotRegular } = accountStore
 
   if (!accountIsNotRegular) return
-  if (account.formatCredit) return
+  if (!force && account.formatCredit) return
+
+  if (force) queryClient.removeQueries({ queryKey: queryKeys.billing.all })
 
   const billingData = await billingGqlService.getCreditAndExpirationDate()
   if (!billingData) return
@@ -90,12 +111,14 @@ export const loadBillingData = async () => {
   accountStore.setAccountData({ credit, formatCredit, days })
 }
 
-export const loadContractData = async () => {
+export const loadContractData = async ({ force = false } = {}) => {
   const accountStore = useAccountStore()
   const { account } = accountStore
 
   if (!account?.client_id) return
-  if (account.yourServicePlan) return
+  if (!force && account.yourServicePlan) return
+
+  if (force) queryClient.removeQueries({ queryKey: queryKeys.contract.all })
 
   const contractData = await contractService.getContractServicePlan(account.client_id)
   if (!contractData) return

--- a/src/router/hooks/guards/accountGuard.js
+++ b/src/router/hooks/guards/accountGuard.js
@@ -17,17 +17,14 @@ export async function accountGuard({ to, accountStore, tracker }) {
       await loadUserAndAccountInfo()
       sessionManager.afterLogin()
 
-      // Check if needs service order plan
-      const needsServiceOrder = accountStore.hasServiceOrderPlan === false
+      const needsOnboarding = accountStore.needsOnboarding
       const isAdditionalDataRoute = to.name === 'additional-data'
 
-      // If needs service order and not on additional-data route, redirect
-      if (needsServiceOrder && !isAdditionalDataRoute) {
+      if (needsOnboarding && !isAdditionalDataRoute) {
         return { name: 'additional-data' }
       }
 
-      // If doesn't need service order and trying to access additional-data, go to home
-      if (!needsServiceOrder && isAdditionalDataRoute) {
+      if (!needsOnboarding && isAdditionalDataRoute) {
         return { name: 'home' }
       }
 

--- a/src/router/routes/signup-routes/index.js
+++ b/src/router/routes/signup-routes/index.js
@@ -32,13 +32,9 @@ export const signupRoutes = {
       beforeEnter: (to, from, next) => {
         const accountStore = useAccountStore()
 
-        // Only allow access to additional-data if:
-        // 1. User has active session (hasActiveUserId)
-        // 2. hasServiceOrderPlan === false (needs to complete service order)
-        if (accountStore.hasActiveUserId && accountStore.hasServiceOrderPlan === false) {
+        if (accountStore.hasActiveUserId && accountStore.needsOnboarding) {
           next()
         } else {
-          // If user doesn't need service order, redirect to home
           next({ name: 'home' })
         }
       }

--- a/src/services/v2/service-orders/service-orders-adapter.js
+++ b/src/services/v2/service-orders/service-orders-adapter.js
@@ -303,5 +303,19 @@ export const ServiceOrdersAdapter = {
       message: response.message,
       meta: this.transformMeta(response.meta)
     }
+  },
+
+  transformCancelDowngradeResponse(response = {}) {
+    const data = response.data ?? response
+    const serviceOrderData = pick(data?.serviceOrder, data?.service_order)
+    const transition = pick(data?.transition, data?.planTransition)
+
+    return {
+      success: response.success,
+      serviceOrder: serviceOrderData ? this.transformServiceOrder(serviceOrderData) : undefined,
+      transition: this.transformTransition(transition),
+      message: response.message,
+      meta: this.transformMeta(response.meta)
+    }
   }
 }

--- a/src/services/v2/service-orders/service-orders-adapter.js
+++ b/src/services/v2/service-orders/service-orders-adapter.js
@@ -217,7 +217,6 @@ export const ServiceOrdersAdapter = {
 
   toCreatePayload(payload = {}) {
     return {
-      accountId: payload.accountId,
       planId: payload.planId,
       priceId: pick(payload.priceId, payload.planPricingId)
     }
@@ -225,7 +224,6 @@ export const ServiceOrdersAdapter = {
 
   toUpdatePayload(payload = {}) {
     return {
-      accountId: payload.accountId,
       planId: payload.planId,
       priceId: pick(payload.priceId, payload.planPricingId),
       status: payload.status,
@@ -249,15 +247,16 @@ export const ServiceOrdersAdapter = {
   toUpgradePayload(payload = {}) {
     const priceId = pick(payload.priceId, payload.planPricingId)
     return {
-      accountId: payload.accountId,
       newPlanId: payload.newPlanId,
       ...(priceId && { priceId })
     }
   },
 
   toDowngradePayload(payload = {}) {
+    const priceId = pick(payload.priceId, payload.planPricingId)
     return {
-      newPlanId: payload.newPlanId
+      newPlanId: payload.newPlanId,
+      ...(priceId && { priceId })
     }
   },
 

--- a/src/services/v2/service-orders/service-orders-service.js
+++ b/src/services/v2/service-orders/service-orders-service.js
@@ -3,16 +3,30 @@ import { BaseService } from '@/services/v2/base/query/baseService'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
 export class ServiceOrdersService extends BaseService {
-  #baseURL = '/edge_api/api/v1/service_orders'
-  #plansBaseURL = '/edge_api/api/v1/plans'
+  #baseURL = '/edge_api/api/v1'
+  #serviceOrdersURL = `${this.#baseURL}/service_orders`
+  #plansURL = `${this.#baseURL}/plans`
+  #accountPlanURL = `${this.#baseURL}/account/plan`
 
   listPlansService = async () => {
     const { data } = await this.http.request({
       method: 'GET',
-      url: this.#plansBaseURL
+      url: this.#plansURL
     })
 
     return ServiceOrdersAdapter.transformPlansList(data?.data ?? data)
+  }
+
+  getAccountPlanStatus = async () => {
+    try {
+      await this.http.request({
+        method: 'GET',
+        url: this.#accountPlanURL
+      })
+      return true
+    } catch {
+      return false
+    }
   }
 
   // Plan catalogue is effectively static — cache aggressively to avoid the
@@ -30,7 +44,7 @@ export class ServiceOrdersService extends BaseService {
   listServiceOrders = async (params = {}) => {
     const response = await this.http.request({
       method: 'GET',
-      url: this.#baseURL,
+      url: this.#serviceOrdersURL,
       params: {
         ...(params.limit !== undefined && { limit: params.limit }),
         ...(params.offset !== undefined && { offset: params.offset }),
@@ -46,7 +60,7 @@ export class ServiceOrdersService extends BaseService {
   getServiceOrder = async (id) => {
     const response = await this.http.request({
       method: 'GET',
-      url: `${this.#baseURL}/${id}`
+      url: `${this.#serviceOrdersURL}/${id}`
     })
 
     const body = response?.data ?? {}
@@ -65,7 +79,7 @@ export class ServiceOrdersService extends BaseService {
   createServiceOrder = async (payload) => {
     const response = await this.http.request({
       method: 'POST',
-      url: this.#baseURL,
+      url: this.#serviceOrdersURL,
       body: ServiceOrdersAdapter.toCreatePayload(payload)
     })
 
@@ -77,7 +91,7 @@ export class ServiceOrdersService extends BaseService {
   updateServiceOrder = async (id, payload) => {
     const response = await this.http.request({
       method: 'PATCH',
-      url: `${this.#baseURL}/${id}`,
+      url: `${this.#serviceOrdersURL}/${id}`,
       body: ServiceOrdersAdapter.toUpdatePayload(payload)
     })
 
@@ -89,7 +103,7 @@ export class ServiceOrdersService extends BaseService {
   upgradeServiceOrder = async ({ id, payload }) => {
     const response = await this.http.request({
       method: 'PATCH',
-      url: `${this.#baseURL}/${id}/upgrade`,
+      url: `${this.#serviceOrdersURL}/${id}/upgrade`,
       body: ServiceOrdersAdapter.toUpgradePayload(payload)
     })
 
@@ -101,13 +115,24 @@ export class ServiceOrdersService extends BaseService {
   downgradeServiceOrder = async ({ id, payload }) => {
     const response = await this.http.request({
       method: 'PATCH',
-      url: `${this.#baseURL}/${id}/downgrade`,
+      url: `${this.#serviceOrdersURL}/${id}/downgrade`,
       body: ServiceOrdersAdapter.toDowngradePayload(payload)
     })
 
     this.queryClient.invalidateQueries({ queryKey: queryKeys.serviceOrders.all })
 
     return ServiceOrdersAdapter.transformDowngradeResponse(response.data)
+  }
+
+  cancelDowngradeServiceOrder = async (id) => {
+    const response = await this.http.request({
+      method: 'DELETE',
+      url: `${this.#serviceOrdersURL}/${id}/cancel_downgrade`
+    })
+
+    this.queryClient.invalidateQueries({ queryKey: queryKeys.serviceOrders.all })
+
+    return ServiceOrdersAdapter.transformCancelDowngradeResponse(response.data)
   }
 }
 

--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -78,12 +78,11 @@ export const useAccountStore = defineStore({
     isFirstLogin(state) {
       return state.account?.first_login
     },
-    hasServiceOrderPlan(state) {
-      // false = needs to purchase (redirects to additional-data)
-      // true = has contract a plan
-      // null = is old account
-      const value = state.account?.has_service_order_plan
-      return value === false ? false : true
+    hasAccountPlan(state) {
+      return state.account?.hasAccountPlan !== false
+    },
+    needsOnboarding(state) {
+      return state.account?.first_login === true && state.account?.hasAccountPlan === false
     },
     accountUtcOffset(state) {
       return state.account?.utc_offset || '+0000'

--- a/src/templates/checkout-block/pricing-calculation-block.vue
+++ b/src/templates/checkout-block/pricing-calculation-block.vue
@@ -12,6 +12,7 @@
     <PricingSummary
       :subtotal="subtotal"
       :yearlyDiscount="yearlyDiscount"
+      :currentPlanCredit="currentPlanCredit"
       :total="total"
       :billingCycleLabel="billingCycleLabel"
     />
@@ -49,6 +50,11 @@
       type: String,
       default: null,
       validator: (value) => value === null || ['monthly', 'yearly'].includes(value)
+    },
+    mode: {
+      type: String,
+      default: 'subscribe',
+      validator: (value) => ['subscribe', 'edit', 'change-cycle'].includes(value)
     }
   })
 
@@ -85,9 +91,15 @@
       : planPricing.value?.monthly || 0
   })
 
-  const discount = computed(() => yearlyDiscount.value)
+  const currentPlanCredit = computed(() => {
+    if (props.mode !== 'change-cycle') return 0
+    if (billingCycle.value !== 'yearly') return 0
+    return planPricing.value?.monthly || 0
+  })
 
-  const total = computed(() => basePlanPrice.value)
+  const discount = computed(() => yearlyDiscount.value + currentPlanCredit.value)
+
+  const total = computed(() => Math.max(basePlanPrice.value - currentPlanCredit.value, 0))
 
   const billingCycleLabel = computed(() => (billingCycle.value === 'monthly' ? 'month' : 'year'))
 
@@ -145,11 +157,12 @@
   })
 
   watch(
-    [subtotal, discount, total, billingCycleLabel],
+    [subtotal, discount, currentPlanCredit, total, billingCycleLabel],
     () => {
       emit('pricingChange', {
         subtotal: subtotal.value,
         discount: discount.value,
+        currentPlanCredit: currentPlanCredit.value,
         total: total.value,
         billingCycle: billingCycle.value,
         billingCycleLabel: billingCycleLabel.value
@@ -162,6 +175,7 @@
     billingCycle,
     subtotal,
     discount,
+    currentPlanCredit,
     total
   })
 </script>

--- a/src/templates/checkout-block/pricing-summary.vue
+++ b/src/templates/checkout-block/pricing-summary.vue
@@ -25,6 +25,18 @@
       </div>
     </Transition>
 
+    <Transition name="annual-discount-slide">
+      <div
+        v-if="currentPlanCredit > 0"
+        class="flex justify-between text-sm"
+      >
+        <span class="text-muted">Current Plan Credit</span>
+        <div class="text-right">
+          <span class="text-success">-${{ formattedCurrentPlanCredit }}</span>
+        </div>
+      </div>
+    </Transition>
+
     <div class="flex justify-between text-base font-semibold">
       <span class="text-default">Total</span>
       <span class="text-default">
@@ -44,6 +56,7 @@
   const props = defineProps({
     subtotal: { type: Number, required: true },
     yearlyDiscount: { type: Number, default: 0 },
+    currentPlanCredit: { type: Number, default: 0 },
     total: { type: Number, required: true },
     billingCycleLabel: { type: String, required: true }
   })
@@ -52,6 +65,7 @@
 
   const formattedSubtotal = computed(() => formatPrice(props.subtotal))
   const formattedYearlyDiscount = computed(() => formatPrice(props.yearlyDiscount))
+  const formattedCurrentPlanCredit = computed(() => formatPrice(props.currentPlanCredit))
   const formattedTotal = computed(() => formatPrice(props.total))
 </script>
 

--- a/src/tests/stores/account.test.js
+++ b/src/tests/stores/account.test.js
@@ -28,32 +28,56 @@ describe('account store session state', () => {
   })
 })
 
-describe('account store hasServiceOrderPlan getter', () => {
+describe('account store hasAccountPlan getter', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
   })
 
-  it('should return true when has_service_order_plan is true', () => {
+  it('should return true when hasAccountPlan is true', () => {
     const store = useAccountStore()
-    store.setAccountData({ has_service_order_plan: true })
-    expect(store.hasServiceOrderPlan).toBe(true)
+    store.setAccountData({ hasAccountPlan: true })
+    expect(store.hasAccountPlan).toBe(true)
   })
 
-  it('should return true when has_service_order_plan is null', () => {
+  it('should return true when hasAccountPlan is undefined', () => {
     const store = useAccountStore()
-    store.setAccountData({ has_service_order_plan: null })
-    expect(store.hasServiceOrderPlan).toBe(true)
+    store.setAccountData({ id: 1 })
+    expect(store.hasAccountPlan).toBe(true)
   })
 
-  it('should return true when has_service_order_plan is undefined', () => {
+  it('should return false when hasAccountPlan is false', () => {
     const store = useAccountStore()
-    store.setAccountData({ id: 1 }) // has_service_order_plan is undefined
-    expect(store.hasServiceOrderPlan).toBe(true)
+    store.setAccountData({ hasAccountPlan: false })
+    expect(store.hasAccountPlan).toBe(false)
+  })
+})
+
+describe('account store needsOnboarding getter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
   })
 
-  it('should return false when has_service_order_plan is false', () => {
+  it('should return true when first_login=true and hasAccountPlan=false', () => {
     const store = useAccountStore()
-    store.setAccountData({ has_service_order_plan: false })
-    expect(store.hasServiceOrderPlan).toBe(false)
+    store.setAccountData({ first_login: true, hasAccountPlan: false })
+    expect(store.needsOnboarding).toBe(true)
+  })
+
+  it('should return false when first_login=true but hasAccountPlan=true', () => {
+    const store = useAccountStore()
+    store.setAccountData({ first_login: true, hasAccountPlan: true })
+    expect(store.needsOnboarding).toBe(false)
+  })
+
+  it('should return false when first_login=false and hasAccountPlan=false', () => {
+    const store = useAccountStore()
+    store.setAccountData({ first_login: false, hasAccountPlan: false })
+    expect(store.needsOnboarding).toBe(false)
+  })
+
+  it('should return false when first_login is undefined', () => {
+    const store = useAccountStore()
+    store.setAccountData({ hasAccountPlan: false })
+    expect(store.needsOnboarding).toBe(false)
   })
 })

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -290,8 +290,7 @@
   const subscription = useCurrentSubscription()
   const {
     downgrade: downgradeServiceOrderPlan,
-    upgrade: upgradeServiceOrder,
-    updateServiceOrder,
+    upgrade: upgradeServiceOrderPlan,
     loadAccountServiceOrders,
     serviceOrder,
     activeServiceOrder
@@ -545,7 +544,7 @@
       billingCycle
     })
 
-    await upgradeServiceOrder({
+    await upgradeServiceOrderPlan({
       id: serviceOrderId,
       accountId,
       newPlanId: planId,
@@ -559,10 +558,11 @@
       billingCycle
     })
 
-    await updateServiceOrder(serviceOrderId, {
+    await downgradeServiceOrderPlan({
+      id: serviceOrderId,
       accountId,
-      planId,
-      planPricingId
+      newPlanId: planId,
+      priceId: planPricingId
     })
   }
 

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -291,6 +291,7 @@
   const {
     downgrade: downgradeServiceOrderPlan,
     upgrade: upgradeServiceOrderPlan,
+    cancelDowngrade: cancelDowngradeServiceOrderPlan,
     loadAccountServiceOrders,
     serviceOrder,
     activeServiceOrder
@@ -325,7 +326,8 @@
     hasContractedPlan: computed(() => subscription.hasContractedPlan.value),
     isHobby: computed(() => subscription.isHobby.value),
     isPro: computed(() => subscription.isPro.value),
-    isLoading: computed(() => subscription.isLoading.value)
+    isLoading: computed(() => subscription.isLoading.value),
+    currentInvoiceAmountCharged: computed(() => subscription.currentInvoiceAmountCharged.value)
   })
 
   const currentInvoice = ref({})
@@ -679,15 +681,42 @@
   }
 
   const handleCancelDowngradeConfirm = async ({ fail, done } = {}) => {
+    const fromPlan = subscription.planSku.value
     try {
-      fail?.('Cancel scheduled downgrade is not available yet.')
-    } finally {
-      if (done) {
-        trackBilling('downgradeCancelled', {
-          fromPlan: subscription.planSku.value,
-          toPlan: 'hobby'
-        })
+      const serviceOrderId = serviceOrder.value?.serviceOrderId
+      if (!serviceOrderId) {
+        throw new Error('Missing service order to cancel.')
       }
+
+      await cancelDowngradeServiceOrderPlan({ id: serviceOrderId })
+
+      await subscription.refetchUntil((so) => so?.metadata?.status !== 'downgrade_pending')
+
+      trackBilling('downgradeCancelled', {
+        fromPlan,
+        toPlan: 'hobby'
+      })
+
+      toast.add({
+        severity: 'success',
+        summary: 'Downgrade cancelled',
+        detail: 'Your scheduled downgrade has been cancelled.',
+        life: 6000,
+        closable: true
+      })
+
+      done?.()
+    } catch (err) {
+      const detail =
+        (Array.isArray(err?.message) ? err.message[0] : err?.message) ||
+        'Unable to cancel scheduled downgrade.'
+      trackBilling('planChangeFailed', {
+        plan: fromPlan,
+        billingCycle: subscription.billingCycle.value,
+        errorType: 'cancel-downgrade',
+        errorMessage: detail
+      })
+      fail?.(detail)
     }
   }
 

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -125,7 +125,7 @@
 </template>
 
 <script setup>
-  import { ref, computed, reactive, watch, inject, onBeforeUnmount } from 'vue'
+  import { ref, computed, reactive, watch, inject, onBeforeUnmount, onMounted } from 'vue'
   import { useRouter } from 'vue-router'
   import { storeToRefs } from 'pinia'
   import EmptyResultsBlock from '@aziontech/webkit/empty-results-block'
@@ -147,7 +147,11 @@
   import { useCurrentSubscription } from '@/composables/useCurrentSubscription'
   import { useServiceOrders } from '@/composables/useServiceOrders'
   import { useCheckoutSessionPreparer } from '@/composables/useCheckoutSessionPreparer'
-  import { markAwaitingActiveServiceOrder } from '@/composables/post-payment-flag'
+  import {
+    markAwaitingActiveServiceOrder,
+    isAwaitingActiveServiceOrder,
+    clearAwaitingActiveServiceOrder
+  } from '@/composables/post-payment-flag'
   import { useAccountStore } from '@/stores/account'
   import * as Sentry from '@sentry/vue'
 
@@ -378,6 +382,18 @@
     },
     { immediate: true }
   )
+
+  onMounted(async () => {
+    if (!isAwaitingActiveServiceOrder()) return
+    try {
+      await subscription.refetchUntil((so) => Boolean(so?.priceId && so?.currentPeriodEnd))
+    } catch (err) {
+      Sentry.captureException(err)
+    } finally {
+      clearAwaitingActiveServiceOrder()
+      loadCurrentInvoice()
+    }
+  })
 
   onBeforeUnmount(cancelInvoiceRetry)
 

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -125,7 +125,7 @@
 </template>
 
 <script setup>
-  import { ref, computed, reactive, watch, inject } from 'vue'
+  import { ref, computed, reactive, watch, inject, onBeforeUnmount } from 'vue'
   import { useRouter } from 'vue-router'
   import { storeToRefs } from 'pinia'
   import EmptyResultsBlock from '@aziontech/webkit/empty-results-block'
@@ -331,22 +331,55 @@
   })
 
   const currentInvoice = ref({})
+  const INVOICE_RETRY_INTERVAL_MS = 2000
+  const INVOICE_RETRY_MAX_ATTEMPTS = 6
+  let invoiceRetryTimer = null
+  let invoiceRetryAttempt = 0
+
+  const isInvoicePopulated = (invoice) => {
+    if (!invoice) return false
+    const billId = invoice.billId
+    return Boolean(invoice.redirectId) || (Boolean(billId) && billId !== '---')
+  }
+
+  const cancelInvoiceRetry = () => {
+    if (invoiceRetryTimer) {
+      clearTimeout(invoiceRetryTimer)
+      invoiceRetryTimer = null
+    }
+    invoiceRetryAttempt = 0
+  }
 
   const loadCurrentInvoice = async () => {
     try {
-      currentInvoice.value = (await props.loadCurrentInvoiceService()) || {}
+      const result = (await props.loadCurrentInvoiceService()) || {}
+      currentInvoice.value = result
+      if (!isInvoicePopulated(result) && invoiceRetryAttempt < INVOICE_RETRY_MAX_ATTEMPTS) {
+        invoiceRetryAttempt += 1
+        if (invoiceRetryTimer) clearTimeout(invoiceRetryTimer)
+        invoiceRetryTimer = setTimeout(loadCurrentInvoice, INVOICE_RETRY_INTERVAL_MS)
+      } else {
+        cancelInvoiceRetry()
+      }
     } catch {
       currentInvoice.value = {}
+      cancelInvoiceRetry()
     }
   }
 
   watch(
     () => subscriptionState.isPro,
     (isPro, wasPro) => {
-      if (isPro && !wasPro) loadCurrentInvoice()
+      if (isPro && !wasPro) {
+        cancelInvoiceRetry()
+        loadCurrentInvoice()
+      }
+      if (!isPro) cancelInvoiceRetry()
     },
     { immediate: true }
   )
+
+  onBeforeUnmount(cancelInvoiceRetry)
 
   const cardsReady = computed(() => !subscriptionState.isLoading)
 

--- a/src/views/Billing/Drawer/CheckoutSubmissionFooter.vue
+++ b/src/views/Billing/Drawer/CheckoutSubmissionFooter.vue
@@ -1,48 +1,34 @@
 <template>
   <div
-    class="flex shrink-0 flex-col gap-2 border-t border-default bg-[var(--surface-50)] px-4 py-3 md:px-8"
+    class="flex shrink-0 justify-end gap-3 border-t border-default bg-[var(--surface-50)] px-4 py-3 md:px-8"
   >
-    <div
-      v-if="errorMessage"
-      class="flex items-start gap-2 rounded-md border border-error bg-[var(--surface-error)] px-3 py-2 text-xs text-error"
-    >
-      <i class="pi pi-exclamation-circle mt-[2px] shrink-0" />
-      <span class="flex-1">{{ errorMessage }}</span>
-    </div>
-
-    <div class="flex justify-end gap-3">
-      <Button
-        class="h-8 px-4 font-protomono text-xs flex items-center justify-center"
-        outlined
-        label="Cancel"
-        :disabled="isSubmitting"
-        @click="$emit('cancel')"
-      />
-      <Button
-        class="h-8 px-4 font-protomono text-xs flex items-center justify-center"
-        :label="confirmLabel"
-        :loading="isSubmitting"
-        :disabled="isConfirmDisabled"
-        @click="$emit('confirm')"
-      />
-    </div>
+    <Button
+      class="h-8 px-4 font-protomono text-xs flex items-center justify-center"
+      outlined
+      label="Cancel"
+      :disabled="isSubmitting"
+      @click="$emit('cancel')"
+    />
+    <Button
+      class="h-8 px-4 font-protomono text-xs flex items-center justify-center"
+      :label="submitLabel"
+      :loading="isSubmitting"
+      :disabled="isConfirmDisabled"
+      @click="$emit('confirm')"
+    />
   </div>
 </template>
 
 <script setup>
-  import { computed } from 'vue'
   import Button from '@aziontech/webkit/button'
 
   defineOptions({ name: 'checkout-submission-footer' })
 
-  const props = defineProps({
+  defineProps({
     submitLabel: { type: String, required: true },
-    errorMessage: { type: String, default: '' },
     isSubmitting: { type: Boolean, default: false },
     isConfirmDisabled: { type: Boolean, default: false }
   })
 
   defineEmits(['cancel', 'confirm'])
-
-  const confirmLabel = computed(() => (props.errorMessage ? 'Retry' : props.submitLabel))
 </script>

--- a/src/views/Billing/Drawer/DrawerPlanInfo.vue
+++ b/src/views/Billing/Drawer/DrawerPlanInfo.vue
@@ -37,6 +37,7 @@
             ref="pricingRef"
             :plan="plan"
             :lockedCycle="lockedCycle"
+            :mode="mode"
             @update:billing-cycle="handleBillingCycleChange"
             @update:checkout-session-client-secret="handleCheckoutSessionClientSecretChange"
           />

--- a/src/views/Billing/Drawer/DrawerPlanInfo.vue
+++ b/src/views/Billing/Drawer/DrawerPlanInfo.vue
@@ -59,7 +59,6 @@
 
         <CheckoutSubmissionFooter
           :submitLabel="submitLabel"
-          :errorMessage="submitError"
           :isSubmitting="isSubmitting"
           :isConfirmDisabled="isConfirmDisabled"
           @cancel="closeDrawer"
@@ -117,7 +116,6 @@
   const isAddressFormReady = ref(false)
   const billingCycle = ref('yearly')
   const checkoutSessionClientSecret = ref(props.initialClientSecret)
-  const submitError = ref('')
 
   const isChangeCycleMode = computed(() => props.mode === 'change-cycle')
 
@@ -192,7 +190,6 @@
   const handleSubmit = async () => {
     if (isSubmitting.value) return
     isSubmitting.value = true
-    submitError.value = ''
     try {
       if (isChangeCycleMode.value) {
         await new Promise((resolve, reject) => {
@@ -236,7 +233,6 @@
     } catch (err) {
       const detail =
         (Array.isArray(err?.message) ? err.message[0] : err?.message) || 'Unable to subscribe.'
-      submitError.value = detail
       showError(detail)
     } finally {
       isSubmitting.value = false

--- a/src/views/Billing/TabsView.vue
+++ b/src/views/Billing/TabsView.vue
@@ -157,7 +157,7 @@
               @click="handleRefresh"
             >
               <Tag
-                severity="info"
+                severity="secondary"
                 :icon="isRefreshing ? 'pi pi-spin pi-spinner' : 'pi pi-refresh'"
                 :value="invoiceLastUpdated"
               />

--- a/src/views/Billing/components/CurrentInvoiceCard.vue
+++ b/src/views/Billing/components/CurrentInvoiceCard.vue
@@ -114,11 +114,19 @@
 
   const creditUsedValue = computed(() => formatAmount(props.invoice?.creditUsedForPayment ?? 0))
 
-  // Total is the sum of Plan Charge + Professional Services charges. Replaces
-  // the legacy `invoice.total` field which doesn't reflect the plan price.
-  const totalValue = computed(() =>
-    formatAmount(planChargeNumeric.value + servicePlanChargesNumeric.value)
-  )
+  const amountChargedNumeric = computed(() => {
+    const raw = props.subscription?.currentInvoiceAmountCharged
+    if (raw === null || raw === undefined) return null
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : null
+  })
+
+  const totalValue = computed(() => {
+    if (amountChargedNumeric.value !== null) {
+      return formatAmount(amountChargedNumeric.value)
+    }
+    return formatAmount(planChargeNumeric.value + servicePlanChargesNumeric.value)
+  })
 
   const emitViewDetails = () => {
     // `redirectId` is the "is the details page reachable?" flag the legacy

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -106,6 +106,8 @@
   import { markAwaitingActiveServiceOrder } from '@/composables/post-payment-flag'
   import * as Sentry from '@sentry/vue'
   import { loadUserAndAccountInfo } from '@/helpers/account-data'
+  import { queryClient } from '@/services/v2/base/query/queryClient'
+  import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
   const router = useRouter()
   /** @type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
@@ -178,15 +180,9 @@
     if (!planId) return
 
     if (plan === 'hobby') {
-      // Onboarding only enters when has_service_order_plan === false, so no
-      // ACTIVE SO can exist yet — what may exist is a DRAFT from a previous
-      // attempt. submitServiceOrder already routes: no SO → POST hobby;
-      // DRAFT (any plan) → PATCH to hobby; same plan → no-op.
       try {
         await submitServiceOrder({ accountId, planId })
 
-        // Refresh /info so accountGuard sees has_service_order_plan=true and
-        // doesn't bounce back to additional-data on reload.
         await loadUserAndAccountInfo()
         handleProceedToCheckout()
       } catch (err) {
@@ -255,6 +251,12 @@
       currency: checkoutData?.currency || 'USD'
     })
     markAwaitingActiveServiceOrder()
+    try {
+      queryClient.removeQueries({ queryKey: queryKeys.serviceOrders.all })
+      await loadUserAndAccountInfo({ force: true })
+    } catch (err) {
+      Sentry.captureException(err)
+    }
     currentStep.value = 'success'
   }
 


### PR DESCRIPTION
## Summary

Follow-up fixes on top of the new plans view (ENG-37160) merged in #3526. Covers post-checkout refresh, current plan credit, downgrade routing and onboarding → billing data freshness.

## Root cause

After confirming PRO payment in onboarding, the billing screen rendered the Pro plan title but with stale/zero values (price, period, charges) until a manual reload. Two issues combined:

1. `handleCheckoutSuccess` invalidated only the service-orders / account / user / settings caches. Billing GQL (`queryKeys.billing.all`) and contract (`queryKeys.contract.all`) caches were left untouched, and the Pinia fields that gate `loadBillingData` / `loadContractData` (`formatCredit`, `yourServicePlan`, etc.) persisted across the navigation — so the next mount short-circuited and served stale state.
2. `BillsView` rendered the cards as soon as `isLoading` became false. The post-payment polling in `useCurrentSubscription` was best-effort and bailed out early when neither the active nor the draft SO had a `priceId`, so cards settled on zeroed values before the Stripe webhook finished populating the SO.

## Changes

- **`src/helpers/account-data.js`** — `loadUserAndAccountInfo({ force: true })` now also drops the billing/contract Vue Query caches and clears the Pinia fields that gate the lazy loaders. `loadBillingData` and `loadContractData` accept `{ force }` for callers that need to bypass the short-circuit. Fixes the latent bug where `subscription.refetch()` (used by in-billing plan changes) silently kept stale credit/contract data.
- **`src/views/Billing/BillsView.vue`** — on mount, when `isAwaitingActiveServiceOrder()` is set, mirrors the in-billing drawer flow: `subscription.refetchUntil((so) => so?.priceId && so?.currentPeriodEnd)` keeps `isLoading=true` so the cards render the skeleton until the SO is fully populated; clears the flag and reloads the current invoice in `finally`.
- Includes the previous commits already on this branch: current plan credit on PRO/m → PRO/Y upgrade, accountId-less SO payloads, downgrade routing through the dedicated downgrade API, and the SO polling fix.

## Test plan

- [ ] Sign up a new account → choose PRO → confirm payment in Stripe checkout → click Start → navigate to Billing. Subscription + Current Invoice cards should show the skeleton until the SO is populated, then render the correct values without a manual reload.
- [ ] From Billing, change plan via the drawer (PRO → PRO yearly, PRO → Hobby) and verify credit/contract values update without stale state.
- [ ] Existing flows: change cycle, schedule downgrade, cancel downgrade — all still render correctly.
- [ ] No infinite reload loop when re-entering the Billing tab after onboarding.