### PR TITLE
[NO-ISSUE] fix: signup checkout mobile + PCI message + Stripe primary color

### DIFF
--- a/src/templates/checkout-block/address-information-block.vue
+++ b/src/templates/checkout-block/address-information-block.vue
@@ -414,7 +414,7 @@
     font-size: 12px !important;
   }
 
-  .address-full-width :deep([class*='max-w-lg']) {
+  :deep([class*='max-w-lg']) {
     max-width: none !important;
   }
 

--- a/src/templates/checkout-block/checkout-action-footer.vue
+++ b/src/templates/checkout-block/checkout-action-footer.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="flex shrink-0 justify-end gap-3 border-t border-[var(--border-default)] bg-surface px-6 lg:px-8 py-4"
+    class="flex shrink-0 gap-3 border-t border-[var(--border-default)] bg-surface px-4 lg:px-8 py-4 lg:justify-end"
   >
     <Button
-      class="font-protomono flex items-center justify-center text-xs"
+      class="font-protomono flex items-center justify-center text-xs flex-1 lg:flex-none"
       :disabled="submitting"
       outlined
       label="Back"
@@ -11,7 +11,7 @@
     />
     <Button
       severity="secondary"
-      class="font-protomono flex items-center justify-center text-xs"
+      class="font-protomono flex items-center justify-center text-xs flex-1 lg:flex-none"
       :loading="loading"
       :disabled="disabled"
       label="Subscribe"

--- a/src/templates/checkout-block/checkout-action-footer.vue
+++ b/src/templates/checkout-block/checkout-action-footer.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex shrink-0 justify-end gap-3 border-t border-[var(--border-default)] bg-surface px-8 py-4"
+    class="flex shrink-0 justify-end gap-3 border-t border-[var(--border-default)] bg-surface px-6 lg:px-8 py-4"
   >
     <Button
       class="font-protomono flex items-center justify-center text-xs"

--- a/src/templates/checkout-block/checkout-features-block.vue
+++ b/src/templates/checkout-block/checkout-features-block.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="flex flex-col gap-6 border-l surface-border bg-surface p-6 max-w-[300px] flex-1">
+  <div
+    class="flex flex-col gap-6 border-t lg:border-t-0 lg:border-l surface-border bg-surface p-6 w-full lg:max-w-[300px] flex-1"
+  >
     <p class="text-[13px] leading-[21px] text-color-secondary">
       <span>Upgrade to </span>
       <span class="font-semibold">{{ planName }}</span>

--- a/src/templates/checkout-block/checkout-features-block.vue
+++ b/src/templates/checkout-block/checkout-features-block.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="flex flex-col gap-6 border-t lg:border-t-0 lg:border-l surface-border bg-surface p-6 w-full lg:max-w-[300px] flex-1"
+    class="flex flex-col gap-6 border-b lg:border-b-0 lg:border-l surface-border bg-surface p-4 lg:p-6 w-full lg:max-w-[300px] flex-1"
   >
-    <p class="text-[13px] leading-[21px] text-color-secondary">
+    <p class="text-[13px] leading-[21px] text-color-secondary text-center lg:text-left">
       <span>Upgrade to </span>
       <span class="font-semibold">{{ planName }}</span>
       <span> to power your businesses with advanced security and compliance.</span>

--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative flex lg:h-full flex-col lg:overflow-hidden pt-6 w-full lg:w-[600px]">
-    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-6 lg:px-8 overflow-y-auto">
+    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-4 lg:px-8 overflow-y-auto">
       <PricingCalculationBlock
         ref="pricingCalculationRef"
         :plan="plan"

--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="relative flex h-full flex-col overflow-hidden pt-6 w-[600px]">
-    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-8 overflow-y-auto">
+  <div class="relative flex lg:h-full flex-col lg:overflow-hidden pt-6 w-full lg:w-[600px]">
+    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-6 lg:px-8 overflow-y-auto">
       <PricingCalculationBlock
         ref="pricingCalculationRef"
         :plan="plan"

--- a/src/templates/checkout-block/helpers/stripe-appearance.js
+++ b/src/templates/checkout-block/helpers/stripe-appearance.js
@@ -43,7 +43,7 @@ export const buildCheckoutAppearance = (themeStore) => {
   return {
     theme: isDarkTheme ? 'night' : 'stripe',
     variables: {
-      colorPrimary: '#f3652b',
+      colorPrimary: textColor,
       colorText: textColor,
       colorTextPlaceholder: placeholderColor,
       colorBackground: surfaceBackground,
@@ -119,6 +119,11 @@ export const buildCheckoutAppearance = (themeStore) => {
       },
       '.Block': {
         fontFamily: "'Sora', sans-serif"
+      },
+      '.LinkAutofillPrompt': {
+        fontFamily: "'Sora', sans-serif",
+        fontSize: '0.875rem',
+        fontWeight: '500'
       }
     }
   }

--- a/src/templates/checkout-block/payment-method-block.vue
+++ b/src/templates/checkout-block/payment-method-block.vue
@@ -87,9 +87,12 @@
           </small>
         </div>
 
-        <InlineMessage severity="info">
-          Sensitive data is handled by a PCI-compliant payment partner.
-        </InlineMessage>
+        <div
+          class="flex items-center gap-2 rounded-md bg-[#a6a6a61f] px-3 py-2 text-xs leading-snug text-color"
+        >
+          <i class="pi pi-info-circle text-sm shrink-0" />
+          <span>Sensitive data is handled by a PCI-compliant payment partner.</span>
+        </div>
       </form>
     </div>
   </div>
@@ -97,7 +100,6 @@
 
 <script setup>
   import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
-  import InlineMessage from '@aziontech/webkit/inlinemessage'
   import Skeleton from '@aziontech/webkit/skeleton'
   import { useAccountStore } from '@/stores/account'
   import { useThemeStore } from '@/stores/theme'

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border min-h-[600px] lg:h-[800px]"
+    class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border lg:h-[800px]"
   >
-    <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col lg:flex-row">
+    <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col-reverse lg:flex-row">
       <CheckoutPlanBlock
         ref="planBlockRef"
         :plan="plan"

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -2,7 +2,7 @@
   <div
     class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border min-h-[600px] lg:h-[800px]"
   >
-    <div class="flex h-full min-h-0 overflow-hidden flex-col lg:flex-row">
+    <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col lg:flex-row">
       <CheckoutPlanBlock
         ref="planBlockRef"
         :plan="plan"

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border lg:h-[800px]"
-  >
+  <div class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border lg:h-[800px]">
     <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col-reverse lg:flex-row">
       <CheckoutPlanBlock
         ref="planBlockRef"


### PR DESCRIPTION
## Summary
- Conjunto de ajustes no fluxo de checkout do signup (mobile-first), no aviso de PCI compliance dentro do Payment Method, e na cor primária do Stripe usada por elementos do Link.

## Changes

### Mobile signup checkout
- `choosing-plan-container`: removido `min-h-[600px]` (eliminou whitespace forçado em mobile); `flex-col` → `flex-col-reverse` abaixo de `lg` pra features bloco renderizar acima do form.
- `checkout-features-block`: border-t/border-b reorganizada conforme stack, padding `p-4 lg:p-6`, descrição centralizada em mobile (`text-center lg:text-left`).
- `checkout-plan-block`: padding lateral mais enxuto em mobile (`px-4 lg:px-8`); width responsiva (`w-full lg:w-[600px]`); fixed-height / overflow só no desktop.
- `checkout-action-footer`: botões Back/Subscribe ocupam metade da row cada em mobile (`flex-1 lg:flex-none`), alinhamento `lg:justify-end` no desktop.

### PCI compliance message
- `payment-method-block`: substituído o `InlineMessage` por uma div custom que preserva o tom de fundo info do tema, mas usa `items-center` + `shrink-0` no ícone pra quebra de texto não travar a layout em mobile.

### Stripe primary color
- `stripe-appearance.js`: `colorPrimary: '#f3652b'` → `colorPrimary: textColor`. O botão Link Autofill Prompt e demais surfaces que herdam do `--colorPrimary` deixam de aparecer em laranja conflitante; hover/focus dos inputs mantém o laranja (regras separadas com hex literal, mantém afetação visual). Regra `.LinkAutofillPrompt` define Sora/0.875rem/500 weight.

## Test plan
- [ ] Signup `/signup/additional-data` no mobile: features block aparece acima do form, sem whitespace residual.
- [ ] Botões Back / Subscribe em mobile ocupam 50/50 da row.
- [ ] Aviso "Sensitive data is handled by a PCI-compliant payment partner" quebra texto naturalmente em telas estreitas.
- [ ] Botão Link autofill no Stripe Payment Element aparece com cor de texto (não laranja).
- [ ] Hover/focus dos campos do Stripe continuam laranja (não regrediram).
- [ ] Desktop: layout do checkout do signup continua igual (features sidebar 300px + form 600px lado a lado, h-[800px]).