### PR TITLE
[NO-ISSUE] chore: plan card refresh, onboarding url precedence, address dropdown clip

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@analytics/segment": "^2.1.0",
     "@aziontech/icons": "^1.4.0",
-    "@aziontech/theme": "^2.0.4",
+    "@aziontech/theme": "^2.1.1",
     "@aziontech/webkit": "^3.3.0",
     "@guolao/vue-monaco-editor": "^1.6.0",
     "@jsonforms/core": "3.7.0",

--- a/src/composables/useCurrentSubscription.js
+++ b/src/composables/useCurrentSubscription.js
@@ -87,12 +87,23 @@ export function useCurrentSubscription() {
   const nextChargeDate = computed(() =>
     formatNextChargeDate(activeServiceOrder.value?.currentPeriodEnd)
   )
-  const nextChargeValue = computed(() => planChargeValue.value)
   const lastUpdate = computed(() =>
     formatLastUpdate(currentServiceOrder.value?.updatedAt ?? activeServiceOrder.value?.updatedAt)
   )
 
   const scheduledDowngrade = computed(() => activeServiceOrder.value?.downgradePending ?? null)
+
+  const scheduledDowngradePricing = computed(() => {
+    const toPriceId = scheduledDowngrade.value?.toPriceId
+    if (!toPriceId) return null
+    return findPricingById(plansData.value, toPriceId)
+  })
+
+  const nextChargeValue = computed(() => {
+    if (!hasContractedPlan.value) return 0
+    const pricing = scheduledDowngradePricing.value ?? activePricing.value
+    return toFiniteNumber(pricing?.priceValue, 0)
+  })
 
   const currentInvoiceAmountCharged = computed(() =>
     toFiniteNumber(activeServiceOrder.value?.invoiceAmountCharged, null)

--- a/src/composables/usePlans.js
+++ b/src/composables/usePlans.js
@@ -66,7 +66,7 @@ const setupSync = (accountStore) => {
           _plan.value = null
           _billingCycle.value = null
           if (!hydrateFromScope()) {
-            _plan.value = 'pro'
+            _plan.value = 'hobby'
             _billingCycle.value = 'monthly'
           }
         } else if (!newId && oldId) {
@@ -81,7 +81,7 @@ const setupSync = (accountStore) => {
     _plan.value = null
     _billingCycle.value = null
     if (!hydrateFromScope()) {
-      _plan.value = 'pro'
+      _plan.value = 'hobby'
       _billingCycle.value = 'monthly'
     }
   })
@@ -132,21 +132,27 @@ export function usePlans() {
   }
 
   const initialize = () => {
-    if (hydrateFromScope()) {
-      syncToUrl()
+    const urlParams = readFromUrl()
+
+    if (urlParams) {
+      if (urlParams.plan) _plan.value = urlParams.plan
+      if (urlParams.billingCycle) _billingCycle.value = urlParams.billingCycle
+
+      if (!_plan.value || !_billingCycle.value) {
+        const stored = readScoped(BASE_KEY)
+        if (stored) {
+          if (!_plan.value && stored.plan) _plan.value = stored.plan
+          if (!_billingCycle.value && stored.billingCycle) _billingCycle.value = stored.billingCycle
+        }
+      }
       return
     }
 
-    const urlParams = readFromUrl()
-    if (urlParams) {
-      _plan.value = urlParams.plan || null
-      _billingCycle.value = urlParams.billingCycle || null
-      return
-    }
+    if (hydrateFromScope()) return
 
     if (_plan.value || _billingCycle.value) return
 
-    _plan.value = 'pro'
+    _plan.value = 'hobby'
     _billingCycle.value = 'monthly'
   }
 

--- a/src/layout/components/menu-profile/index.vue
+++ b/src/layout/components/menu-profile/index.vue
@@ -331,7 +331,6 @@
   import { computed, inject, ref, watch, onBeforeMount } from 'vue'
   import { RouterLink } from 'vue-router'
   import { storeToRefs } from 'pinia'
-  import Avatar from '@aziontech/webkit/avatar'
   import Button from '@aziontech/webkit/button'
   import IconButton from '@aziontech/webkit/icon-button'
   import Divider from '@aziontech/webkit/divider'

--- a/src/layout/components/navbar/button-copilot.vue
+++ b/src/layout/components/navbar/button-copilot.vue
@@ -11,8 +11,7 @@
   const currentWidth = inject('currentWidth')
   const SCREEN_BREAKPOINT_MD = 768
 
-  
-  const currentLabel = computed(() => currentWidth.value > SCREEN_BREAKPOINT_MD ? 'Copilot' : '')
+  const currentLabel = computed(() => (currentWidth.value > SCREEN_BREAKPOINT_MD ? 'Copilot' : ''))
   const showButton = computed(() => route.name !== 'copilot')
 </script>
 
@@ -23,5 +22,5 @@
     size="medium"
     :label="currentLabel"
     @click="toggleSidebarComponent('copilot')"
-  /> 
+  />
 </template>

--- a/src/layout/components/navbar/button-helper.vue
+++ b/src/layout/components/navbar/button-helper.vue
@@ -14,5 +14,5 @@
   import { useLayout } from '@/composables/use-layout'
 
   defineOptions({ name: 'ButtonHelper' })
-  const { isSidebarActive, toggleSidebarComponent, activeComponentKey } = useLayout()
+  const { toggleSidebarComponent } = useLayout()
 </script>

--- a/src/layout/components/navbar/feedback.vue
+++ b/src/layout/components/navbar/feedback.vue
@@ -112,7 +112,7 @@
 
   defineOptions({ name: 'console-feedback' })
 
-  const props = defineProps({
+  defineProps({
     styleTextColor: {
       type: String,
       default: () => 'text-color'

--- a/src/templates/action-bar-block/index.vue
+++ b/src/templates/action-bar-block/index.vue
@@ -1,7 +1,5 @@
 <script setup>
   import { computed } from 'vue'
-  import ButtonSave from '@aziontech/webkit/button-save'
-  import ButtonCancel from '@aziontech/webkit/button-cancel'
   import Button from '@aziontech/webkit/button'
 
   defineOptions({ name: 'action-bar-block' })

--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative flex lg:h-full flex-col lg:overflow-hidden pt-6 w-full lg:w-[600px]">
-    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-4 lg:px-8 overflow-y-auto">
+    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-4 lg:px-8 pb-6 overflow-y-auto">
       <PricingCalculationBlock
         ref="pricingCalculationRef"
         :plan="plan"
@@ -183,11 +183,32 @@
 
 <style scoped>
   .checkout-scroll-area {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
   }
 
   .checkout-scroll-area::-webkit-scrollbar {
-    display: none;
+    width: 8px;
+    height: 8px;
+  }
+
+  .checkout-scroll-area::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 4px;
+  }
+
+  .checkout-scroll-area:hover,
+  .checkout-scroll-area:focus-within {
+    scrollbar-color: var(--border-default) transparent;
+  }
+
+  .checkout-scroll-area:hover::-webkit-scrollbar-thumb,
+  .checkout-scroll-area:focus-within::-webkit-scrollbar-thumb {
+    background-color: var(--border-default);
+  }
+
+  .checkout-scroll-area:hover::-webkit-scrollbar-thumb:hover,
+  .checkout-scroll-area:focus-within::-webkit-scrollbar-thumb:hover {
+    background-color: var(--text-color-secondary);
   }
 </style>

--- a/src/templates/checkout-block/city-selector.vue
+++ b/src/templates/checkout-block/city-selector.vue
@@ -11,7 +11,7 @@
       optionLabel="name"
       optionValue="geonameId"
       placeholder="Select a City"
-      appendTo="self"
+      appendTo="body"
       filter
       class="w-full"
       @change="$emit('change', $event)"

--- a/src/templates/checkout-block/country-selector.vue
+++ b/src/templates/checkout-block/country-selector.vue
@@ -10,7 +10,7 @@
       optionLabel="name"
       optionValue="geonameId"
       placeholder="Select a Country"
-      appendTo="self"
+      appendTo="body"
       filter
       class="w-full"
       @change="$emit('change', $event)"

--- a/src/templates/checkout-block/helpers/plan-features.js
+++ b/src/templates/checkout-block/helpers/plan-features.js
@@ -1,10 +1,12 @@
 export const PRO_UPGRADE_HIGHLIGHTS = [
   { title: '20 Workloads' },
+  { title: '2 TB/month Workload Data Transfer' },
+  { title: '20M Requests/month across Workloads and Firewalls' },
+  { title: '20 Rules per Application and per Firewall' },
+  { title: '10 hours/month Functions Compute Time' },
+  { title: '10,000 Image Transformations/month' },
   { title: '20 GB Object Storage' },
-  { title: '20M Application requests' },
-  { title: '20M Firewall requests' },
-  { title: '10 hours Functions compute time' },
-  { title: '2 GB Real-Time Events Storage' }
+  { title: '200,000 WAF-Analyzed Requests/month' }
 ]
 
 export const PLAN_INFO = {
@@ -25,14 +27,28 @@ export const PLAN_INFO = {
     label: 'Pro',
     features: [
       { title: '20 Workloads', description: 'then $0.10 per workload per month' },
-      { title: '20M Application requests', description: 'then as low as $0.90 per 1M' },
-      { title: '10 hours Function compute time', description: 'then $0.18 per hour' },
-      { title: '2 GB Real-Time Events Storage', description: 'then $0.10 per GB-month' },
+      { title: '2 TB/month Workload Data Transfer', description: 'then as low as $0.02 per GB' },
+      {
+        title: '20M Requests/month across Workloads and Firewalls',
+        description: 'then as low as $0.30 per 1M'
+      },
+      {
+        title: '20 Rules per Application and per Firewall',
+        description: 'then from $0.20 per additional rule'
+      },
+      {
+        title: '10 hours/month Functions Compute Time',
+        description: 'then $0.072 per 1,000 seconds'
+      },
+      {
+        title: '10,000 Image Transformations/month',
+        description: 'then as low as $0.64 per 10,000 images'
+      },
       { title: '20 GB Object Storage', description: 'then as low as $0.021 per GB-month' },
-      { title: '1 GB SQL Database Storage', description: 'then $0.75 per GB-month' },
-      { title: '20M Firewall requests', description: 'then as low as $0.30 per 1M' },
-      { title: 'DDoS Protection included' },
-      { title: 'Universal Data Migration Service' }
+      {
+        title: '200,000 WAF-Analyzed Requests/month',
+        description: 'then as low as $0.018 per 10,000 requests'
+      }
     ]
   }
 }

--- a/src/templates/checkout-block/pricing-footer-links.vue
+++ b/src/templates/checkout-block/pricing-footer-links.vue
@@ -1,31 +1,19 @@
 <template>
-  <div class="flex flex-col gap-[10px]">
-    <a
-      :href="pricingUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="flex items-center gap-1 text-xs leading-5 text-[var(--text-color-link)] hover:underline"
-    >
-      Learn more about Pricing
-      <i class="pi pi-external-link text-[10px]" />
-    </a>
-    <a
-      :href="comparePlansUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="flex items-center gap-1 text-xs leading-5 text-[var(--text-color-link)] hover:underline"
-    >
-      Compare Plans
-      <i class="pi pi-external-link text-[10px]" />
-    </a>
-  </div>
+  <a
+    :href="comparePlansUrl"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="flex items-center gap-1 text-xs leading-5 text-[var(--text-color-link)] hover:underline"
+  >
+    Compare Plans
+    <i class="pi pi-external-link text-[10px]" />
+  </a>
 </template>
 
 <script setup>
   defineOptions({ name: 'pricing-footer-links' })
 
   defineProps({
-    pricingUrl: { type: String, default: 'https://www.azion.com/en/pricing/' },
-    comparePlansUrl: { type: String, default: 'https://www.azion.com/en/plans/' }
+    comparePlansUrl: { type: String, default: 'https://www.azion.com/en/pricing/' }
   })
 </script>

--- a/src/templates/checkout-block/region-selector.vue
+++ b/src/templates/checkout-block/region-selector.vue
@@ -11,7 +11,7 @@
       optionLabel="name"
       optionValue="geonameId"
       placeholder="Select a State/Region"
-      appendTo="self"
+      appendTo="body"
       filter
       class="w-full"
       @change="$emit('change', $event)"

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -196,7 +196,10 @@
       .string()
       .trim()
       .max(61, 'Your Full Name must be less than 61 characters')
-      .matches(/[A-Za-zÀ-ž.'-]+ [A-Za-zÀ-ž.'-]+/, 'Your Full Name must include first and last name')
+      .matches(
+        /[A-Za-zÀ-ž.'-]+\s+[A-Za-zÀ-ž.'-]+/,
+        'Your Full Name must include first and last name'
+      )
       .required('Your Full Name is required')
   })
 
@@ -420,10 +423,8 @@
   onMounted(async () => {
     initializePlans()
 
-    // Pre-fill plan from URL params/storage
-    if (storedPlan.value && ['hobby', 'pro'].includes(storedPlan.value)) {
-      plan.value = storedPlan.value
-    }
+    // Pre-fill plan from URL params/storage; default to Hobby when missing/invalid
+    plan.value = ['hobby', 'pro'].includes(storedPlan.value) ? storedPlan.value : 'hobby'
 
     // Pre-fill billing cycle
     if (storedBillingCycle.value) {

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -29,7 +29,7 @@
       type: String,
       required: true,
       validator: (value) => ['hobby', 'pro'].includes(value),
-      default: 'pro'
+      default: 'hobby'
     },
     checkoutSessionClientSecret: {
       type: String,

--- a/src/templates/signup-block/plan-selection-drawer.vue
+++ b/src/templates/signup-block/plan-selection-drawer.vue
@@ -198,7 +198,7 @@
     if (target === current) {
       if (target === 'hobby') return 'Subscribed'
       if (props.billingCycle === localBillingCycle.value) return 'Subscribed'
-      return localBillingCycle.value === 'yearly' ? 'Upgrade Cycle' : 'Downgrade Cycle'
+      return localBillingCycle.value === 'yearly' ? 'Switch to Annual' : 'Downgrade Cycle'
     }
     const targetRank = PLAN_RANK[target] ?? 0
     const currentRank = PLAN_RANK[current] ?? 0

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -61,29 +61,8 @@
     title="No payment activity yet."
     description="Add a payment method and start using services and products to view your activity."
     :inTabs="true"
-    createButtonLabel="Add Credit"
     :documentationService="props.documentPaymentHistoryService"
-  >
-    <template #default>
-      <ActionButton
-        class="max-md:w-full w-fit"
-        kind="outlined"
-        size="medium"
-        label="Credit"
-        icon="pi pi-plus"
-        :disabled="!defaultCardStatus.hasData"
-        @click="goToPayment"
-      />
-      <ActionButton
-        class="max-md:w-full w-fit"
-        kind="secondary"
-        size="medium"
-        icon="pi pi-plus"
-        label="Payment Method"
-        @click="goToPayment"
-      />
-    </template>
-  </EmptyResultsBlock>
+  />
 
   <PlanSelectionDrawer
     v-model:visible="showChangePlanDrawer"
@@ -135,7 +114,6 @@
   import EmptyResultsBlock from '@aziontech/webkit/empty-results-block'
   import { columnBuilder } from '@/components/list-table/columns/column-builder'
   import ListTable from '@/components/list-table/ListTable.vue'
-  import ActionButton from '@aziontech/webkit/button'
   import SubscriptionPlanCard from './components/SubscriptionPlanCard.vue'
   import UpgradeToProCard from './components/UpgradeToProCard.vue'
   import CurrentInvoiceCard from './components/CurrentInvoiceCard.vue'
@@ -327,11 +305,6 @@
       drawerMode.value = 'subscribe'
     }
   })
-
-  const defaultCardStatus = computed(() => ({
-    loaded: props.cardDefault?.loader,
-    hasData: !!props.cardDefault?.cardData
-  }))
 
   const { defaultPaymentMethod } = useBillingPaymentMethods()
 

--- a/src/views/Billing/Dialog/DialogDowngradePlan.vue
+++ b/src/views/Billing/Dialog/DialogDowngradePlan.vue
@@ -122,7 +122,13 @@
     return 'Downgrade plan'
   })
 
-  const keepLabel = computed(() => `Keep ${getPlanLabel(props.fromPlan)}`)
+  const keepLabel = computed(() => {
+    if (props.cycleChange) {
+      const fromCycleLabel = props.fromCycle === 'yearly' ? 'Annual' : 'Monthly'
+      return `Keep ${fromCycleLabel}`
+    }
+    return `Keep ${getPlanLabel(props.fromPlan)}`
+  })
 
   const effectiveDate = computed(() => formatBillingDate(props.effectiveAt))
 

--- a/src/views/Billing/components/UpgradeToProCard.vue
+++ b/src/views/Billing/components/UpgradeToProCard.vue
@@ -9,10 +9,10 @@
           <div
             v-for="feature in features"
             :key="feature.title"
-            class="flex items-center gap-2.5 h-5 text-xs leading-none text-default"
+            class="flex items-center gap-2.5 text-xs leading-none text-default"
           >
             <i class="pi pi-check text-base shrink-0 text-success-check" />
-            <span>{{ feature.title }}</span>
+            <span class="leading-5">{{ feature.title }}</span>
           </div>
         </div>
         <p class="text-sm leading-[1.25] text-color-secondary">
@@ -23,16 +23,14 @@
 
     <template #footer>
       <div class="w-full flex justify-between items-center gap-4 flex-wrap">
-        <p class="text-xs leading-5 text-color-secondary">
-          Learn more about
-          <a
-            :href="pricingAndPlansUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-[var(--text-color-link)]"
-            >Pricing and Plans</a
-          >.
-        </p>
+        <a
+          :href="pricingAndPlansUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs leading-5 text-[var(--text-color-link)]"
+        >
+          View all plan limits
+        </a>
         <ActionButton
           label="Upgrade to Pro"
           kind="primary"

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
   resolved "https://registry.npmjs.org/@aziontech/icons/-/icons-1.4.0.tgz"
   integrity sha512-V2AQJoY4iV6ZlrcKiCW9pyZeMJXou8cg2sqmsTn3KTH7G/cLiHD0QZG/y8md8rfSSSEvsBzR/82JM45+taaRIQ==
 
-"@aziontech/theme@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@aziontech/theme/-/theme-2.0.4.tgz"
-  integrity sha512-3AiiYORhklGqPqVggKeoVn3yQe26wsQ5+9LowEF2SI6nNBwBnXVg7WAMLHmoKf5T7g7uSfTDAgzz/TZ0tlEorA==
+"@aziontech/theme@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aziontech/theme/-/theme-2.1.1.tgz#e0d99cd9fe51453e9e44caf8d392fb34a6640299"
+  integrity sha512-d877nA5y9XJNY1MM4jEBWBhVAozcXtBEHBR3lFYpoq48jNER04Vyr6AjHUtXHAoiflSrk7QRchbF2hTFC5IguQ==
 
 "@aziontech/webkit@^3.3.0":
   version "3.3.0"


### PR DESCRIPTION
## Summary
- Refresh Pro plan highlights and pricing copy in the billing surfaces, with prices verified against the on-demand pricing docs
- Make the onboarding flow honor URL params over local storage and default the plan to Hobby
- Fix address dropdowns being clipped by the checkout scroll area and surface the scrollbar on focus/hover
- Reflect the scheduled-downgrade pricing in the "Next Charge Amount" of the Subscription Plan card

## Root cause
- `usePlans.initialize` hydrated from storage before reading the URL and then synced the URL back to the stored value — deep links like `?plan=hobby&billing-cycle=monthly` were silently overwritten by a previously chosen Pro/Yearly in localStorage.
- The country/region/city selectors used `appendTo="self"` on `FieldDropdown`, so any ancestor with `overflow:auto|hidden` (the checkout scroll area in both onboarding and drawer) clipped the panel.
- `useCurrentSubscription.nextChargeValue` mirrored `planChargeValue`, ignoring `downgradePending.toPriceId`. After a downgrade was scheduled, the card kept showing the current plan's amount.
- The full-name regex required a single literal space between first and last name, rejecting valid input with double spaces from paste/typing.

## Changes
- `feat: refresh pro plan highlights, prices and cycle copy` — `PRO_UPGRADE_HIGHLIGHTS` updated to 8 production-aligned features; `PLAN_INFO.pro` descriptions updated to match the floor prices on the docs; footer collapses to a single "Compare Plans" link; downgrade dialog "Keep" button switches to "Keep Annual/Monthly" for cycle change; plan selection drawer cycle upgrade renamed to "Switch to Annual".
- `fix: respect URL params over storage and default plan to hobby in onboarding` — `usePlans.initialize` now prefers URL params and falls back to storage for missing values; `additional-data-form-block` defaults plan to Hobby when nothing is present and tolerates multi-space full names via `\s+`; `choosing-plan-container` default prop aligned to `hobby`.
- `fix: address dropdowns rendered on body and visible scroll on focus` — country/region/city selectors switched to `appendTo="body"` so the panel escapes the scroll-area clip; `checkout-plan-block` reserves the scrollbar gutter and reveals the thumb on `:hover`/`:focus-within` (no layout shift, no fade); `pb-6` added so the address block stops sticking to the footer.
- `fix: next charge amount reflects scheduled-downgrade pricing` — when `downgradePending.toPriceId` is set, the Subscription Plan card uses the destination pricing's `priceValue`; `planChargeValue` stays unchanged so the current invoice still shows the active plan's amount.

## Test plan
- [ ] Open `/signup/additional-data?plan=hobby&billing-cycle=monthly` with a previous Pro/Yearly in localStorage — Hobby/Monthly should win and persist
- [ ] Open `/signup/additional-data` with no params and no storage — Hobby/Monthly default applied
- [ ] Submit full name with extra spaces ("Herbert  Cotta") — Continue button enables
- [ ] On the onboarding checkout, open the Country/State/City dropdowns — panel renders above the scroll area, not clipped
- [ ] Scroll inside the checkout panel — scrollbar is visible on hover and when focusing any Stripe/address field, no layout shift
- [ ] Schedule a downgrade (Pro→Hobby or Pro Yearly→Monthly) — Subscription Plan card "Next Charge Amount" shows the destination pricing value; Current Invoice card "Plan Charge" still shows the in-effect plan amount
- [ ] Open the downgrade-cycle dialog — secondary button reads "Keep Annual" (or "Keep Monthly" for monthly→yearly)
- [ ] Open the plan selection drawer with Pro Monthly current and Yearly selected — button reads "Switch to Annual"