### PR TITLE
refactor: scope signup localStorage by client_id

### DIFF
--- a/src/composables/useAdditionalDataFormState.js
+++ b/src/composables/useAdditionalDataFormState.js
@@ -1,6 +1,15 @@
-import { computed, ref } from 'vue'
+import { computed, effectScope, ref, watch } from 'vue'
+import { useAccountStore } from '@/stores/account'
+import {
+  readScoped,
+  writeScoped,
+  removeScoped,
+  migrateGuestTo
+} from '@/helpers/client-scoped-storage'
+import { onSwitchAccount } from '@/services/v2/base/auth/session-broadcast'
 
-const STORAGE_KEY = 'additional-data-form-state:v1'
+const BASE_KEY = 'additional-data-form-state:v1'
+
 const FIELD_KEYS = [
   'usageIntent',
   'role',
@@ -12,58 +21,12 @@ const FIELD_KEYS = [
 
 const isStorageAvailable = () => typeof window !== 'undefined' && Boolean(window.localStorage)
 
-const removePersistedState = () => {
-  if (!isStorageAvailable()) return
-  window.localStorage.removeItem(STORAGE_KEY)
-}
-
-const readPersistedState = () => {
-  if (!isStorageAvailable()) return {}
-
-  try {
-    const rawValue = window.localStorage.getItem(STORAGE_KEY)
-    if (!rawValue) return {}
-
-    const parsedValue = JSON.parse(rawValue)
-    if (!parsedValue || typeof parsedValue !== 'object') {
-      removePersistedState()
-      return {}
-    }
-
-    return parsedValue
-  } catch {
-    removePersistedState()
-    return {}
-  }
-}
-
-const writePersistedState = (snapshot) => {
-  if (!isStorageAvailable()) return
-
-  const sanitizedSnapshot = FIELD_KEYS.reduce((acc, key) => {
-    const value = snapshot[key]
-    if (value !== undefined) {
-      acc[key] = value
-    }
-    return acc
-  }, {})
-
-  if (!Object.keys(sanitizedSnapshot).length) {
-    removePersistedState()
-    return
-  }
-
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedSnapshot))
-}
-
-const initialState = readPersistedState()
-
-const _usageIntent = ref(initialState.usageIntent)
-const _role = ref(initialState.role)
-const _companySize = ref(initialState.companySize)
-const _companyWebsite = ref(initialState.companyWebsite)
-const _fullName = ref(initialState.fullName)
-const _termsAccepted = ref(initialState.termsAccepted)
+const _usageIntent = ref(undefined)
+const _role = ref(undefined)
+const _companySize = ref(undefined)
+const _companyWebsite = ref(undefined)
+const _fullName = ref(undefined)
+const _termsAccepted = ref(undefined)
 
 const state = computed(() => ({
   usageIntent: _usageIntent.value,
@@ -73,6 +36,70 @@ const state = computed(() => ({
   fullName: _fullName.value,
   termsAccepted: _termsAccepted.value
 }))
+
+const sanitizeSnapshot = (snapshot) =>
+  FIELD_KEYS.reduce((acc, key) => {
+    if (snapshot[key] !== undefined) acc[key] = snapshot[key]
+    return acc
+  }, {})
+
+const writePersistedState = () => {
+  const sanitized = sanitizeSnapshot(state.value)
+  if (!Object.keys(sanitized).length) {
+    removeScoped(BASE_KEY)
+    return
+  }
+  writeScoped(BASE_KEY, sanitized)
+}
+
+const applyToRefs = (data) => {
+  const snapshot = data || {}
+  _usageIntent.value = snapshot.usageIntent
+  _role.value = snapshot.role
+  _companySize.value = snapshot.companySize
+  _companyWebsite.value = snapshot.companyWebsite
+  _fullName.value = snapshot.fullName
+  _termsAccepted.value = snapshot.termsAccepted
+}
+
+const hydrateFromScope = () => {
+  applyToRefs(readScoped(BASE_KEY))
+}
+
+let _isSynced = false
+const _moduleScope = effectScope(true)
+
+const setupSync = () => {
+  if (_isSynced) return
+  _isSynced = true
+  if (!isStorageAvailable()) return
+
+  const accountStore = useAccountStore()
+
+  hydrateFromScope()
+
+  _moduleScope.run(() => {
+    watch(
+      () => accountStore.account?.client_id,
+      (newId, oldId) => {
+        if (newId && !oldId) {
+          migrateGuestTo(BASE_KEY, newId)
+          hydrateFromScope()
+        } else if (newId && oldId && newId !== oldId) {
+          applyToRefs(undefined)
+          hydrateFromScope()
+        } else if (!newId && oldId) {
+          applyToRefs(undefined)
+        }
+      }
+    )
+  })
+
+  onSwitchAccount(() => {
+    applyToRefs(undefined)
+    hydrateFromScope()
+  })
+}
 
 const setField = (key, value) => {
   switch (key) {
@@ -96,7 +123,7 @@ const setField = (key, value) => {
       break
   }
 
-  writePersistedState(state.value)
+  writePersistedState()
 }
 
 const hydrate = (fields = {}) => {
@@ -109,16 +136,12 @@ const hydrate = (fields = {}) => {
 }
 
 const clear = () => {
-  _usageIntent.value = undefined
-  _role.value = undefined
-  _companySize.value = undefined
-  _companyWebsite.value = undefined
-  _fullName.value = undefined
-  _termsAccepted.value = undefined
-  removePersistedState()
+  applyToRefs(undefined)
+  removeScoped(BASE_KEY)
 }
 
 export function useAdditionalDataFormState() {
+  setupSync()
   return {
     state,
     setField,

--- a/src/composables/usePlans.js
+++ b/src/composables/usePlans.js
@@ -1,22 +1,98 @@
-import { computed, onScopeDispose, ref, watch } from 'vue'
+import { computed, effectScope, onScopeDispose, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useAccountStore } from '@/stores/account'
+import {
+  readScoped,
+  writeScoped,
+  removeScoped,
+  migrateGuestTo
+} from '@/helpers/client-scoped-storage'
+import { onSwitchAccount } from '@/services/v2/base/auth/session-broadcast'
 
+const BASE_KEY = 'plans:v1'
 const VALID_PLANS = ['hobby', 'pro']
 const VALID_BILLING_CYCLES = ['monthly', 'yearly']
 
 const isValidPlan = (value) => VALID_PLANS.includes(value)
 const isValidBillingCycle = (value) => VALID_BILLING_CYCLES.includes(value)
 
+const isStorageAvailable = () => typeof window !== 'undefined' && Boolean(window.localStorage)
+
 // Signup-scoped state. The user is in a single onboarding flow at a time, so
 // sharing the plan/cycle choice across the components in that flow is
-// intentional. Module-level refs survive in-session navigation; URL params
-// (?plan, ?billing-cycle) are the source of truth across reloads/deep links.
+// intentional. Module-level refs survive in-session navigation; localStorage
+// scoped by client_id is the source of truth across reloads, deep links, and
+// account switches (storage wins over URL).
 const _plan = ref(null)
 const _billingCycle = ref(null)
+
+const persistScope = () => {
+  if (!isStorageAvailable()) return
+  const value = { plan: _plan.value, billingCycle: _billingCycle.value }
+  if (!value.plan && !value.billingCycle) {
+    removeScoped(BASE_KEY)
+    return
+  }
+  writeScoped(BASE_KEY, value)
+}
+
+const hydrateFromScope = () => {
+  const stored = readScoped(BASE_KEY)
+  if (stored && (stored.plan || stored.billingCycle)) {
+    _plan.value = stored.plan ?? null
+    _billingCycle.value = stored.billingCycle ?? null
+    return true
+  }
+  return false
+}
+
+let _isSynced = false
+const _moduleScope = effectScope(true)
+
+const setupSync = (accountStore) => {
+  if (_isSynced) return
+  _isSynced = true
+
+  _moduleScope.run(() => {
+    watch([_plan, _billingCycle], persistScope)
+
+    watch(
+      () => accountStore.account?.client_id,
+      (newId, oldId) => {
+        if (newId && !oldId) {
+          migrateGuestTo(BASE_KEY, newId)
+          hydrateFromScope()
+        } else if (newId && oldId && newId !== oldId) {
+          _plan.value = null
+          _billingCycle.value = null
+          if (!hydrateFromScope()) {
+            _plan.value = 'pro'
+            _billingCycle.value = 'monthly'
+          }
+        } else if (!newId && oldId) {
+          _plan.value = null
+          _billingCycle.value = null
+        }
+      }
+    )
+  })
+
+  onSwitchAccount(() => {
+    _plan.value = null
+    _billingCycle.value = null
+    if (!hydrateFromScope()) {
+      _plan.value = 'pro'
+      _billingCycle.value = 'monthly'
+    }
+  })
+}
 
 export function usePlans() {
   const route = useRoute()
   const router = useRouter()
+  const accountStore = useAccountStore()
+
+  setupSync(accountStore)
 
   const readFromUrl = () => {
     if (!route) return null
@@ -56,6 +132,11 @@ export function usePlans() {
   }
 
   const initialize = () => {
+    if (hydrateFromScope()) {
+      syncToUrl()
+      return
+    }
+
     const urlParams = readFromUrl()
     if (urlParams) {
       _plan.value = urlParams.plan || null
@@ -90,6 +171,7 @@ export function usePlans() {
   const clear = async () => {
     _plan.value = null
     _billingCycle.value = null
+    removeScoped(BASE_KEY)
     await syncToUrl()
   }
 

--- a/src/helpers/client-scoped-storage.js
+++ b/src/helpers/client-scoped-storage.js
@@ -1,0 +1,71 @@
+import { useAccountStore } from '@/stores/account'
+
+const GUEST_NAMESPACE = 'guest'
+
+const isStorageAvailable = () => typeof window !== 'undefined' && Boolean(window.localStorage)
+
+const namespaceFor = (clientId) => {
+  if (clientId === null || clientId === undefined || clientId === '') return GUEST_NAMESPACE
+  return String(clientId)
+}
+
+const currentNamespace = () => {
+  try {
+    const store = useAccountStore()
+    return namespaceFor(store.account?.client_id)
+  } catch {
+    return GUEST_NAMESPACE
+  }
+}
+
+export const buildScopedKey = (baseKey, clientId) => `client:${namespaceFor(clientId)}:${baseKey}`
+
+export const scopedKey = (baseKey) => `client:${currentNamespace()}:${baseKey}`
+
+export const readScoped = (baseKey) => {
+  if (!isStorageAvailable()) return null
+  try {
+    const raw = window.localStorage.getItem(scopedKey(baseKey))
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export const writeScoped = (baseKey, value) => {
+  if (!isStorageAvailable()) return
+  try {
+    window.localStorage.setItem(scopedKey(baseKey), JSON.stringify(value))
+  } catch {
+    // ignore quota or serialization errors
+  }
+}
+
+export const removeScoped = (baseKey) => {
+  if (!isStorageAvailable()) return
+  try {
+    window.localStorage.removeItem(scopedKey(baseKey))
+  } catch {
+    // ignore
+  }
+}
+
+// Moves data from `client:guest:{baseKey}` to `client:{clientId}:{baseKey}`.
+// If a value already exists for the target client_id, the existing value wins
+// (the authenticated user's previous choice is more authoritative) and the
+// guest entry is discarded.
+export const migrateGuestTo = (baseKey, clientId) => {
+  if (!isStorageAvailable() || !clientId) return
+  const sourceKey = buildScopedKey(baseKey, null)
+  const targetKey = buildScopedKey(baseKey, clientId)
+  try {
+    const guestValue = window.localStorage.getItem(sourceKey)
+    if (!guestValue) return
+    if (!window.localStorage.getItem(targetKey)) {
+      window.localStorage.setItem(targetKey, guestValue)
+    }
+    window.localStorage.removeItem(sourceKey)
+  } catch {
+    // ignore
+  }
+}

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -85,7 +85,7 @@
   import ChoosingPlanContainer from '@/templates/signup-block/choosing-plan-container.vue'
   import PlanSuccessBlock from '@/templates/signup-block/plan-success-block.vue'
   import ActionButton from '@aziontech/webkit/actions/button'
-  import { computed, inject, onMounted, ref } from 'vue'
+  import { computed, inject, onMounted, ref, watch } from 'vue'
   import { useRouter } from 'vue-router'
   import { usePlans } from '@/composables/usePlans'
   import { usePlansList, ensurePlansList, getPlanPricingId } from '@/composables/usePlansService'
@@ -107,7 +107,11 @@
       .catch(Sentry.captureException)
   }
   const { clear: clearAdditionalDataFormState } = useAdditionalDataFormState()
-  const { initialize: initializePlans, billingCycle: storedBillingCycle } = usePlans()
+  const {
+    initialize: initializePlans,
+    billingCycle: storedBillingCycle,
+    clear: clearPlans
+  } = usePlans()
   const accountStore = useAccountStore()
   // Auto-fetch on mount when the cache entry is stale/missing (staleTime
   // 1h). The view reads `plansData.value` reactively in helpers like
@@ -269,10 +273,15 @@
   }
 
   const handleStartFromSuccess = () => {
-    clearAdditionalDataFormState()
     invalidateBillingCaches()
     router.push({ name: 'home' })
   }
+
+  watch(isSuccessStep, (reachedSuccess) => {
+    if (!reachedSuccess) return
+    clearAdditionalDataFormState()
+    clearPlans()
+  })
 
   onMounted(async () => {
     initializePlans()


### PR DESCRIPTION
## Feature

### Description

Escopa os dados persistidos no `localStorage` durante o fluxo de signup/contratação por `client_id`, evitando que a seleção de plano e os dados do formulário de additional-data de um usuário vazem para outro no mesmo navegador.

**Mudanças principais:**

- **`src/helpers/client-scoped-storage.js`** *(novo)* — helper centralizando o scoping (`client:{clientId}:{baseKey}`), com fallback `client:guest:*` para sessões pré-login e migração `guest → client_id` no momento da autenticação.
- **`src/composables/useAdditionalDataFormState.js`** — persistência migrada para o helper scoped. Watcher em `accountStore.account.client_id` re-hidrata as refs em troca de conta, login (com migração de `guest`) e logout. Listener `onSwitchAccount` cobre o caso cross-tab.
- **`src/composables/usePlans.js`** — adicionada persistência scoped em `client:{id}:plans:v1`. `initialize()` agora prioriza localStorage sobre URL (storage vence) e ressincroniza a URL. Defaults `pro/monthly` aplicam só quando não há storage nem URL.
- **`src/views/Signup/AdditionalDataView.vue`** — `watch(isSuccessStep)` limpa as duas chaves do `client_id` atual assim que o checkout finaliza, sem depender do clique em "Start Deploying".

**Comportamento por chave (ex.: dois usuários no mesmo navegador):**

```
localStorage
├── client:12345:additional-data-form-state:v1  → dados do user A
├── client:12345:plans:v1                       → plano do user A
├── client:67890:additional-data-form-state:v1  → dados do user B
└── client:67890:plans:v1                       → plano do user B
```

API pública dos composables permanece intacta — nenhum consumidor (`AdditionalDataView.vue`, `additional-data-form-block.vue`, `plan-selection-drawer.vue`, `LoginView.vue`, `BillsView.vue`, `DrawerPlanInfo.vue`, `pricing-calculation-block.vue`) precisou mudar.

### How to test

1. **Isolamento entre contas:**
   - Limpar localStorage. Logar como user A.
   - Iniciar signup, preencher additional-data (`fullName`, `companySize`, etc.) e selecionar plano `pro`.
   - Confirmar no DevTools que existem `client:{idA}:additional-data-form-state:v1` e `client:{idA}:plans:v1`.
   - Fazer logout (chaves permanecem).
   - Logar como user B.
   - Confirmar que o form abre vazio e plano cai nos defaults (`pro/monthly`) ou no estado salvo de B.
   - Logar novamente como user A → estado de A volta a ser exibido.

2. **Pré-login via deep link:**
   - Sem login, abrir `http://localhost:5173/signup?plan=pro&billing-cycle=yearly`.
   - Confirmar `client:guest:plans:v1` no localStorage.
   - Completar signup → após `client_id` chegar no `accountStore`, `client:guest:plans:v1` desaparece e `client:{clientId}:plans:v1` é criada com o mesmo conteúdo.

3. **localStorage vence sobre URL:**
   - Logado como A com `plan=hobby` salvo, abrir `/signup?plan=pro` → URL é reescrita para `?plan=hobby`.

4. **Cleanup pós-checkout:**
   - Concluir o checkout até a tela de sucesso (`PlanSuccessBlock`).
   - Confirmar que `client:{clientId}:additional-data-form-state:v1` e `client:{clientId}:plans:v1` são removidas no instante em que a tela de sucesso aparece — mesmo sem clicar em "Start Deploying".

5. **Account switch cross-tab:**
   - Duas abas abertas com user A.
   - Trocar de conta em uma aba → a outra aba re-hidrata via `onSwitchAccount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)