### PR TITLE
[NO-ISSUE] refactor: gate onboarding by first_login and client kind

### DIFF
--- a/src/composables/useCurrentSubscription.js
+++ b/src/composables/useCurrentSubscription.js
@@ -30,7 +30,7 @@ export function useCurrentSubscription() {
   const { accountData } = storeToRefs(accountStore)
 
   const accountId = computed(() => accountData.value?.id ?? null)
-  const hasFinishedOnboarding = computed(() => accountData.value?.hasAccountPlan !== false)
+  const hasFinishedOnboarding = computed(() => accountData.value?.first_login !== true)
   const hasContractedPlan = hasFinishedOnboarding
 
   const {

--- a/src/helpers/account-data.js
+++ b/src/helpers/account-data.js
@@ -5,7 +5,6 @@ import {
   contractService
 } from '@/services/v2/account'
 import { DEFAULT_JOB_ROLE } from '@/services/v2/account/job-role-validator'
-import { serviceOrdersService } from '@/services/v2/service-orders/service-orders-service'
 import { queryClient } from '@/services/v2/base/query/queryClient'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
 import { useAccountStore } from '@/stores/account'
@@ -60,11 +59,10 @@ const pickAddressSnapshot = (settings) => {
 }
 
 /**
- * Refresh the account + user + settings caches and signal whether the
- * account has an entitled plan. Does NOT load billing or contract data —
- * use `loadAccountHydration` for the full post-login warm-up. Pass
- * `force: true` to drop the Vue Query entries first so the next fetch hits
- * the network (used after plan changes / downgrades).
+ * Refresh the account + user + settings caches. Does NOT load billing or
+ * contract data — use `loadAccountHydration` for the full post-login
+ * warm-up. Pass `force: true` to drop the Vue Query entries first so the
+ * next fetch hits the network (used after plan changes / downgrades).
  *
  * @param {Object} [options]
  * @param {boolean} [options.force=false]
@@ -78,16 +76,14 @@ export const loadUserAndAccountInfo = async ({ force = false } = {}) => {
     clearBillingDerivedFields(accountStore)
   }
 
-  const [accountInfo, userInfo, accountSettingsInfo, hasAccountPlan] = await Promise.all([
+  const [accountInfo, userInfo, accountSettingsInfo] = await Promise.all([
     accountService.getAccountInfo(),
     userService.getUserInfo(),
-    accountSettingsService.getAccountSettingsInfo().catch(() => null),
-    serviceOrdersService.getAccountPlanStatus()
+    accountSettingsService.getAccountSettingsInfo().catch(() => null)
   ])
 
   Object.assign(accountInfo, pickUserSnapshot(userInfo), pickAddressSnapshot(accountSettingsInfo), {
-    jobRole: accountSettingsInfo?.jobRole ?? DEFAULT_JOB_ROLE,
-    hasAccountPlan
+    jobRole: accountSettingsInfo?.jobRole ?? DEFAULT_JOB_ROLE
   })
 
   accountStore.setAccountData(accountInfo)
@@ -111,10 +107,9 @@ export const loadContractData = async ({ force = false } = {}) => {
 }
 
 /**
- * Full post-login account hydration. Loads user/account/settings/SO status
- * first (needed to derive `client_id` and `needsOnboarding`), then chains
- * billing + contract in parallel — those depend on the data above and on
- * the store getters that derive from it.
+ * Full post-login account hydration. Loads user/account/settings first
+ * (needed to derive `client_id`, `kind`, and `first_login`), then loads
+ * contract data — which depends on `client_id`.
  *
  * The accountGuard awaits this BEFORE making redirect decisions so the
  * `needsOnboarding` and `hasAccessConsole` getters return correct values

--- a/src/services/v2/service-orders/service-orders-service.js
+++ b/src/services/v2/service-orders/service-orders-service.js
@@ -33,18 +33,6 @@ export class ServiceOrdersService extends BaseService {
     return ServiceOrdersAdapter.transformPlanDetailResponse(response.data)
   }
 
-  getAccountPlanStatus = async () => {
-    try {
-      await this.http.request({
-        method: 'GET',
-        url: this.#currentPlanURL
-      })
-      return true
-    } catch {
-      return false
-    }
-  }
-
   listServiceOrders = async (params = {}) => {
     const response = await this.http.request({
       method: 'GET',

--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -86,11 +86,8 @@ export const useAccountStore = defineStore({
     isFirstLogin(state) {
       return state.account?.first_login
     },
-    hasAccountPlan(state) {
-      return state.account?.hasAccountPlan !== false
-    },
     needsOnboarding(state) {
-      return state.account?.hasAccountPlan === false
+      return state.account?.first_login === true && state.account?.kind === 'client'
     },
     accountUtcOffset(state) {
       return state.account?.utc_offset || '+0000'

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -246,9 +246,9 @@
   const usageIntentOptions = [
     { value: 'learn', description: 'Learn', ariaLabel: 'Learn usage intent' },
     {
-      value: 'personal-project',
-      description: 'Personal Project',
-      ariaLabel: 'Personal project usage intent'
+      value: 'personal-projects',
+      description: 'Personal Projects',
+      ariaLabel: 'Personal projects usage intent'
     },
     { value: 'work', description: 'Work', ariaLabel: 'Work usage intent' }
   ]
@@ -375,7 +375,7 @@
 
   const usageIntentToApiValue = {
     learn: 'Study',
-    'personal-project': 'Personal',
+    'personal-projects': 'Personal',
     work: 'Work'
   }
 

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col min-h-screen var(--bg-color)">
+  <div class="flex flex-col flex-1 var(--bg-color)">
     <!-- Main Content -->
     <div class="flex-1 flex flex-col items-center py-8 px-4 gap-6">
       <!-- Card Container (only for step 1) -->


### PR DESCRIPTION
## Summary
- `needsOnboarding` agora deriva de `account.first_login === true && account.kind === 'client'`. Contas não-client (reseller, groups, brand, etc.) deixam de cair na tela de billing onboarding.
- Removido o request extra `GET /edge_api/v4/service_orders/plans/current` que era usado apenas para derivar `hasAccountPlan` na hidratação pós-login.
- `useCurrentSubscription.hasFinishedOnboarding` migrado para o mesmo sinal (`first_login !== true`).
- Ajuste de label/valor da opção de usage intent: `personal-project` → `personal-projects`.

## Root cause
A hidratação pós-login disparava 4 requests em paralelo (account + user + settings + SO plan status) só para sinalizar onboarding. `hasAccountPlan` se sobrepunha conceitualmente a `first_login`, que já é o flag autoritativo. Além disso, o redirect para `additional-data` não diferenciava por `kind`, mandando resellers/groups/brands para um fluxo que não se aplica a eles.

## Changes
- `src/stores/account.js` — `needsOnboarding` baseado em `first_login` + `kind === 'client'`; getter `hasAccountPlan` removido (sem consumidores).
- `src/helpers/account-data.js` — `loadUserAndAccountInfo` faz 3 requests em vez de 4; import e uso de `serviceOrdersService` removidos; docs atualizadas.
- `src/services/v2/service-orders/service-orders-service.js` — método `getAccountPlanStatus` removido (sem chamadores).
- `src/composables/useCurrentSubscription.js` — `hasFinishedOnboarding` alinhado ao novo sinal.
- `src/templates/signup-block/additional-data-form-block.vue` — `personal-project` → `personal-projects`.
- `src/views/Signup/AdditionalDataView.vue` — ajuste de layout (`min-h-screen` → `flex-1`).

## Test plan
- [ ] Login como conta `client` em primeiro acesso (`first_login=true`) → redireciona para `/signup/additional-data`.
- [ ] Login como conta `client` já onboardada (`first_login=false`) → vai para home; navegar manualmente para `/signup/additional-data` redireciona de volta para home.
- [ ] Login como conta `reseller`/`groups`/`brand` com `first_login=true` → NÃO redireciona para `additional-data`; vai para home.
- [ ] Verificar via Network tab que `GET /edge_api/v4/service_orders/plans/current` não é mais disparado durante o login.
- [ ] Mudar plano / abrir tela "Your Plan" continua funcionando (usa `useCurrentSubscription`).
- [ ] Selecionar opção "Personal Projects" no signup envia `Personal` para a API.