### PR TITLE
[NO-ISSUE] fix: reflect selected plan in signup heading

### DIFF
--- a/src/templates/signup-block/form-signup-block.vue
+++ b/src/templates/signup-block/form-signup-block.vue
@@ -9,7 +9,7 @@
             @submit.prevent
           >
             <div class="gap-2 flex flex-col">
-              <h1 class="text-start text-xl lg:text-2xl font-medium">Sign Up for a Free Account</h1>
+              <h1 class="text-start text-xl lg:text-2xl font-medium">{{ signupHeading }}</h1>
             </div>
 
             <div>
@@ -78,17 +78,22 @@
   import PrimeButton from '@aziontech/webkit/button'
   import PrimeDivider from '@aziontech/webkit/divider'
   import LoginWithEmailBlock from '@/templates/signup-block/login-with-email-block'
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+  import { computed, ref } from 'vue'
+  import { useRoute, useRouter } from 'vue-router'
 
   const props = defineProps({
     signupService: { required: true, type: Function },
     resendEmailService: { required: true, type: Function }
   })
 
+  const route = useRoute()
   const router = useRouter()
   const showLoginFromEmail = ref(true)
   const showActivation = ref(true)
+
+  const signupHeading = computed(() =>
+    route.query.plan === 'pro' ? 'Sign Up for the Pro Plan' : 'Sign Up for a Free Account'
+  )
 
   const showActivationEmail = () => {
     showActivation.value = false


### PR DESCRIPTION
## Summary
- Em `/signup?plan=pro&billing-cycle=monthly` o título "Sign Up for a Free Account" era exibido mesmo com o usuário escolhendo o plano Pro. Agora o heading reflete o `plan` da query param.

## Root cause
O `<h1>` em `form-signup-block.vue` estava hardcoded como "Sign Up for a Free Account". A query param `plan` não era lida no entry point do signup.

## Changes
- `src/templates/signup-block/form-signup-block.vue` — lê `route.query.plan` e usa computed `signupHeading`:
  - `plan === 'pro'` → `"Sign Up for the Pro Plan"`
  - caso contrário → `"Sign Up for a Free Account"` (mantém copy original para Hobby/sem param)

## Test plan
- [ ] Abrir `/signup` (sem query) → "Sign Up for a Free Account".
- [ ] Abrir `/signup?plan=hobby` → "Sign Up for a Free Account".
- [ ] Abrir `/signup?plan=pro&billing-cycle=monthly` → "Sign Up for the Pro Plan".
- [ ] Abrir `/signup?plan=pro&billing-cycle=yearly` → "Sign Up for the Pro Plan".
- [ ] Fluxo de signup completo (cadastro + ativação) continua funcionando idêntico para ambos.