### PR TITLE
[NO-ISSUE] fix: point Compare Plans link to /pricing instead of /plans

### DIFF
--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -67,7 +67,7 @@
 
         <!-- Compare Plans Link (only in step 1) -->
         <a
-          href="https://www.azion.com/en/plans/"
+          href="https://www.azion.com/en/pricing/"
           target="_blank"
           class="text-xs text-[var(--text-color-link)] hover:underline flex items-center gap-1"
         >


### PR DESCRIPTION
## Summary
- O link "Compare Plans" do onboarding apontava para `https://www.azion.com/en/plans/`. A URL canônica é `https://www.azion.com/en/pricing/` (alinhada com o resto do app — `pricing-footer-links.vue` já usa `/pricing/` por padrão).

## Changes
- `src/views/Signup/AdditionalDataView.vue` — href atualizado para `https://www.azion.com/en/pricing/`.

## Test plan
- [ ] Acessar `/signup/additional-data` (step 1).
- [ ] Clicar em "Compare Plans" → abre nova aba em `https://www.azion.com/en/pricing/`.