### PR TITLE
[ENG-45589] fix: add application rules metric label in billing

### DIFF
--- a/src/services/billing-services/list-service-and-products-changes-accounting-service.js
+++ b/src/services/billing-services/list-service-and-products-changes-accounting-service.js
@@ -124,6 +124,7 @@ const METRIC_SLUGS = {
     unit: 'GB'
   },
   application_requests: { title: 'Applications Requests' },
+  application_rules: { title: 'Application Rules' },
   bot_manager_invocations: { title: 'Bot Manager Requests' },
   cache_purges: { title: 'Cache Purges' },
   compute_time: { title: 'Edge Functions Compute Time', unit: 'ms' },

--- a/src/services/billing-services/list-service-and-products-changes.js
+++ b/src/services/billing-services/list-service-and-products-changes.js
@@ -158,6 +158,7 @@ const METRIC_SLUGS = {
     unit: 'GB'
   },
   application_requests: { title: 'Applications Requests' },
+  application_rules: { title: 'Applications Rules' },
   bot_manager_invocations: { title: 'Bot Manager Requests' },
   cache_purges: { title: 'Cache Purges' },
   compute_time: { title: 'Edge Functions Compute Time', unit: 'ms' },


### PR DESCRIPTION
## Bug fix

### What was the problem?

The `application_rules` metric returned by the billing API had no entry in the `METRIC_SLUGS` map at `src/services/billing-services/list-service-and-products-changes.js`, so the "Applications Rules" line item was rendered without a human-readable label in the billing breakdown.

### Expected behavior

The billing services and products list should display "Applications Rules" as the label for the `application_rules` metric.

### How was it solved

Added the `application_rules` slug to the `METRIC_SLUGS` map with title `"Applications Rules"`.

### How to test

1. Navigate to Billing → Services and Products.
2. On an account that consumes Application Rules, confirm the line item is now labeled "Applications Rules" instead of appearing unlabeled.