### PR TITLE
[NO-ISSUE] chore: clean up stage azion.json rules and add skip-deletion

### DIFF
--- a/azion/stage/azion.json
+++ b/azion/stage/azion.json
@@ -5,6 +5,7 @@
   "env": "production",
   "prefix": "20240821142547",
   "rotate-prefix": false,
+  "skip-deletion": true, 
   "not-first-run": true,
   "function": {
     "id": 28363,
@@ -239,16 +240,6 @@
         "phase": "request"
       },
       {
-        "id": 537350,
-        "name": "Run Function | SSE Beholder Proxy",
-        "phase": "request"
-      },
-      {
-        "id": 488499,
-        "name": "Debug",
-        "phase": "response"
-      },
-      {
         "id": 563632,
         "name": "Route Edge API Requests",
         "phase": "request"
@@ -267,10 +258,6 @@
     {
       "id": 266296,
       "name": "Statics - Cache .html"
-    },
-    {
-      "id": 261825,
-      "name": "Marketplace - Cache"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Sincroniza o `azion/stage/azion.json` com o estado real do ambiente de stage.

## Root cause
O arquivo local de configuração do stage estava com referências a regras e cache que já não existem mais no ambiente remoto, gerando ruído em deploys futuros via Azion CLI.

## Changes
- Adiciona `"skip-deletion": true` no manifest do stage para evitar remoção indevida de recursos durante o deploy.
- Remove regras obsoletas:
  - `Run Function | SSE Beholder Proxy` (request)
  - `Debug` (response)
- Remove entrada de cache obsoleta `Marketplace - Cache`.

## Test plan
- [ ] Rodar `azion deploy` apontando para stage e confirmar que não há tentativa de recriar/remover as regras/caches retirados.
- [ ] Confirmar que `skip-deletion` é respeitado e nenhum recurso é excluído inesperadamente.