### PR TITLE
perf: warm Stripe SDK only on real payment intent

### DIFF
--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -391,11 +391,6 @@
   )
 
   onMounted(async () => {
-    // Warm Stripe.js up front: the plan-info, add-payment and change-cycle
-    // drawers opened from this view all mount Stripe behind a user action, so
-    // pre-downloading the client here keeps those drawers from stalling on a
-    // cold js.stripe.com load.
-    warmStripe()
     // Post-checkout entry refreshes once so the cards reflect the just-paid
     // SO without depending on stale persisted cache.
     try {
@@ -436,6 +431,10 @@
   }
 
   const showOtherPlans = async () => {
+    // Intent to change plan: warm the Stripe SDK while the user browses plans,
+    // so the checkout drawer reuses it. Loads the SDK only — no checkout
+    // session is created here.
+    warmStripe()
     const initialCycle = subscription.isPro.value ? 'yearly' : 'monthly'
     setParam('billingCycle', initialCycle)
     await syncToUrl()
@@ -513,6 +512,9 @@
   }
 
   const openUpgradeToPro = async () => {
+    // Direct upgrade-to-Pro intent: warm the SDK before the checkout drawer
+    // mounts. SDK only — no checkout session created here.
+    warmStripe()
     setParam('billingCycle', 'monthly')
     await syncToUrl()
     trackBilling('upgradeBannerClicked', { location: 'upgrade-card' })

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -117,6 +117,7 @@
   const { warmStripe } = useWarmStripe()
   const {
     initialize: initializePlans,
+    plan: chosenPlan,
     billingCycle: storedBillingCycle,
     clear: clearPlans
   } = usePlans()
@@ -291,12 +292,21 @@
     clearPlans()
   })
 
+  // Warm Stripe only once the user actually commits to Pro (the only paid
+  // plan). This pre-loads the SDK while they finish the form, so the checkout
+  // step reuses it — but never fires Stripe for hobby/undecided users, and
+  // never creates a checkout session (warm only loads the SDK). `immediate`
+  // covers arriving with ?plan=pro already selected.
+  watch(
+    chosenPlan,
+    (plan) => {
+      if (plan === 'pro') warmStripe()
+    },
+    { immediate: true }
+  )
+
   onMounted(async () => {
     initializePlans()
-    // Warm Stripe.js while the user fills the additional-data form so the Pro
-    // checkout step (the very next screen) reuses the already-downloaded
-    // client instead of blocking on a cold js.stripe.com load.
-    warmStripe()
     // Cache-aware: uses the existing plans entry when fresh, fetches only
     // when stale/missing. Replaces the previous `refetch()` call that
     // always hit the network.


### PR DESCRIPTION
## Follow-up to #3553

#3553 warmed Stripe on the **mount** of the signup and billing screens. As the
DevTools traces showed, that loaded the Stripe SDK (script + controller +
fingerprint/cookies) for **everyone** who landed on those screens - including
hobby/undecided signups and users who only open billing to view invoices.

This PR gates the warm on **real intent to pay**, so it never fires for users
who will not checkout.

## What the warm does (and does not)

The warm loads the **SDK only**. It does **not** create a checkout session -
no service order, no Stripe session, no `clientSecret`. The heavy Elements
init (`api.stripe.com/v1/payment_pages`, custom-checkout, hCaptcha, wallets)
is inherent to Stripe Elements and gated on the `clientSecret`, so it
necessarily runs on the card screen and is out of scope here.

## Changes

| Flow | Before (#3553) | Now |
|---|---|---|
| Signup | warm on `AdditionalDataView` mount (all users) | warm only when chosen plan is `pro` (watch on shared plan ref) |
| Billing | warm on `BillsView` mount (all users) | warm only on plan-change intent: `showOtherPlans` (change-plan drawer) or `openUpgradeToPro` |

Net effect: hobby/undecided signups and invoice-only billing visits load **zero**
Stripe; users who actually head toward a paid plan still get the SDK pre-loaded
while they browse/fill the form, so the payment form reuses it.

## What is unchanged

`getStripeClientService`, the `useWarmStripe` composable and their tests are
untouched (all shipped in #3553).

## Testing

- `vitest run` - full suite green.
- Lint: 0 errors.

## How to verify

DevTools Network filtered by `stripe`:
- Signup with hobby selected, or billing while only viewing invoices -> no
  `js.stripe.com` requests.
- Select Pro (signup) or open Change Plan / Upgrade (billing) -> `stripe.js`
  loads in the background on that screen.
