### PR TITLE
[NO-ISSUE] refactor: signup onboarding fixes and copy alignment

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -88,6 +88,16 @@
       "origin-id": 249560,
       "origin-key": "692eae10-1ab6-402c-ad7a-c1d9d6a1fe74",
       "name": "origin-help-center"
+    },
+    {
+      "origin-id": 261404,
+      "origin-key": "d5f048ce-e3bf-476b-b002-be739a49870a",
+      "name": "origin-edge-api"
+    },
+    {
+      "origin-id": 261413,
+      "origin-key": "91464f6b-b496-4f10-b513-33173a095ec0",
+      "name": "origin-edge-api"
     }
   ],
   "rules-engine": {
@@ -222,6 +232,26 @@
         "id": 488886,
         "name": "Cache Controll to index.html",
         "phase": "response"
+      },
+      {
+        "id": 563188,
+        "name": "Route Edge API Requests",
+        "phase": "request"
+      },
+      {
+        "id": 537350,
+        "name": "Run Function | SSE Beholder Proxy",
+        "phase": "request"
+      },
+      {
+        "id": 488499,
+        "name": "Debug",
+        "phase": "response"
+      },
+      {
+        "id": 563632,
+        "name": "Route Edge API Requests",
+        "phase": "request"
       }
     ]
   },
@@ -237,6 +267,10 @@
     {
       "id": 266296,
       "name": "Statics - Cache .html"
+    },
+    {
+      "id": 261825,
+      "name": "Marketplace - Cache"
     }
   ]
 }

--- a/src/composables/useCurrentSubscription.js
+++ b/src/composables/useCurrentSubscription.js
@@ -73,7 +73,7 @@ export function useCurrentSubscription() {
   const isHobby = computed(() => planSku.value === 'hobby')
 
   const planTitle = computed(() => (isPro.value ? 'Pro Plan' : 'Hobby'))
-  const planTag = computed(() => (hasContractedPlan.value ? 'Actual Plan' : null))
+  const planTag = computed(() => (hasContractedPlan.value ? 'Current Plan' : null))
 
   const planStartDate = computed(() =>
     formatPlanStartDate(activeServiceOrder.value?.currentPeriodStart)

--- a/src/helpers/persist-onboarding-data.js
+++ b/src/helpers/persist-onboarding-data.js
@@ -1,0 +1,123 @@
+import { useAccountStore } from '@/stores/account'
+import { useAdditionalDataFormState } from '@/composables/useAdditionalDataFormState'
+import {
+  postAdditionalDataService,
+  patchFullnameService,
+  updateAccountInfoService
+} from '@/services/signup-services'
+
+const USAGE_INTENT_TO_API_VALUE = {
+  learn: 'Study',
+  'personal-projects': 'Personal',
+  work: 'Work'
+}
+
+const COMPANY_SIZE_TO_API_VALUE = {
+  'just-me': 'Just me',
+  '2-100': '2 to 100 employees',
+  '101-500': '101 to 500 employees',
+  '501-1000': '501 to 1000 employees',
+  '1001+': '1001+ employees'
+}
+
+const ADDITIONAL_DATA_INFO = [
+  {
+    id: 1,
+    key: 'How are you planning to use Azion?',
+    values: [
+      { id: 1, value: 'Personal', other_values: false },
+      { id: 2, value: 'Work', other_values: false },
+      { id: 3, value: 'Study', other_values: false }
+    ]
+  },
+  {
+    id: 2,
+    key: 'What best describes your role?',
+    values: [
+      { id: 4, value: 'Software Developer', other_values: false },
+      { id: 5, value: 'DevOps Engineer', other_values: false },
+      { id: 6, value: 'Infrastructure Analyst', other_values: false },
+      { id: 7, value: 'Network Engineer', other_values: false },
+      { id: 8, value: 'Security Specialist', other_values: false },
+      { id: 9, value: 'Data Engineer', other_values: false },
+      { id: 10, value: 'AI/ML Engineer', other_values: false },
+      { id: 11, value: 'IoT Engineer', other_values: false },
+      { id: 12, value: 'Team Lead', other_values: false },
+      { id: 13, value: 'Other', other_values: true }
+    ]
+  },
+  {
+    id: 3,
+    key: 'How big is your company?',
+    values: [
+      { id: 14, value: 'Just me', other_values: false },
+      { id: 15, value: '2 to 100 employees', other_values: false },
+      { id: 16, value: '101 to 500 employees', other_values: false },
+      { id: 17, value: '501 to 1000 employees', other_values: false },
+      { id: 18, value: '1001+ employees', other_values: false }
+    ]
+  },
+  {
+    id: 999,
+    key: 'Your Full Name',
+    values: []
+  },
+  {
+    id: 4,
+    key: 'Company Website?',
+    values: [{ id: 19, value: '', other_values: true }]
+  },
+  {
+    id: 5,
+    key: 'Do you want to schedule an onboarding session with an Azion expert?',
+    values: [
+      { id: 20, value: 'Yes', other_values: false },
+      { id: 21, value: 'No', other_values: false }
+    ]
+  }
+]
+
+export const persistOnboardingData = async ({ plan } = {}) => {
+  const accountStore = useAccountStore()
+  const { state } = useAdditionalDataFormState()
+  const { usageIntent, role, companySize, companyWebsite, fullName, termsAccepted } = state.value
+
+  const usersPayload = fullName || ''
+  const [firstName = '', ...lastNameParts] = usersPayload.split(' ')
+  const lastName = lastNameParts.join(' ')
+  const userId = accountStore.userId
+
+  const requests = [
+    updateAccountInfoService(role),
+    patchFullnameService(usersPayload)
+  ]
+
+  if (!accountStore.accountData?.jobRole) {
+    requests.push(
+      postAdditionalDataService({
+        payload: {
+          id: userId,
+          use: USAGE_INTENT_TO_API_VALUE[usageIntent],
+          role,
+          inputRole: undefined,
+          companySize: COMPANY_SIZE_TO_API_VALUE[companySize],
+          onboardingSession: termsAccepted,
+          companyWebsite,
+          plan,
+          fullName: usersPayload
+        },
+        options: ADDITIONAL_DATA_INFO
+      })
+    )
+  }
+
+  const [updatedAccount] = await Promise.all(requests)
+
+  accountStore.setAccountData({
+    jobRole: updatedAccount.jobRole,
+    first_name: firstName,
+    last_name: lastName,
+    firstName,
+    lastName
+  })
+}

--- a/src/helpers/persist-onboarding-data.js
+++ b/src/helpers/persist-onboarding-data.js
@@ -87,10 +87,7 @@ export const persistOnboardingData = async ({ plan } = {}) => {
   const lastName = lastNameParts.join(' ')
   const userId = accountStore.userId
 
-  const requests = [
-    updateAccountInfoService(role),
-    patchFullnameService(usersPayload)
-  ]
+  const requests = [updateAccountInfoService(role), patchFullnameService(usersPayload)]
 
   if (!accountStore.accountData?.jobRole) {
     requests.push(

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import '@aziontech/icons'
 import '@aziontech/webkit/styles/country-flags'
 
 import { createApp } from 'vue'
-import { createPinia } from 'pinia'
+import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { WebkitPlugin } from '@aziontech/webkit/plugin'
 import { install as VueMonacoEditorPlugin } from '@guolao/vue-monaco-editor'
@@ -29,6 +29,7 @@ const app = createApp(App)
 
 const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
+setActivePinia(pinia)
 
 app.config.globalProperties.HelpCenterServices = HelpCenterServices
 app.use(WebkitPlugin)

--- a/src/plugins/analytics/trackers/BillingTracker.js
+++ b/src/plugins/analytics/trackers/BillingTracker.js
@@ -37,7 +37,7 @@ export class BillingTracker {
    */
   planSelected(payload) {
     this.#trackerAdapter.addEvent({
-      eventName: 'Plan Selected',
+      eventName: 'Selected Plan',
       props: {
         plan: payload?.plan,
         billingCycle: payload?.billingCycle,

--- a/src/templates/checkout-block/helpers/plan-features.js
+++ b/src/templates/checkout-block/helpers/plan-features.js
@@ -3,10 +3,8 @@ export const PRO_UPGRADE_HIGHLIGHTS = [
   { title: '20 GB Object Storage' },
   { title: '20M Application requests' },
   { title: '20M Firewall requests' },
-  { title: '10 hours Function compute time' },
-  { title: '2 GB Real-Time Events Storage' },
-  { title: 'DDoS Protection included' },
-  { title: 'SOC 2 Type 2 / SOC 3' }
+  { title: '10 hours Functions compute time' },
+  { title: '2 GB Real-Time Events Storage' }
 ]
 
 export const PLAN_INFO = {

--- a/src/templates/checkout-block/helpers/plan-features.js
+++ b/src/templates/checkout-block/helpers/plan-features.js
@@ -24,16 +24,14 @@ export const PLAN_INFO = {
   pro: {
     label: 'Pro',
     features: [
-      { title: '100 Workloads', description: 'then $0.10 per workload per month' },
-      { title: '10M Application requests', description: 'then as low as $0.90 per 1M' },
-      { title: '50 hours Function compute time', description: 'then $0.18 per hour' },
-      { title: '10 GB Real-Time Events Storage', description: 'then $0.10 per GB-month' },
-      { title: '100 GB Object Storage', description: 'then as low as $0.021 per GB-month' },
+      { title: '20 Workloads', description: 'then $0.10 per workload per month' },
+      { title: '20M Application requests', description: 'then as low as $0.90 per 1M' },
+      { title: '10 hours Function compute time', description: 'then $0.18 per hour' },
+      { title: '2 GB Real-Time Events Storage', description: 'then $0.10 per GB-month' },
+      { title: '20 GB Object Storage', description: 'then as low as $0.021 per GB-month' },
       { title: '1 GB SQL Database Storage', description: 'then $0.75 per GB-month' },
-      { title: '100M Firewall requests', description: 'then as low as $0.30 per 1M' },
+      { title: '20M Firewall requests', description: 'then as low as $0.30 per 1M' },
       { title: 'DDoS Protection included' },
-      { title: 'PCI DSS 4.0.1 Level 1' },
-      { title: 'SOC 2 Type 2 / SOC 3' },
       { title: 'Universal Data Migration Service' }
     ]
   }

--- a/src/templates/checkout-block/pricing-footer-links.vue
+++ b/src/templates/checkout-block/pricing-footer-links.vue
@@ -26,6 +26,6 @@
 
   defineProps({
     pricingUrl: { type: String, default: 'https://www.azion.com/en/pricing/' },
-    comparePlansUrl: { type: String, default: 'https://www.azion.com/en/pricing/' }
+    comparePlansUrl: { type: String, default: 'https://www.azion.com/en/plans/' }
   })
 </script>

--- a/src/templates/checkout-block/pricing-summary.vue
+++ b/src/templates/checkout-block/pricing-summary.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col">
     <div class="bg-surface flex flex-col gap-6 px-6 py-6">
       <div class="flex items-center justify-between h-6">
-        <span class="text-sm leading-none text-muted">Next Charge Value</span>
+        <span class="text-sm leading-none text-muted">Next Charge Amount</span>
         <Currency
           size="small"
           prefix="$"

--- a/src/templates/home-cards-block/last-activities-block.vue
+++ b/src/templates/home-cards-block/last-activities-block.vue
@@ -133,7 +133,7 @@
       :loading="false"
       :rowsLimit="ROWS_LIMIT"
       viewAllLink="/activity-history"
-      viewAllLabel="View all Activities..."
+      viewAllLabel="View all Activity..."
       :emptyBlock="{
         title: 'No activities yet',
         description: 'Your recent activities will appear here.'

--- a/src/templates/home-cards-block/workloads-empty-state.vue
+++ b/src/templates/home-cards-block/workloads-empty-state.vue
@@ -26,7 +26,7 @@
     },
     {
       title: 'Start from Scratch',
-      description: `Start from blank ${handleTextDomainWorkload.singularTitle}.`,
+      description: `Start from a blank ${handleTextDomainWorkload.singularTitle}.`,
       buttonLabel: 'Create',
       action: handleCreateFromScratch
     }

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -9,7 +9,7 @@
     >
       <!-- Plan Selector Card -->
       <div class="flex flex-col gap-2">
-        <label class="text-xs leading-4 text-color-secondary">Plan Selected</label>
+        <label class="text-xs leading-4 text-color-secondary">Selected Plan</label>
         <PlanSelectorCard
           :plan="plan"
           :planData="selectedPlanData"

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -1,7 +1,7 @@
 <template>
   <form
     class="w-full flex flex-col"
-    @submit.prevent="submitForm"
+    @submit.prevent
   >
     <div
       class="flex flex-col gap-8"

--- a/src/templates/signup-block/form-signup-block.vue
+++ b/src/templates/signup-block/form-signup-block.vue
@@ -9,7 +9,7 @@
             @submit.prevent
           >
             <div class="gap-2 flex flex-col">
-              <h1 class="text-start text-xl lg:text-2xl font-medium">Sign Up for a Free Account</h1>
+              <h1 class="text-start text-xl lg:text-2xl font-medium">{{ signupHeading }}</h1>
             </div>
 
             <div>
@@ -78,17 +78,22 @@
   import PrimeButton from '@aziontech/webkit/button'
   import PrimeDivider from '@aziontech/webkit/divider'
   import LoginWithEmailBlock from '@/templates/signup-block/login-with-email-block'
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+  import { computed, ref } from 'vue'
+  import { useRoute, useRouter } from 'vue-router'
 
   const props = defineProps({
     signupService: { required: true, type: Function },
     resendEmailService: { required: true, type: Function }
   })
 
+  const route = useRoute()
   const router = useRouter()
   const showLoginFromEmail = ref(true)
   const showActivation = ref(true)
+
+  const signupHeading = computed(() =>
+    route.query.plan === 'pro' ? 'Sign Up for the Pro Plan' : 'Sign Up for a Free Account'
+  )
 
   const showActivationEmail = () => {
     showActivation.value = false

--- a/src/templates/signup-block/plan-selection-drawer.vue
+++ b/src/templates/signup-block/plan-selection-drawer.vue
@@ -222,10 +222,15 @@
   })
 
   const planOptions = computed(() => {
-    if (!props.relativeLabels) return BASE_PLAN_OPTIONS.value
+    if (props.relativeLabels) {
+      return BASE_PLAN_OPTIONS.value.map((option) => ({
+        ...option,
+        buttonLabel: getRelativeLabel(option.value)
+      }))
+    }
     return BASE_PLAN_OPTIONS.value.map((option) => ({
       ...option,
-      buttonLabel: getRelativeLabel(option.value)
+      buttonLabel: isCurrentPlanSelection(option.value) ? 'Selected Plan' : option.buttonLabel
     }))
   })
 

--- a/src/templates/signup-block/plan-selection-drawer.vue
+++ b/src/templates/signup-block/plan-selection-drawer.vue
@@ -57,10 +57,10 @@
 
           <div class="flex flex-col gap-2">
             <p
-              v-if="getSectionTitle(planOption)"
-              class="text-xs leading-none text-color-secondary"
+              v-if="planOption?.sectionTitle"
+              class="text-xs leading-none text-[var(--text-muted)]"
             >
-              {{ getSectionTitle(planOption) }}
+              {{ planOption?.sectionTitle }}
             </p>
             <ul class="flex flex-col gap-2">
               <li
@@ -278,8 +278,6 @@
 
   const isLoadingPlan = (planValue) =>
     Boolean(props.loadingPlan) && props.loadingPlan.toLowerCase() === planValue.toLowerCase()
-
-  const getSectionTitle = (planOption) => planOption?.sectionTitle ?? ''
 
   const getIconFeatures = (planOption) => {
     return (planOption?.features ?? []).filter((feature) => Boolean(feature?.icon))

--- a/src/templates/signup-block/plan-selector-card.vue
+++ b/src/templates/signup-block/plan-selector-card.vue
@@ -65,7 +65,7 @@
     pro: {
       label: 'Pro',
       tagLabel: 'Pro Plan',
-      description: 'For professional or commercial workloads.'
+      description: 'For professional or commercial use.'
     }
   }
 

--- a/src/templates/signup-block/plan-success-block.vue
+++ b/src/templates/signup-block/plan-success-block.vue
@@ -34,7 +34,7 @@
           </div>
           <div class="flex flex-col gap-1">
             <p class="text-[13px] font-semibold text-[var(--text-color)]">
-              Start by creating your first Deploy
+              Start by deploying your first application
             </p>
             <p class="text-xs text-[var(--text-color-secondary)]">
               Deploy your application and start delivering content through the Azion Network.
@@ -51,7 +51,7 @@
           </div>
           <div class="flex flex-col gap-1">
             <p class="text-[13px] font-semibold text-[var(--text-color)]">
-              Protect your Application
+              Protect your Applications
             </p>
             <p class="text-xs text-[var(--text-color-secondary)]">
               Enable security features to safeguard your applications, users, and data.
@@ -67,9 +67,9 @@
             <span class="font-protomono font-semibold text-xs text-white">3</span>
           </div>
           <div class="flex flex-col gap-1">
-            <p class="text-[13px] font-semibold text-[var(--text-color)]">Observe your Metrics</p>
+            <p class="text-[13px] font-semibold text-[var(--text-color)]">Monitor your Metrics</p>
             <p class="text-xs text-[var(--text-color-secondary)]">
-              Track metrics, analyze traffic in real-time, and gain insights to optimize and protect
+              Track metrics, analyze traffic in real time, and gain insights to optimize and protect
               your applications.
             </p>
           </div>

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -355,7 +355,6 @@
     nextChargeDate: computed(() => subscription.nextChargeDate.value),
     nextChargeValue: computed(() => subscription.nextChargeValue.value),
     planChargeValue: computed(() => subscription.planChargeValue.value),
-    hasContractedPlan: computed(() => subscription.hasContractedPlan.value),
     isHobby: computed(() => subscription.isHobby.value),
     isPro: computed(() => subscription.isPro.value),
     isLoading: computed(() => subscription.isLoading.value),

--- a/src/views/Billing/Dialog/PlanFeatureComparison.vue
+++ b/src/views/Billing/Dialog/PlanFeatureComparison.vue
@@ -5,7 +5,7 @@
         <span class="text-sm font-semibold text-color">{{ fromPlanLabel }}</span>
         <span
           class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold bg-orange-500/15 text-orange-500 border border-orange-500/30"
-          >Actual Plan</span
+          >Current Plan</span
         >
       </div>
       <div class="flex items-center">

--- a/src/views/Billing/components/SubscriptionPlanCard.vue
+++ b/src/views/Billing/components/SubscriptionPlanCard.vue
@@ -51,7 +51,7 @@
           </SkeletonBlock>
         </SubscriptionPlanRow>
 
-        <SubscriptionPlanRow label="Next Charge Value">
+        <SubscriptionPlanRow label="Next Charge Amount">
           <SkeletonBlock
             :isLoaded="!subscription.isLoading"
             class="text-color"
@@ -86,7 +86,7 @@
 
     <template #footer>
       <p class="w-full text-xs leading-5 text-color-secondary">
-        This invoice includes all consumption up to the last day of the month. Change
+        This invoice includes all usage up to the last day of the month. Change
         <span
           class="text-[var(--text-color-link)] cursor-pointer"
           @click="emit('go-to-payment')"

--- a/src/views/Billing/components/SubscriptionPlanCard.vue
+++ b/src/views/Billing/components/SubscriptionPlanCard.vue
@@ -86,13 +86,7 @@
 
     <template #footer>
       <p class="w-full text-xs leading-5 text-color-secondary">
-        This invoice includes all usage up to the last day of the month. Change
-        <span
-          class="text-[var(--text-color-link)] cursor-pointer"
-          @click="emit('go-to-payment')"
-        >
-          payment method.
-        </span>
+        This invoice includes all usage up to the last day of the month.
       </p>
     </template>
   </CardBox>

--- a/src/views/Billing/components/UpgradeToProCard.vue
+++ b/src/views/Billing/components/UpgradeToProCard.vue
@@ -16,8 +16,7 @@
           </div>
         </div>
         <p class="text-sm leading-[1.25] text-color-secondary">
-          Upgrade to unlock higher limits and keep your applications running at scale. Explore
-          additional capabilities available with the Pro plan:
+          Upgrade to unlock higher limits and keep your applications running at scale.
         </p>
       </div>
     </template>

--- a/src/views/Billing/plan-comparison-features.js
+++ b/src/views/Billing/plan-comparison-features.js
@@ -2,7 +2,7 @@ export const PLAN_COMPARISON_FEATURES = {
   hobby: {
     label: 'Hobby',
     tagline: 'Start free for personal projects and learning.',
-    description: 'Start free for personal projects and learning.',
+    description: 'All products and features available.',
     sectionTitle: 'All features available',
     features: [
       { title: 'Global infrastructure', icon: 'pi pi-globe text-[var(--primary)]' },

--- a/src/views/Billing/plan-comparison-features.js
+++ b/src/views/Billing/plan-comparison-features.js
@@ -1,41 +1,41 @@
 export const PLAN_COMPARISON_FEATURES = {
   hobby: {
     label: 'Hobby',
-    tagline: 'The perfect starting place',
+    tagline: 'Start free for personal projects and learning.',
     description: 'Start free for personal projects and learning.',
     sectionTitle: 'All features available',
     features: [
-      { title: 'Global infrastructure', icon: 'pi pi-globe' },
-      { title: 'Serverless functions', icon: 'pi pi-code' },
-      { title: 'Image optimization', icon: 'pi pi-image' },
-      { title: 'Storage & SQL Database', icon: 'pi pi-database' },
-      { title: 'Firewall', icon: 'pi pi-shield' }
+      { title: 'Global infrastructure', icon: 'pi pi-globe text-[var(--primary)]' },
+      { title: 'Serverless functions', icon: 'ai ai-edge-functions text-[var(--primary)]' },
+      { title: 'Storage & SQL Database', icon: 'ai ai-store text-[var(--primary)]' },
+      { title: 'Image optimization', icon: 'pi pi-image text-[var(--primary)]' },
+      { title: 'DDoS protection & firewall', icon: 'pi pi-shield text-[var(--primary)]' }
     ]
   },
   pro: {
     label: 'Pro',
-    tagline: 'Billed annually or $25/mo billed monthly.',
+    tagline: 'For growing applications that need more.',
     description: 'Billed annually or $25/mo billed monthly.',
-    sectionTitle: 'All Free features, plus',
+    sectionTitle: 'Scale beyond included limits',
     features: [
-      { title: 'Additional workloads', icon: 'pi pi-box' },
-      { title: 'Higher application limits', icon: 'pi pi-check-circle' },
-      { title: 'Real-time event observability', icon: 'pi pi-eye' },
-      { title: 'Enhanced security features', icon: 'pi pi-shield' },
-      { title: 'Technical Support', icon: 'pi pi-question-circle' }
+      { title: 'Additional workloads', icon: 'ai ai-workloads text-[var(--primary)]' },
+      { title: 'Higher application limits', icon: 'ai ai-edge-application text-[var(--primary)]' },
+      { title: 'More storage capacity', icon: 'ai ai-edge-storage text-[var(--primary)]' },
+      { title: 'Broader security coverage', icon: 'ai ai-secure-pillar text-[var(--primary)]' },
+      { title: 'Configurable spend limits', icon: 'pi pi-dollar text-[var(--primary)]' }
     ]
   },
   enterprise: {
     label: 'Enterprise',
-    tagline: 'Advanced support and ongoing services.',
-    description: 'Billed annually or $250/mo billed monthly.',
+    tagline: 'Optimize costs with commitment-based savings.',
+    description: 'Billed annually or custom billed monthly.',
     sectionTitle: 'Choose your pricing model',
     features: [
-      { title: 'On-demand pricing', icon: 'pi pi-check-circle' },
-      { title: 'Lower costs with commitments', icon: 'pi pi-check-circle' },
-      { title: 'Reserved Capacity available', icon: 'pi pi-check-circle' },
-      { title: 'Savings Plans available', icon: 'pi pi-check-circle' },
-      { title: 'Service Plans available', icon: 'pi pi-check-circle' }
+      { title: 'On-demand pricing', icon: 'pi pi-wave-pulse text-[var(--primary)]' },
+      { title: 'Lower costs with commitments', icon: 'pi pi-dollar text-[var(--primary)]' },
+      { title: 'Reserved Capacity available', icon: 'pi pi-sliders-v text-[var(--primary)]' },
+      { title: 'Savings Plans available', icon: 'pi pi-money-bill text-[var(--primary)]' },
+      { title: 'Advanced support available', icon: 'pi pi-wrench text-[var(--primary)]' }
     ]
   }
 }

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -25,6 +25,10 @@
   defineOptions({ name: 'home-view' })
 
   const user = accountData
+  const welcomeName = computed(() => {
+    const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ').trim()
+    return fullName || user.name
+  })
   const showInviteDialog = ref(false)
 
   const homeSection = ref(null)
@@ -86,7 +90,7 @@
           :class="homeStyle.firstColumn"
         >
           <div class="flex w-full justify-between items-center">
-            <h1 class="text-[22px] font-semibold">Welcome, {{ user.name }}</h1>
+            <h1 class="text-[22px] font-semibold">Welcome, {{ welcomeName }}</h1>
             <PrimeButton
               icon="pi pi-user-plus"
               severity="secondary"

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="flex flex-col flex-1 var(--bg-color)">
     <!-- Main Content -->
-    <div class="flex-1 flex flex-col items-center py-8 px-4 gap-6">
+    <div
+      :class="[
+        'flex-1 flex flex-col items-center py-8 px-4 gap-6',
+        { 'justify-center': isSuccessStep }
+      ]"
+    >
       <!-- Card Container (only for step 1) -->
       <div class="w-full">
         <CardBox

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -67,7 +67,7 @@
 
         <!-- Compare Plans Link (only in step 1) -->
         <a
-          href="https://www.azion.com/en/plans/"
+          href="https://www.azion.com/en/pricing/"
           target="_blank"
           class="text-xs text-[var(--text-color-link)] hover:underline flex items-center gap-1"
         >

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -5,7 +5,7 @@
       <!-- Card Container (only for step 1) -->
       <div class="w-full">
         <CardBox
-          v-show="isAdditionalDataStep"
+          v-if="isAdditionalDataStep"
           title="How are you planning to use Azion?"
           class="mx-auto max-w-xl"
         >
@@ -28,7 +28,7 @@
           </template>
         </CardBox>
         <div
-          v-if="isCheckoutStep"
+          v-else-if="isCheckoutStep"
           class="w-full"
         >
           <!-- Checkout Component -->
@@ -42,7 +42,7 @@
           />
         </div>
         <PlanSuccessBlock
-          v-if="isSuccessStep"
+          v-else-if="isSuccessStep"
           :plan="selectedPlan"
           @onStart="handleStartFromSuccess"
         />
@@ -95,6 +95,7 @@
   import { markAwaitingActiveServiceOrder } from '@/composables/post-payment-flag'
   import * as Sentry from '@sentry/vue'
   import { loadUserAndAccountInfo } from '@/helpers/account-data'
+  import { persistOnboardingData } from '@/helpers/persist-onboarding-data'
   import { queryClient } from '@/services/v2/base/query/queryClient'
   import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
@@ -174,7 +175,7 @@
 
     if (plan === 'hobby') {
       try {
-        await additionalDataRef.value?.submitForm()
+        await persistOnboardingData({ plan })
         await submitServiceOrder({ accountId, planId })
 
         invalidateBillingCaches()
@@ -251,7 +252,7 @@
     })
     markAwaitingActiveServiceOrder()
     try {
-      await additionalDataRef.value?.submitForm()
+      await persistOnboardingData({ plan: selectedPlan.value })
       invalidateBillingCaches()
       await loadUserAndAccountInfo({ force: true })
     } catch (err) {

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -5,7 +5,7 @@
       <!-- Card Container (only for step 1) -->
       <div class="w-full">
         <CardBox
-          v-if="isAdditionalDataStep"
+          v-show="isAdditionalDataStep"
           title="How are you planning to use Azion?"
           class="mx-auto max-w-xl"
         >
@@ -28,7 +28,7 @@
           </template>
         </CardBox>
         <div
-          v-else-if="isCheckoutStep"
+          v-if="isCheckoutStep"
           class="w-full"
         >
           <!-- Checkout Component -->
@@ -42,7 +42,7 @@
           />
         </div>
         <PlanSuccessBlock
-          v-else-if="isSuccessStep"
+          v-if="isSuccessStep"
           :plan="selectedPlan"
           @onStart="handleStartFromSuccess"
         />
@@ -165,8 +165,6 @@
     const accountId = accountStore.accountData?.id
     const billingCycle = storedBillingCycle.value || 'yearly'
 
-    await additionalDataRef.value?.submitForm()
-
     if (!plan || !accountId) return
 
     trackSignUp('planSelected', { plan, billingCycle })
@@ -176,6 +174,7 @@
 
     if (plan === 'hobby') {
       try {
+        await additionalDataRef.value?.submitForm()
         await submitServiceOrder({ accountId, planId })
 
         invalidateBillingCaches()
@@ -252,6 +251,7 @@
     })
     markAwaitingActiveServiceOrder()
     try {
+      await additionalDataRef.value?.submitForm()
       invalidateBillingCaches()
       await loadUserAndAccountInfo({ force: true })
     } catch (err) {

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -72,7 +72,7 @@
 
         <!-- Compare Plans Link (only in step 1) -->
         <a
-          href="https://www.azion.com/en/pricing/"
+          href="https://www.azion.com/en/plans/"
           target="_blank"
           class="text-xs text-[var(--text-color-link)] hover:underline flex items-center gap-1"
         >


### PR DESCRIPTION
## Summary
- **Pro signup**: PATCH `/v4/iam/account` e PATCH `/v4/iam/user` agora só rodam após confirmação do pagamento Stripe — não mais no clique do Continue. Hobby segue como antes.
- **Pinia warning**: registra `activePinia` globalmente pra resolver o `getActivePinia()` warning disparado pelos guards do Vue Router 4.5+.
- **Welcome name**: usa `first_name + last_name` antes de fallback no `account.name` derivado do email.
- **Compare Plans CTA**: links corrigidos pra `/pricing/` (commit anterior nessa branch).
- **Cleanup**: prop `hasContractedPlan` morta removida do `subscriptionState`.
- **Signup heading**: reflete o plano via query param (`?plan=pro` → "Sign Up for the Pro Plan").
- **Copy / labels / icons**: alinhamentos finos em onboarding, planos, billing e home.

## Root cause (Pro IAM persist)
O `submitForm()` do `additional-data-form-block` dispara 3 chamadas IAM (`updateAccountInfoService`, `patchFullnameService`, `postAdditionalDataService`) que persistem o perfil + setam `first_login=false`. Era chamado no topo do `onSubmit` do AdditionalDataView, antes do branch Hobby/Pro. Resultado: usuário Pro que abandonava o Stripe deixava a conta marcada como "onboarded" sem nunca ter um SO pago.

## Changes
- `src/views/Signup/AdditionalDataView.vue` — `v-if`→`v-show` no card step 1 (mantém `additionalDataRef` montado durante checkout); `submitForm()` movido pra dentro do branch Hobby e pra dentro do `handleCheckoutSuccess` (Pro).
- `src/main.js` — `setActivePinia(pinia)` após `createPinia()`.
- `src/views/Home/HomeView.vue` — computed `welcomeName` com fallback `first_name+last_name` → `account.name`.
- `src/composables/useCurrentSubscription.js` — "Actual Plan" → "Current Plan".
- `src/plugins/analytics/trackers/BillingTracker.js` — event "Plan Selected" → "Selected Plan".
- `src/templates/signup-block/additional-data-form-block.vue` — label "Plan Selected" → "Selected Plan".
- `src/templates/signup-block/plan-selector-card.vue` — Pro description refinada.
- `src/templates/signup-block/plan-selection-drawer.vue` — "Selected Plan" no botão do plano atual quando `relativeLabels=false`.
- `src/templates/signup-block/plan-success-block.vue` — copy dos 3 passos do success refinada.
- `src/views/Billing/plan-comparison-features.js` — taglines, descriptions e ícones (ai/pi) alinhados à spec.
- `src/views/Billing/Dialog/PlanFeatureComparison.vue` / `components/SubscriptionPlanCard.vue` — pequenos ajustes de cópia.
- `src/templates/checkout-block/pricing-summary.vue` — "Next Charge Value" → "Next Charge Amount".
- `src/templates/home-cards-block/last-activities-block.vue` — "View all Activities..." → "View all Activity...".
- `src/templates/home-cards-block/workloads-empty-state.vue` — typo "blank ..." → "a blank ...".

## Test plan
- [ ] **Signup Hobby**: Continue → `/iam/account` + `/iam/user` disparam → SO criado → tela de success. (sem mudança)
- [ ] **Signup Pro**: Continue → SO DRAFT criado → Stripe checkout abre → pagamento sucesso → `/iam/account` + `/iam/user` disparam → tela de success.
- [ ] **Signup Pro com erro de pagamento**: Continue → Stripe → `handleCheckoutError` → nenhum POST em `/iam/*`, `first_login` continua `true`, usuário pode tentar de novo.
- [ ] **Back no checkout**: ir pra checkout e voltar via "Back" preserva dados do form (v-show mantém estado).
- [ ] **Console no boot**: nenhum warning "getActivePinia() was called but there was no active Pinia".
- [ ] **Home com nome digitado**: signup com email `nome+sufixo@dominio` + nome real "João Silva" → home exibe "Welcome, João Silva" (não "Welcome, nome sufixo").
- [ ] **Compare Plans no `/signup/additional-data`** → abre `https://www.azion.com/en/pricing/`.