### PR TITLE
feat: Accelerate signup checkout preparation

### DIFF
--- a/src/components/base/advanced-filter-system/filterFields/filterPanel/index.vue
+++ b/src/components/base/advanced-filter-system/filterFields/filterPanel/index.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script setup>
-  import { ref, computed, defineModel } from 'vue'
+  import { ref, computed } from 'vue'
   import PrimeButton from '@aziontech/webkit/button'
   import InputText from '@aziontech/webkit/inputtext'
   import FilterRow from '../filterRow/index.vue'

--- a/src/components/base/advanced-filter-system/filterFields/filterRow/index.vue
+++ b/src/components/base/advanced-filter-system/filterFields/filterRow/index.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup>
-  import { computed, defineModel, ref, watch } from 'vue'
+  import { computed, ref, watch } from 'vue'
   import PrimeButton from '@aziontech/webkit/button'
   import Dropdown from '@aziontech/webkit/dropdown'
   import { FIELDS_MAPPING } from '@/components/base/filterFields/filterRow/component'

--- a/src/components/base/advanced-filter-system/filterFields/index.vue
+++ b/src/components/base/advanced-filter-system/filterFields/index.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-  import { ref, defineModel } from 'vue'
+  import { ref } from 'vue'
   import PrimeButton from '@aziontech/webkit/button'
   import OverlayPanel from '@aziontech/webkit/overlaypanel'
   import FilterPanel from './filterPanel/index.vue'

--- a/src/components/base/advanced-filter-system/filterFields/temp/index.vue
+++ b/src/components/base/advanced-filter-system/filterFields/temp/index.vue
@@ -1,6 +1,6 @@
 <script setup>
   defineOptions({ name: 'advanced-filter' })
-  import { computed, defineModel } from 'vue'
+  import { computed } from 'vue'
   import dialogFilter from './dialog-filter.vue'
 
   import { OPERATOR_MAPPING } from '../filterRow/component'

--- a/src/components/base/advanced-filter-system/index.vue
+++ b/src/components/base/advanced-filter-system/index.vue
@@ -9,7 +9,7 @@
   import { useAccountStore } from '@/stores/account'
   import { createUtcDateFromUserTimezoneParts } from '@/helpers/convert-date'
   import { createRelativeRange } from '@utils/date.js'
-  import { listTimezonesService } from '@/services/users-services'
+  import { listTimezonesService } from '@/services/v2/listTimezones'
 
   defineOptions({ name: 'advanced-filter-system' })
   const accountStore = useAccountStore()
@@ -308,7 +308,7 @@
           :maxDays="props.filterDateRangeMaxDays"
           :defaultUtcOffset="userUTC"
           :userTimezone="userTimezone"
-          :listTimezonesService="listTimezonesService"
+          :listTimezonesService="listTimezonesService.listTimezones"
           @select="onDateRangeSelect"
           @autoRefresh="onAutoRefreshTick"
         />

--- a/src/components/base/advanced-filter-system/index.vue
+++ b/src/components/base/advanced-filter-system/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, onMounted, defineModel, computed, watch } from 'vue'
+  import { ref, onMounted, computed, watch } from 'vue'
   import DataTimeRange from '@/components/base/dataTimeRange'
   import DialogFilter from '@/components/base/advanced-filter-system/filterFields/temp/index.vue'
   import AzionQueryLanguage from '@/components/base/advanced-filter-system/filterAQL/azion-query-language.vue'

--- a/src/components/base/dataTimeRange/index.vue
+++ b/src/components/base/dataTimeRange/index.vue
@@ -134,7 +134,7 @@
 </template>
 
 <script setup>
-  import { computed, defineModel, nextTick, onMounted, ref } from 'vue'
+  import { computed, nextTick, onMounted, ref } from 'vue'
   import QuickSelect from './quickSelect/index.vue'
   import InputDateRange from './inputDateRange/index.vue'
   import PrimeButton from '@aziontech/webkit/button'

--- a/src/components/base/dataTimeRange/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange/inputDateRange/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, computed, defineModel, onMounted } from 'vue'
+  import { ref, computed, onMounted } from 'vue'
   import PrimeButton from '@aziontech/webkit/button'
   import Calendar from '@aziontech/webkit/calendar'
   import Dropdown from '@aziontech/webkit/dropdown'

--- a/src/components/base/dataTimeRange/quickSelect/index.vue
+++ b/src/components/base/dataTimeRange/quickSelect/index.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup>
-  import { ref, defineModel, onMounted, onUnmounted, watch } from 'vue'
+  import { ref, onMounted, onUnmounted, watch } from 'vue'
   import PrimeButton from '@aziontech/webkit/button'
   import Dropdown from '@aziontech/webkit/dropdown'
   import InputNumber from '@aziontech/webkit/inputnumber'

--- a/src/composables/signup-checkout-preparation.js
+++ b/src/composables/signup-checkout-preparation.js
@@ -1,0 +1,82 @@
+import { getPlanPricingId } from '@/composables/usePlansService'
+
+export const extractCheckoutClientSecret = (response) =>
+  response?.payment?.clientSecret ||
+  response?.data?.clientSecret ||
+  response?.data?.payment?.clientSecret ||
+  response?.serviceOrder?.clientSecret ||
+  ''
+
+const findPlanBySku = (plans, plan) => {
+  if (!Array.isArray(plans) || !plan) return null
+  return plans.find((item) => item.sku?.toLowerCase() === plan.toLowerCase()) ?? null
+}
+
+export const getPlanIdFromSku = (plans, plan) => findPlanBySku(plans, plan)?.id ?? null
+
+const getResponseServiceOrder = (response) =>
+  response?.data || response?.serviceOrder || response?.service_order || null
+
+const getDraftServiceOrderId = (draft) => draft?.serviceOrderId || draft?.id || null
+
+const resolvePlanPayload = ({ plans, plan, billingCycle }) => {
+  const planId = getPlanIdFromSku(plans, plan)
+  if (!planId) {
+    throw new Error(`Plan not found for ${plan}.`)
+  }
+
+  if (plan === 'hobby') {
+    return { planId }
+  }
+
+  const planPricingId = getPlanPricingId(plans, plan, billingCycle)
+  if (!planPricingId) {
+    throw new Error(`Plan pricing not found for ${plan} (${billingCycle}).`)
+  }
+
+  return { planId, planPricingId }
+}
+
+export const preparePaidSignupCheckout = async ({
+  plan,
+  billingCycle,
+  plans,
+  prepareSignupCheckout
+}) => {
+  if (plan !== 'pro') {
+    return { clientSecret: '', draftServiceOrderId: null, serviceOrder: null }
+  }
+
+  const payload = resolvePlanPayload({ plans, plan, billingCycle })
+  const response = await prepareSignupCheckout(payload)
+
+  const clientSecret = extractCheckoutClientSecret(response)
+  if (!clientSecret) {
+    throw new Error('Payment session client secret missing in response.')
+  }
+
+  const serviceOrder = getResponseServiceOrder(response)
+  return {
+    clientSecret,
+    draftServiceOrderId: getDraftServiceOrderId(serviceOrder),
+    serviceOrder
+  }
+}
+
+export const submitSignupPlanFromDraftOrCreate = async ({
+  plan,
+  billingCycle,
+  plans,
+  prepareSignupCheckout
+}) => {
+  const payload = resolvePlanPayload({ plans, plan, billingCycle })
+  const response = await prepareSignupCheckout(payload)
+  const serviceOrder = getResponseServiceOrder(response)
+
+  return {
+    response,
+    payment: plan === 'pro' ? { clientSecret: extractCheckoutClientSecret(response) } : null,
+    serviceOrder,
+    draftServiceOrderId: getDraftServiceOrderId(serviceOrder)
+  }
+}

--- a/src/composables/useCheckoutSessionPreparer.js
+++ b/src/composables/useCheckoutSessionPreparer.js
@@ -17,6 +17,77 @@ const extractSecret = (response) =>
   response?.serviceOrder?.clientSecret ||
   ''
 
+export const prepareCheckoutSessionForServiceOrder = async ({
+  accountId,
+  plan,
+  cycle,
+  plans,
+  draftServiceOrderId,
+  signup,
+  ensureServiceOrdersList,
+  getCurrentServiceOrder,
+  createServiceOrder,
+  prepareSignupCheckout,
+  updateServiceOrder,
+  upgrade
+}) => {
+  const planId = plans?.find((item) => item.sku?.toLowerCase() === plan.toLowerCase())?.id
+  const planPricingId = getPlanPricingId(plans, plan, cycle)
+
+  if (!planId || !planPricingId) {
+    throw new Error(`Plan pricing not found for ${plan} (${cycle}).`)
+  }
+
+  if (signup) {
+    const prepareResponse = await prepareSignupCheckout({
+      planId,
+      planPricingId
+    })
+    const signupSecret = extractSecret(prepareResponse)
+    if (signupSecret) return signupSecret
+    throw new Error('Payment session client secret missing in response.')
+  }
+
+  if (draftServiceOrderId) {
+    const updateResponse = await updateServiceOrder(draftServiceOrderId, {
+      planId,
+      planPricingId
+    })
+    const refreshedSecret = extractSecret(updateResponse)
+    if (refreshedSecret) return refreshedSecret
+    throw new Error('Unable to refresh the existing checkout session.')
+  }
+
+  await ensureServiceOrdersList(accountId)
+  const currentSO = getCurrentServiceOrder(accountId)
+
+  if (currentSO?.status === SO_STATUS.DRAFT && currentSO.serviceOrderId) {
+    const updateResponse = await updateServiceOrder(currentSO.serviceOrderId, {
+      planId,
+      planPricingId
+    })
+    const refreshedSecret = extractSecret(updateResponse)
+    if (refreshedSecret) return refreshedSecret
+    throw new Error('Unable to refresh the existing checkout session.')
+  }
+
+  const response =
+    currentSO?.status === SO_STATUS.ACTIVE && currentSO.serviceOrderId
+      ? await upgrade({
+          id: currentSO.serviceOrderId,
+          accountId,
+          newPlanId: planId,
+          priceId: planPricingId
+        })
+      : await createServiceOrder({ planId, planPricingId })
+
+  const secret = extractSecret(response)
+  if (!secret) {
+    throw new Error('Payment session client secret missing in response.')
+  }
+  return secret
+}
+
 /**
  * Prepares a Stripe checkout session for the requested plan/cycle. When a
  * DRAFT service order already exists for the same plan, this issues a PATCH
@@ -25,15 +96,16 @@ const extractSecret = (response) =>
  * consumed since the last time the cache was warmed. The PATCH is cheap
  * compared to the bug surface of mounting Stripe.js with a dead secret.
  *
- * Concurrent invocations dedupe through Vue Query's mutation cache; no
- * manual in-flight tracking required.
+ * Callers that can fire multiple preparations in parallel must keep their
+ * own "latest request wins" guard before applying returned secrets.
  */
 export function useCheckoutSessionPreparer() {
   const accountStore = useAccountStore()
-  const { createServiceOrder, updateServiceOrder, upgrade } = useServiceOrders()
+  const { createServiceOrder, prepareSignupCheckout, updateServiceOrder, upgrade } =
+    useServiceOrders()
 
   const prepareMutation = useMutation({
-    mutationFn: async ({ plan, cycle }) => {
+    mutationFn: async ({ plan, cycle, draftServiceOrderId, signup }) => {
       const plans = await ensurePlansList()
 
       if (!accountStore.accountData?.country) {
@@ -45,46 +117,30 @@ export function useCheckoutSessionPreparer() {
         throw new Error('Account data not available yet.')
       }
 
-      const planId = plans?.find((item) => item.sku?.toLowerCase() === plan.toLowerCase())?.id
-      const planPricingId = getPlanPricingId(plans, plan, cycle)
-
-      if (!planId || !planPricingId) {
-        throw new Error(`Plan pricing not found for ${plan} (${cycle}).`)
-      }
-
-      await ensureServiceOrdersList(accountId)
-      const currentSO = getCurrentServiceOrder(accountId)
-
-      if (currentSO?.status === SO_STATUS.DRAFT && currentSO.serviceOrderId) {
-        const updateResponse = await updateServiceOrder(currentSO.serviceOrderId, {
-          planId,
-          planPricingId
-        })
-        const refreshedSecret = extractSecret(updateResponse)
-        if (refreshedSecret) return refreshedSecret
-        throw new Error('Unable to refresh the existing checkout session.')
-      }
-
-      const response =
-        currentSO?.status === SO_STATUS.ACTIVE && currentSO.serviceOrderId
-          ? await upgrade({
-              id: currentSO.serviceOrderId,
-              accountId,
-              newPlanId: planId,
-              priceId: planPricingId
-            })
-          : await createServiceOrder({ planId, planPricingId })
-
-      const secret = extractSecret(response)
-      if (!secret) {
-        throw new Error('Payment session client secret missing in response.')
-      }
-      return secret
+      return prepareCheckoutSessionForServiceOrder({
+        accountId,
+        plan,
+        cycle,
+        plans,
+        draftServiceOrderId,
+        signup,
+        ensureServiceOrdersList,
+        getCurrentServiceOrder,
+        createServiceOrder,
+        prepareSignupCheckout,
+        updateServiceOrder,
+        upgrade
+      })
     }
   })
 
-  const prepare = ({ plan, preferredCycle = null }) =>
-    prepareMutation.mutateAsync({ plan, cycle: preferredCycle || 'monthly' })
+  const prepare = ({ plan, preferredCycle = null, draftServiceOrderId = null, signup = false }) =>
+    prepareMutation.mutateAsync({
+      plan,
+      cycle: preferredCycle || 'monthly',
+      draftServiceOrderId,
+      signup
+    })
 
   /**
    * Recovery path for when Stripe rejects the secret returned by `prepare`
@@ -92,10 +148,15 @@ export function useCheckoutSessionPreparer() {
    * SO snapshots so the next `prepare` reads server-truth, then re-prepares
    * — yielding a brand-new Stripe Checkout Session.
    */
-  const recoverFromStaleSession = ({ plan, preferredCycle = null }) => {
+  const recoverFromStaleSession = ({
+    plan,
+    preferredCycle = null,
+    draftServiceOrderId = null,
+    signup = false
+  }) => {
     queryClient.invalidateQueries({ queryKey: queryKeys.serviceOrders.all })
     invalidateCurrentAccountSubscription()
-    return prepare({ plan, preferredCycle })
+    return prepare({ plan, preferredCycle, draftServiceOrderId, signup })
   }
 
   return {

--- a/src/composables/usePlans.js
+++ b/src/composables/usePlans.js
@@ -7,12 +7,13 @@ import {
   removeScoped,
   migrateGuestTo
 } from '@/helpers/client-scoped-storage'
+// Cross-tab/session switch broadcast is a local event listener, not server data.
+// eslint-disable-next-line azion-architecture/require-vue-query
 import { onSwitchAccount } from '@/services/v2/base/auth/session-broadcast'
 
 const BASE_KEY = 'plans:v1'
 const VALID_PLANS = ['hobby', 'pro']
 const VALID_BILLING_CYCLES = ['monthly', 'yearly']
-
 const isValidPlan = (value) => VALID_PLANS.includes(value)
 const isValidBillingCycle = (value) => VALID_BILLING_CYCLES.includes(value)
 
@@ -22,7 +23,8 @@ const isStorageAvailable = () => typeof window !== 'undefined' && Boolean(window
 // sharing the plan/cycle choice across the components in that flow is
 // intentional. Module-level refs survive in-session navigation; localStorage
 // scoped by client_id is the source of truth across reloads, deep links, and
-// account switches (storage wins over URL).
+// account switches. Explicit URL params win over storage so deep links can
+// override a stale local selection.
 const _plan = ref(null)
 const _billingCycle = ref(null)
 
@@ -46,6 +48,19 @@ const hydrateFromScope = () => {
   return false
 }
 
+const applyDefaultSelection = ({ defaultPlan = null, defaultBillingCycle = null } = {}) => {
+  if (defaultPlan && isValidPlan(defaultPlan)) _plan.value = defaultPlan
+  if (defaultBillingCycle && isValidBillingCycle(defaultBillingCycle)) {
+    _billingCycle.value = defaultBillingCycle
+  }
+}
+
+const getDefaultPlan = ({ defaultPlan = null } = {}) =>
+  defaultPlan && isValidPlan(defaultPlan) ? defaultPlan : null
+
+const getDefaultBillingCycle = ({ defaultBillingCycle = null } = {}) =>
+  defaultBillingCycle && isValidBillingCycle(defaultBillingCycle) ? defaultBillingCycle : null
+
 let _isSynced = false
 const _moduleScope = effectScope(true)
 
@@ -65,10 +80,7 @@ const setupSync = (accountStore) => {
         } else if (newId && oldId && newId !== oldId) {
           _plan.value = null
           _billingCycle.value = null
-          if (!hydrateFromScope()) {
-            _plan.value = 'pro'
-            _billingCycle.value = 'monthly'
-          }
+          hydrateFromScope()
         } else if (!newId && oldId) {
           _plan.value = null
           _billingCycle.value = null
@@ -80,10 +92,7 @@ const setupSync = (accountStore) => {
   onSwitchAccount(() => {
     _plan.value = null
     _billingCycle.value = null
-    if (!hydrateFromScope()) {
-      _plan.value = 'pro'
-      _billingCycle.value = 'monthly'
-    }
+    hydrateFromScope()
   })
 }
 
@@ -131,23 +140,22 @@ export function usePlans() {
     await router.replace({ path: route.path, query: nextQuery })
   }
 
-  const initialize = () => {
+  const initialize = (defaults = {}) => {
+    const urlParams = readFromUrl()
+    if (urlParams) {
+      _plan.value = urlParams.plan || getDefaultPlan(defaults)
+      _billingCycle.value = urlParams.billingCycle || getDefaultBillingCycle(defaults)
+      return
+    }
+
     if (hydrateFromScope()) {
       syncToUrl()
       return
     }
 
-    const urlParams = readFromUrl()
-    if (urlParams) {
-      _plan.value = urlParams.plan || null
-      _billingCycle.value = urlParams.billingCycle || null
-      return
-    }
-
     if (_plan.value || _billingCycle.value) return
 
-    _plan.value = 'pro'
-    _billingCycle.value = 'monthly'
+    applyDefaultSelection(defaults)
   }
 
   const setParam = (key, value) => {

--- a/src/composables/useServiceOrders.js
+++ b/src/composables/useServiceOrders.js
@@ -35,6 +35,11 @@ export function useServiceOrders() {
     ...mutationOptions
   })
 
+  const prepareSignupCheckoutMutation = useMutation({
+    mutationFn: (payload) => serviceOrdersService.prepareSignupCheckout(payload),
+    ...mutationOptions
+  })
+
   const updateMutation = useMutation({
     mutationFn: ({ id, payload }) => serviceOrdersService.updateServiceOrder(id, payload),
     ...mutationOptions
@@ -63,6 +68,7 @@ export function useServiceOrders() {
   const isSubmitting = computed(
     () =>
       createMutation.isPending.value ||
+      prepareSignupCheckoutMutation.isPending.value ||
       updateMutation.isPending.value ||
       upgradeMutation.isPending.value ||
       downgradeMutation.isPending.value ||
@@ -82,6 +88,8 @@ export function useServiceOrders() {
   }
 
   const createServiceOrder = (payload) => createMutation.mutateAsync(payload)
+
+  const prepareSignupCheckout = (payload) => prepareSignupCheckoutMutation.mutateAsync(payload)
 
   const updateServiceOrder = (id, payload) => updateMutation.mutateAsync({ id, payload })
 
@@ -164,6 +172,7 @@ export function useServiceOrders() {
     loadAccountServiceOrders,
     getServiceOrder,
     createServiceOrder,
+    prepareSignupCheckout,
     updateServiceOrder,
     submitServiceOrder,
     upgrade,

--- a/src/services/billing-services/get-stripe-client-service.js
+++ b/src/services/billing-services/get-stripe-client-service.js
@@ -1,25 +1,31 @@
 import { getEnvironment } from '@/helpers'
 import { loadStripe } from '@stripe/stripe-js/pure'
 
-const makeStripeClient = async (environment) => {
-  const stripeEnvVarName = {
-    development: 'VITE_STRIPE_TOKEN_DEV',
-    stage: 'VITE_STRIPE_TOKEN_STAGE',
-    production: 'VITE_STRIPE_TOKEN_PROD'
-  }
+const stripeEnvVarName = {
+  development: 'VITE_STRIPE_TOKEN_DEV',
+  stage: 'VITE_STRIPE_TOKEN_STAGE',
+  production: 'VITE_STRIPE_TOKEN_PROD'
+}
 
-  const enviromentStripeToken = stripeEnvVarName[environment]
+let stripeClientPromise = null
+let stripeClientCacheKey = ''
 
+const resolveStripeToken = (environment) => {
   const isInvalidEnvironment = !['development', 'stage', 'production'].includes(environment)
   if (isInvalidEnvironment) {
     throw Error('Provide a valid environment to select correct tracking token')
   }
 
-  const stripeToken = import.meta.env[enviromentStripeToken]
+  const environmentStripeToken = stripeEnvVarName[environment]
+  const stripeToken = import.meta.env[environmentStripeToken]
   if (!stripeToken) {
     throw Error('Stripe token is missing, cannot load Stripe. View readme for more info.')
   }
 
+  return stripeToken
+}
+
+const makeStripeClient = async ({ environment, stripeToken }) => {
   if (environment !== 'production') {
     /**
      * This avoids calling the endpoint m.stripe.com when not in production
@@ -37,11 +43,21 @@ const makeStripeClient = async (environment) => {
 
 export const getStripeClientService = async () => {
   const environment = getEnvironment()
-  try {
-    return await makeStripeClient(environment)
-  } catch (error) {
-    throw new Error(error.message).message
+  const stripeToken = resolveStripeToken(environment)
+  const cacheKey = `${environment}:${stripeToken}`
+
+  if (!stripeClientPromise || stripeClientCacheKey !== cacheKey) {
+    stripeClientCacheKey = cacheKey
+    stripeClientPromise = makeStripeClient({ environment, stripeToken }).catch((error) => {
+      if (stripeClientCacheKey === cacheKey) {
+        stripeClientPromise = null
+        stripeClientCacheKey = ''
+      }
+      throw error
+    })
   }
+
+  return stripeClientPromise
 }
 
 /**
@@ -50,8 +66,9 @@ export const getStripeClientService = async () => {
  * `@stripe/stripe-js/pure` injects and memoizes the js.stripe.com `<script>`
  * on first call, so kicking it off early moves the slow external download off
  * the checkout critical path — the later `getStripeClientService()` reuses the
- * cached download and resolves immediately. Errors are swallowed here; the
- * consuming payment component surfaces load failures when it actually mounts.
+ * cached client promise and resolves immediately. Errors are swallowed here;
+ * the consuming payment component surfaces load failures when it actually
+ * mounts.
  */
 export const warmStripeClient = () => {
   getStripeClientService().catch(() => {})

--- a/src/services/v2/service-orders/service-orders-service.js
+++ b/src/services/v2/service-orders/service-orders-service.js
@@ -73,6 +73,15 @@ export class ServiceOrdersService extends BaseService {
     return ServiceOrdersAdapter.transformCreateResponse(response.data)
   }
 
+  prepareSignupCheckout = async (payload) => {
+    const response = await this.http.request({
+      method: 'POST',
+      url: `${this.#baseURL}/signup/checkout/prepare`,
+      body: ServiceOrdersAdapter.toCreatePayload(payload)
+    })
+    return ServiceOrdersAdapter.transformCreateResponse(response.data)
+  }
+
   updateServiceOrder = async (id, payload) => {
     const response = await this.http.request({
       method: 'PATCH',

--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="relative flex lg:h-full flex-col lg:overflow-hidden pt-6 w-full lg:w-[600px]">
-    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-4 lg:px-8 overflow-y-auto">
+  <div class="relative flex flex-col pt-6 w-full lg:w-[600px]">
+    <div class="flex flex-col gap-6 px-4 lg:px-8">
       <PricingCalculationBlock
         ref="pricingCalculationRef"
         :plan="plan"
+        :draftServiceOrderId="draftServiceOrderId"
+        context="signup"
         @update:billing-cycle="handleBillingCycleChange"
         @update:checkout-session-client-secret="handleCheckoutSessionClientSecretChange"
       />
@@ -13,6 +15,8 @@
         :stripeClientService="getStripeClientService"
         :checkoutSessionClientSecret="checkoutSessionClientSecret"
         @readiness-change="handlePaymentReadinessChange"
+        @element-ready="emit('payment-element-ready')"
+        @stale-session="handleStaleCheckoutSession"
       />
 
       <AddressInformationBlock
@@ -43,7 +47,13 @@
   defineOptions({
     name: 'checkout-plan-block'
   })
-  const emit = defineEmits(['onBack', 'onSubmit'])
+  const emit = defineEmits([
+    'onBack',
+    'onSubmit',
+    'payment-element-ready',
+    'stale-session',
+    'checkout-session-prepared'
+  ])
   const toast = useToast()
   const { scrollToError } = useScrollToError()
 
@@ -60,6 +70,10 @@
     checkoutSessionClientSecret: {
       type: String,
       default: ''
+    },
+    draftServiceOrderId: {
+      type: [String, Number],
+      default: null
     }
   })
 
@@ -68,7 +82,7 @@
   const addressInformationRef = ref(null)
   const isSubmitting = ref(false)
   const showLoading = ref(false)
-  const billingCycle = ref('yearly')
+  const billingCycle = ref('monthly')
   const checkoutSessionClientSecret = ref(props.checkoutSessionClientSecret)
   const isPaymentFormReady = ref(false)
   const isAddressFormReady = ref(false)
@@ -88,6 +102,11 @@
 
   const handleCheckoutSessionClientSecretChange = (value) => {
     checkoutSessionClientSecret.value = value
+    if (!value) return
+    emit('checkout-session-prepared', {
+      clientSecret: value,
+      billingCycle: billingCycle.value
+    })
   }
 
   const handlePaymentReadinessChange = (isReady) => {
@@ -96,6 +115,15 @@
 
   const handleAddressReadinessChange = (isReady) => {
     isAddressFormReady.value = Boolean(isReady)
+  }
+
+  const handleStaleCheckoutSession = (payload = {}) => {
+    isPaymentFormReady.value = false
+    emit('stale-session', {
+      ...payload,
+      plan: props.plan,
+      billingCycle: billingCycle.value
+    })
   }
 
   const handleBack = () => {
@@ -180,14 +208,3 @@
     billingCycle
   })
 </script>
-
-<style scoped>
-  .checkout-scroll-area {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  .checkout-scroll-area::-webkit-scrollbar {
-    display: none;
-  }
-</style>

--- a/src/templates/checkout-block/payment-method-block.vue
+++ b/src/templates/checkout-block/payment-method-block.vue
@@ -72,11 +72,12 @@
               </div>
             </div>
             <div
+              ref="paymentElementContainer"
               id="payment-element"
               name="paymentElement"
               data-testid="payment-method-form__payment-element__input"
               class="stripe-input"
-              :class="{ 'absolute inset-0 invisible': !paymentElementReady }"
+              :class="{ 'absolute inset-0 opacity-0 pointer-events-none': !paymentElementReady }"
             />
           </div>
           <small
@@ -113,7 +114,7 @@
     name: 'payment-method-block'
   })
 
-  const emit = defineEmits(['readiness-change', 'stale-session'])
+  const emit = defineEmits(['readiness-change', 'stale-session', 'element-ready'])
 
   const props = defineProps({
     stripeClientService: {
@@ -132,6 +133,7 @@
   const stripe = ref(null)
   const checkout = ref(null)
   const paymentElement = ref(null)
+  const paymentElementContainer = ref(null)
   const paymentElementReady = ref(false)
   const paymentElementComplete = ref(false)
   const initializationVersion = ref(0)
@@ -160,6 +162,15 @@
 
   const emitReadinessChange = () => {
     emit('readiness-change', isPaymentFormReady())
+  }
+
+  const markPaymentElementReady = (version) => {
+    if (version !== initializationVersion.value || paymentElementReady.value) return
+
+    paymentElementReady.value = true
+    resetPaymentElementErrors()
+    emit('element-ready')
+    emitReadinessChange()
   }
 
   const unmountPaymentElement = () => {
@@ -220,10 +231,7 @@
       })
 
       paymentElement.value.on('ready', () => {
-        if (currentInitializationVersion !== initializationVersion.value) return
-        paymentElementReady.value = true
-        resetPaymentElementErrors()
-        emitReadinessChange()
+        markPaymentElementReady(currentInitializationVersion)
       })
 
       paymentElement.value.on('change', (event) => {
@@ -252,7 +260,7 @@
         emitReadinessChange()
       })
 
-      paymentElement.value.mount('#payment-element')
+      paymentElement.value.mount(paymentElementContainer.value)
     } catch (error) {
       if (currentInitializationVersion !== initializationVersion.value) {
         return

--- a/src/templates/checkout-block/pricing-calculation-block.vue
+++ b/src/templates/checkout-block/pricing-calculation-block.vue
@@ -51,10 +51,19 @@
       default: null,
       validator: (value) => value === null || ['monthly', 'yearly'].includes(value)
     },
+    draftServiceOrderId: {
+      type: [String, Number],
+      default: null
+    },
     mode: {
       type: String,
       default: 'subscribe',
       validator: (value) => ['subscribe', 'edit', 'change-cycle'].includes(value)
+    },
+    context: {
+      type: String,
+      default: 'billing',
+      validator: (value) => ['billing', 'signup'].includes(value)
     }
   })
 
@@ -63,7 +72,8 @@
   const { data: plans } = serviceOrdersService.useListPlansQuery()
   const { prepare: prepareCheckoutSession, isPreparing } = useCheckoutSessionPreparer()
 
-  const billingCycle = ref('monthly')
+  const DEFAULT_BILLING_CYCLE = 'monthly'
+  const billingCycle = ref(DEFAULT_BILLING_CYCLE)
 
   const planPricing = computed(() => getPlanPricing(plans.value, props.plan))
 
@@ -104,7 +114,7 @@
   initialize()
   // `lockedCycle` wins so the toggle reflects the cycle the user already
   // committed to outside the drawer (e.g. Pro/m → Pro/y from BillsView).
-  billingCycle.value = props.lockedCycle || sharedBillingCycle.value || 'monthly'
+  billingCycle.value = props.lockedCycle || sharedBillingCycle.value || DEFAULT_BILLING_CYCLE
 
   watch(
     () => props.lockedCycle,
@@ -115,18 +125,27 @@
 
   const BILLING_CYCLE_DEBOUNCE_MS = 250
   let pendingPlanPricingTimer = null
+  let checkoutSessionRequestVersion = 0
 
-  const flushPlanPricingUpdate = async (value) => {
-    emit('update:checkoutSessionClientSecret', '')
+  const isLatestCheckoutSessionRequest = ({ value, version }) =>
+    version === checkoutSessionRequestVersion && value === billingCycle.value
+
+  const flushPlanPricingUpdate = async ({ value, version }) => {
     try {
       const secret = await prepareCheckoutSession({
         plan: props.plan,
-        preferredCycle: value
+        preferredCycle: value,
+        draftServiceOrderId: props.draftServiceOrderId,
+        signup: props.context === 'signup'
       })
+      if (!isLatestCheckoutSessionRequest({ value, version })) return
+
       if (secret) {
         emit('update:checkoutSessionClientSecret', secret)
       }
     } catch (err) {
+      if (!isLatestCheckoutSessionRequest({ value, version })) return
+
       const detail =
         (Array.isArray(err?.message) ? err.message[0] : err?.message) ||
         'Unable to update billing cycle. Please try again.'
@@ -134,20 +153,31 @@
     }
   }
 
-  watch(billingCycle, (value) => {
-    setParam('billingCycle', value)
-    emit('update:billingCycle', value)
+  watch(
+    billingCycle,
+    (value, previousValue) => {
+      setParam('billingCycle', value)
+      emit('update:billingCycle', value)
 
-    if (pendingPlanPricingTimer) {
-      clearTimeout(pendingPlanPricingTimer)
-    }
-    pendingPlanPricingTimer = setTimeout(() => {
-      pendingPlanPricingTimer = null
-      flushPlanPricingUpdate(value)
-    }, BILLING_CYCLE_DEBOUNCE_MS)
-  })
+      if (previousValue === undefined) return
+
+      checkoutSessionRequestVersion += 1
+      const version = checkoutSessionRequestVersion
+      emit('update:checkoutSessionClientSecret', '')
+
+      if (pendingPlanPricingTimer) {
+        clearTimeout(pendingPlanPricingTimer)
+      }
+      pendingPlanPricingTimer = setTimeout(() => {
+        pendingPlanPricingTimer = null
+        flushPlanPricingUpdate({ value, version })
+      }, BILLING_CYCLE_DEBOUNCE_MS)
+    },
+    { immediate: true }
+  )
 
   onBeforeUnmount(() => {
+    checkoutSessionRequestVersion += 1
     if (pendingPlanPricingTimer) {
       clearTimeout(pendingPlanPricingTimer)
       pendingPlanPricingTimer = null

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -169,6 +169,8 @@
     name: 'additional-data-form-block'
   })
 
+  const emit = defineEmits(['plan-change'])
+
   // Fetch plans from API
   const { data: plansData } = usePlansList()
 
@@ -227,6 +229,7 @@
   } = usePlans()
 
   // Local billing cycle state
+  const DEFAULT_BILLING_CYCLE = 'monthly'
   const billingCycle = ref('monthly')
 
   // Plan drawer state
@@ -414,11 +417,12 @@
     billingCycle.value = selectedBillingCycle
     setPlanParam('plan', selectedPlan)
     setPlanParam('billingCycle', selectedBillingCycle)
+    emit('plan-change', { plan: selectedPlan, billingCycle: selectedBillingCycle })
   }
 
   // Pre-fill form fields on mount
   onMounted(async () => {
-    initializePlans()
+    initializePlans({ defaultPlan: 'hobby', defaultBillingCycle: DEFAULT_BILLING_CYCLE })
 
     // Pre-fill plan from URL params/storage
     if (storedPlan.value && ['hobby', 'pro'].includes(storedPlan.value)) {

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -1,13 +1,17 @@
 <template>
-  <div class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border lg:h-[800px]">
-    <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col-reverse lg:flex-row">
+  <div class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border">
+    <div class="flex flex-col-reverse lg:flex-row">
       <CheckoutPlanBlock
         ref="planBlockRef"
         :plan="plan"
         :checkoutSessionClientSecret="checkoutSessionClientSecret"
+        :draftServiceOrderId="draftServiceOrderId"
         :getStripeClientService="getStripeClientService"
         @onBack="emit('onBack')"
         @onSubmit="handleSubmit"
+        @payment-element-ready="emit('payment-element-ready')"
+        @stale-session="emit('stale-session', $event)"
+        @checkout-session-prepared="emit('checkout-session-prepared', $event)"
       />
       <CheckoutFeaturesBlock :plan="plan" />
     </div>
@@ -34,10 +38,22 @@
     checkoutSessionClientSecret: {
       type: String,
       default: ''
+    },
+    draftServiceOrderId: {
+      type: [String, Number],
+      default: null
     }
   })
 
-  const emit = defineEmits(['onSuccess', 'onError', 'onBack', 'onSubmit'])
+  const emit = defineEmits([
+    'onSuccess',
+    'onError',
+    'onBack',
+    'onSubmit',
+    'payment-element-ready',
+    'stale-session',
+    'checkout-session-prepared'
+  ])
 
   const isSubmitting = ref(false)
   const showLoading = ref(false)

--- a/src/templates/social-idps-block/index.vue
+++ b/src/templates/social-idps-block/index.vue
@@ -37,7 +37,7 @@
   import PrimeButton from '@aziontech/webkit/button'
   import Skeleton from '@aziontech/webkit/skeleton'
   import { useToast } from '@aziontech/webkit/use-toast'
-  import { computed, onMounted, ref, inject, onUnmounted, defineModel } from 'vue'
+  import { computed, onMounted, ref, inject, onUnmounted } from 'vue'
   import socialIdpsData from '@/helpers/social-idps'
 
   defineOptions({ name: 'social-idps-block' })

--- a/src/tests/composables/signup-checkout-preparation.test.js
+++ b/src/tests/composables/signup-checkout-preparation.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  preparePaidSignupCheckout,
+  submitSignupPlanFromDraftOrCreate
+} from '@/composables/signup-checkout-preparation'
+
+const plans = [
+  {
+    id: 'plan_hobby',
+    sku: 'hobby',
+    pricings: []
+  },
+  {
+    id: 'plan_pro',
+    sku: 'pro',
+    pricings: [
+      { id: 'price_pro_monthly', periodicity: 'monthly' },
+      { id: 'price_pro_yearly', periodicity: 'yearly' }
+    ]
+  }
+]
+
+describe('signup-checkout-preparation', () => {
+  it('prepares a paid signup checkout through the dedicated endpoint', async () => {
+    const prepareSignupCheckout = vi.fn().mockResolvedValue({
+      data: { serviceOrderId: 'so_draft' },
+      payment: { clientSecret: 'cs_test_secret' }
+    })
+
+    const result = await preparePaidSignupCheckout({
+      accountId: 123,
+      plan: 'pro',
+      billingCycle: 'monthly',
+      plans,
+      prepareSignupCheckout
+    })
+
+    expect(prepareSignupCheckout).toHaveBeenCalledWith({
+      planId: 'plan_pro',
+      planPricingId: 'price_pro_monthly'
+    })
+    expect(result).toEqual({
+      clientSecret: 'cs_test_secret',
+      draftServiceOrderId: 'so_draft',
+      serviceOrder: { serviceOrderId: 'so_draft' }
+    })
+  })
+
+  it('lets the API reuse an existing DRAFT when preparing another paid cycle', async () => {
+    const prepareSignupCheckout = vi.fn().mockResolvedValue({
+      data: { serviceOrderId: 'so_existing' },
+      payment: { clientSecret: 'cs_next_secret' }
+    })
+
+    const result = await preparePaidSignupCheckout({
+      accountId: 123,
+      plan: 'pro',
+      billingCycle: 'yearly',
+      plans,
+      prepareSignupCheckout
+    })
+
+    expect(prepareSignupCheckout).toHaveBeenCalledWith({
+      planId: 'plan_pro',
+      planPricingId: 'price_pro_yearly'
+    })
+    expect(result.clientSecret).toBe('cs_next_secret')
+    expect(result.draftServiceOrderId).toBe('so_existing')
+  })
+
+  it('activates Hobby through the signup prepare endpoint only when Hobby is submitted', async () => {
+    const prepareSignupCheckout = vi.fn().mockResolvedValue({
+      data: { serviceOrderId: 'so_existing', status: 'ACTIVE', planId: 'plan_hobby' }
+    })
+
+    const result = await submitSignupPlanFromDraftOrCreate({
+      accountId: 123,
+      plan: 'hobby',
+      billingCycle: 'monthly',
+      plans,
+      prepareSignupCheckout
+    })
+
+    expect(prepareSignupCheckout).toHaveBeenCalledWith({
+      planId: 'plan_hobby'
+    })
+    expect(result.payment).toBeNull()
+    expect(result.serviceOrder).toEqual({
+      serviceOrderId: 'so_existing',
+      status: 'ACTIVE',
+      planId: 'plan_hobby'
+    })
+  })
+})

--- a/src/tests/composables/useCheckoutSessionPreparer.test.js
+++ b/src/tests/composables/useCheckoutSessionPreparer.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { prepareCheckoutSessionForServiceOrder } from '@/composables/useCheckoutSessionPreparer'
+
+const plans = [
+  {
+    id: 'plan_pro',
+    sku: 'pro',
+    pricings: [
+      { id: 'price_pro_monthly', periodicity: 'monthly' },
+      { id: 'price_pro_yearly', periodicity: 'yearly' }
+    ]
+  }
+]
+
+describe('useCheckoutSessionPreparer', () => {
+  it('patches a known DRAFT service order directly when changing cycle', async () => {
+    const ensureServiceOrdersList = vi.fn()
+    const updateServiceOrder = vi.fn().mockResolvedValue({
+      payment: { clientSecret: 'cs_yearly' }
+    })
+
+    const secret = await prepareCheckoutSessionForServiceOrder({
+      accountId: 123,
+      plan: 'pro',
+      cycle: 'yearly',
+      plans,
+      draftServiceOrderId: 'so_draft',
+      ensureServiceOrdersList,
+      getCurrentServiceOrder: vi.fn(),
+      createServiceOrder: vi.fn(),
+      prepareSignupCheckout: vi.fn(),
+      updateServiceOrder,
+      upgrade: vi.fn()
+    })
+
+    expect(ensureServiceOrdersList).not.toHaveBeenCalled()
+    expect(updateServiceOrder).toHaveBeenCalledWith('so_draft', {
+      planId: 'plan_pro',
+      planPricingId: 'price_pro_yearly'
+    })
+    expect(secret).toBe('cs_yearly')
+  })
+
+  it('uses signup checkout prepare without loading service orders for signup', async () => {
+    const ensureServiceOrdersList = vi.fn()
+    const prepareSignupCheckout = vi.fn().mockResolvedValue({
+      payment: { clientSecret: 'cs_signup_yearly' }
+    })
+
+    const secret = await prepareCheckoutSessionForServiceOrder({
+      accountId: 123,
+      plan: 'pro',
+      cycle: 'yearly',
+      plans,
+      draftServiceOrderId: 'so_draft',
+      signup: true,
+      ensureServiceOrdersList,
+      getCurrentServiceOrder: vi.fn(),
+      createServiceOrder: vi.fn(),
+      prepareSignupCheckout,
+      updateServiceOrder: vi.fn(),
+      upgrade: vi.fn()
+    })
+
+    expect(ensureServiceOrdersList).not.toHaveBeenCalled()
+    expect(prepareSignupCheckout).toHaveBeenCalledWith({
+      planId: 'plan_pro',
+      planPricingId: 'price_pro_yearly'
+    })
+    expect(secret).toBe('cs_signup_yearly')
+  })
+})

--- a/src/tests/composables/usePlans.test.js
+++ b/src/tests/composables/usePlans.test.js
@@ -1,0 +1,108 @@
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  route: { path: '/signup', query: {} },
+  router: { replace: vi.fn() },
+  accountStore: { account: { client_id: 'client-1' } },
+  readScoped: vi.fn(),
+  writeScoped: vi.fn(),
+  removeScoped: vi.fn(),
+  migrateGuestTo: vi.fn(),
+  onSwitchAccount: vi.fn()
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => mocks.router
+}))
+
+vi.mock('@/stores/account', () => ({
+  useAccountStore: () => mocks.accountStore
+}))
+
+vi.mock('@/helpers/client-scoped-storage', () => ({
+  readScoped: mocks.readScoped,
+  writeScoped: mocks.writeScoped,
+  removeScoped: mocks.removeScoped,
+  migrateGuestTo: mocks.migrateGuestTo
+}))
+
+vi.mock('@/services/v2/base/auth/session-broadcast', () => ({
+  onSwitchAccount: mocks.onSwitchAccount
+}))
+
+const mountUsePlans = async (defaults = {}) => {
+  vi.resetModules()
+  const { usePlans } = await import('@/composables/usePlans')
+
+  return mount(
+    defineComponent({
+      setup() {
+        const plans = usePlans()
+        plans.initialize(defaults)
+        return { plan: plans.plan, billingCycle: plans.billingCycle }
+      },
+      template: '<span>{{ plan }}:{{ billingCycle }}</span>'
+    })
+  )
+}
+
+describe('usePlans', () => {
+  beforeEach(() => {
+    mocks.route.query = {}
+    mocks.router.replace.mockReset()
+    mocks.readScoped.mockReset()
+    mocks.writeScoped.mockReset()
+    mocks.removeScoped.mockReset()
+    mocks.migrateGuestTo.mockReset()
+    mocks.onSwitchAccount.mockReset()
+    mocks.readScoped.mockReturnValue(null)
+  })
+
+  it('defaults signup plan selection to Hobby monthly', async () => {
+    const wrapper = await mountUsePlans({ defaultPlan: 'hobby', defaultBillingCycle: 'monthly' })
+
+    expect(wrapper.text()).toBe('hobby:monthly')
+  })
+
+  it('does not apply signup defaults outside signup callers', async () => {
+    const wrapper = await mountUsePlans()
+
+    expect(wrapper.text()).toBe(':')
+  })
+
+  it('keeps explicit Pro URL selection', async () => {
+    mocks.route.query = { plan: 'pro', 'billing-cycle': 'yearly' }
+
+    const wrapper = await mountUsePlans()
+
+    expect(wrapper.text()).toBe('pro:yearly')
+  })
+
+  it('fills missing signup cycle when URL only provides plan', async () => {
+    mocks.route.query = { plan: 'pro' }
+
+    const wrapper = await mountUsePlans({ defaultPlan: 'hobby', defaultBillingCycle: 'monthly' })
+
+    expect(wrapper.text()).toBe('pro:monthly')
+  })
+
+  it('fills missing signup plan when URL only provides billing cycle', async () => {
+    mocks.route.query = { 'billing-cycle': 'yearly' }
+
+    const wrapper = await mountUsePlans({ defaultPlan: 'hobby', defaultBillingCycle: 'monthly' })
+
+    expect(wrapper.text()).toBe('hobby:yearly')
+  })
+
+  it('lets explicit URL selection override stored signup plan', async () => {
+    mocks.route.query = { plan: 'pro', 'billing-cycle': 'yearly' }
+    mocks.readScoped.mockReturnValue({ plan: 'hobby', billingCycle: 'monthly' })
+
+    const wrapper = await mountUsePlans()
+
+    expect(wrapper.text()).toBe('pro:yearly')
+  })
+})

--- a/src/tests/services/billing-services/get-stripe-client-service.test.js
+++ b/src/tests/services/billing-services/get-stripe-client-service.test.js
@@ -1,26 +1,28 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { getStripeClientService, warmStripeClient } from '@/services/billing-services'
 import { loadStripe } from '@stripe/stripe-js/pure'
 
 vi.mock('@stripe/stripe-js/pure', () => ({
   loadStripe: vi.fn()
 }))
 
-const makeSut = () => {
+const makeSut = async () => {
+  const { getStripeClientService, warmStripeClient } = await import('@/services/billing-services')
   return {
-    sut: getStripeClientService
+    sut: getStripeClientService,
+    warmStripeClient
   }
 }
 
 afterEach(() => {
   vi.unstubAllEnvs()
   vi.resetAllMocks()
+  vi.resetModules()
 })
 
 describe('Billing Services', () => {
   it('should return an error when incorrect environment is provided', async () => {
     vi.stubEnv('VITE_ENVIRONMENT', 'invalid-stub-env')
-    const { sut } = makeSut()
+    const { sut } = await makeSut()
 
     await expect(sut()).rejects.toThrowError(
       'Provide a valid environment to select correct tracking token'
@@ -31,7 +33,7 @@ describe('Billing Services', () => {
     vi.stubEnv('VITE_ENVIRONMENT', 'development')
     vi.stubEnv('VITE_STRIPE_TOKEN_DEV', '')
 
-    const { sut } = makeSut()
+    const { sut } = await makeSut()
 
     await expect(sut()).rejects.toThrowError(
       'Stripe token is missing, cannot load Stripe. View readme for more info.'
@@ -47,7 +49,7 @@ describe('Billing Services', () => {
 
     loadStripe.setLoadParameters = vi.fn()
 
-    const { sut } = makeSut()
+    const { sut } = await makeSut()
 
     await sut()
 
@@ -58,16 +60,30 @@ describe('Billing Services', () => {
     vi.stubEnv('VITE_ENVIRONMENT', 'production')
     vi.stubEnv('VITE_STRIPE_TOKEN_PROD', 'some-stripe-token')
 
-    const { sut } = makeSut()
+    const { sut } = await makeSut()
 
     await expect(sut()).resolves.not.toThrowError()
     expect(loadStripe).toHaveBeenCalledWith('some-stripe-token', { locale: 'en' })
+  })
+
+  it('should reuse the same stripe client promise for the same environment and token', async () => {
+    vi.stubEnv('VITE_ENVIRONMENT', 'production')
+    vi.stubEnv('VITE_STRIPE_TOKEN_PROD', 'some-stripe-token')
+    const stripeClient = { id: 'stripe-client' }
+    loadStripe.mockResolvedValue(stripeClient)
+
+    const { sut } = await makeSut()
+
+    await expect(sut()).resolves.toBe(stripeClient)
+    await expect(sut()).resolves.toBe(stripeClient)
+    expect(loadStripe).toHaveBeenCalledTimes(1)
   })
 
   describe('warmStripeClient', () => {
     it('should kick off the Stripe client load without awaiting', async () => {
       vi.stubEnv('VITE_ENVIRONMENT', 'production')
       vi.stubEnv('VITE_STRIPE_TOKEN_PROD', 'some-stripe-token')
+      const { warmStripeClient } = await makeSut()
 
       expect(() => warmStripeClient()).not.toThrow()
       await Promise.resolve()
@@ -77,6 +93,7 @@ describe('Billing Services', () => {
 
     it('should swallow load errors so the preceding screen is never affected', async () => {
       vi.stubEnv('VITE_ENVIRONMENT', 'invalid-stub-env')
+      const { warmStripeClient } = await makeSut()
 
       // Fire-and-forget: must not throw synchronously and must not surface an
       // unhandled rejection when the underlying load fails.

--- a/src/tests/templates/checkout-plan-block.test.js
+++ b/src/tests/templates/checkout-plan-block.test.js
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import CheckoutPlanBlock from '@/templates/checkout-block/checkout-plan-block.vue'
+
+vi.mock('@aziontech/webkit/use-toast', () => ({
+  useToast: () => ({ add: vi.fn() })
+}))
+
+vi.mock('@/composables/useScrollToError', () => ({
+  useScrollToError: () => ({ scrollToError: vi.fn() })
+}))
+
+const mountCheckoutPlanBlock = () =>
+  mount(CheckoutPlanBlock, {
+    props: {
+      plan: 'pro',
+      getStripeClientService: vi.fn(),
+      checkoutSessionClientSecret: 'cs_test'
+    },
+    global: {
+      stubs: {
+        PricingCalculationBlock: {
+          template: `
+            <button
+              data-testid="prepared-session"
+              @click="
+                $emit('update:billing-cycle', 'yearly');
+                $emit('update:checkout-session-client-secret', 'cs_yearly')
+              "
+            />
+          `,
+          emits: ['update:billing-cycle', 'update:checkout-session-client-secret']
+        },
+        PaymentMethodBlock: {
+          template: `
+            <button
+              data-testid="stale-session"
+              @click="$emit('stale-session', { reason: 'no_such_checkout_session' })"
+            />
+          `,
+          emits: ['readiness-change', 'element-ready', 'stale-session']
+        },
+        AddressInformationBlock: {
+          template: '<div />',
+          emits: ['readiness-change']
+        },
+        CheckoutActionFooter: {
+          template: '<div />'
+        }
+      }
+    }
+  })
+
+describe('checkout-plan-block', () => {
+  it('propagates stale Stripe checkout sessions with current plan and cycle', async () => {
+    const wrapper = mountCheckoutPlanBlock()
+
+    await wrapper.get('[data-testid="stale-session"]').trigger('click')
+
+    expect(wrapper.emitted('stale-session')).toEqual([
+      [
+        {
+          reason: 'no_such_checkout_session',
+          plan: 'pro',
+          billingCycle: 'monthly'
+        }
+      ]
+    ])
+  })
+
+  it('propagates prepared checkout sessions with current cycle', async () => {
+    const wrapper = mountCheckoutPlanBlock()
+
+    await wrapper.get('[data-testid="prepared-session"]').trigger('click')
+
+    expect(wrapper.emitted('checkout-session-prepared')).toEqual([
+      [
+        {
+          clientSecret: 'cs_yearly',
+          billingCycle: 'yearly'
+        }
+      ]
+    ])
+  })
+})

--- a/src/tests/templates/payment-method-block.test.js
+++ b/src/tests/templates/payment-method-block.test.js
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import PaymentMethodBlock from '@/templates/checkout-block/payment-method-block.vue'
+
+const flushPromises = () => Promise.resolve().then(() => Promise.resolve())
+
+const buildStripeClientService = () => {
+  const handlers = {}
+  const paymentElement = {
+    on: vi.fn((eventName, handler) => {
+      handlers[eventName] = handler
+    }),
+    mount: vi.fn((target) => {
+      const iframe = document.createElement('iframe')
+      iframe.src = 'https://js.stripe.com/v3/elements-inner-payment-test.html'
+      target.appendChild(iframe)
+    }),
+    unmount: vi.fn()
+  }
+  const checkout = {
+    createPaymentElement: vi.fn(() => paymentElement)
+  }
+  const stripe = {
+    initCheckoutElementsSdk: vi.fn().mockResolvedValue(checkout)
+  }
+
+  return {
+    handlers,
+    paymentElement,
+    stripeClientService: vi.fn().mockResolvedValue(stripe)
+  }
+}
+
+describe('payment-method-block', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits for the official Stripe ready event before revealing payment fields', async () => {
+    vi.useFakeTimers()
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    const { handlers, stripeClientService } = buildStripeClientService()
+
+    const wrapper = mount(PaymentMethodBlock, {
+      props: {
+        stripeClientService,
+        checkoutSessionClientSecret: 'cs_test'
+      },
+      global: {
+        stubs: {
+          Skeleton: {
+            template: '<div class="p-skeleton" />'
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(wrapper.find('#payment-element').classes()).toContain('opacity-0')
+    expect(wrapper.emitted('element-ready')).toBeUndefined()
+
+    handlers.ready()
+    await flushPromises()
+
+    expect(wrapper.find('#payment-element').classes()).not.toContain('opacity-0')
+    expect(wrapper.emitted('element-ready')).toHaveLength(1)
+    expect(wrapper.emitted('readiness-change')?.at(-1)).toEqual([false])
+  })
+})

--- a/src/tests/templates/pricing-calculation-block.test.js
+++ b/src/tests/templates/pricing-calculation-block.test.js
@@ -1,0 +1,171 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PricingCalculationBlock from '@/templates/checkout-block/pricing-calculation-block.vue'
+
+const mocks = vi.hoisted(() => ({
+  prepareCheckoutSession: vi.fn(),
+  initializePlans: vi.fn(),
+  setPlanParam: vi.fn(),
+  sharedBillingCycle: { value: 'monthly' },
+  plans: {
+    value: [
+      {
+        sku: 'pro',
+        pricings: [
+          { id: 'price_monthly', periodicity: 'monthly', priceValue: 10 },
+          { id: 'price_yearly', periodicity: 'yearly', priceValue: 100 }
+        ]
+      }
+    ]
+  }
+}))
+
+vi.mock('@aziontech/webkit/use-toast', () => ({
+  useToast: () => ({ add: vi.fn() })
+}))
+
+vi.mock('@/composables/usePlans', () => ({
+  usePlans: () => ({
+    initialize: mocks.initializePlans,
+    billingCycle: mocks.sharedBillingCycle,
+    setParam: mocks.setPlanParam
+  })
+}))
+
+vi.mock('@/composables/useCheckoutSessionPreparer', () => ({
+  useCheckoutSessionPreparer: () => ({
+    prepare: mocks.prepareCheckoutSession,
+    isPreparing: { value: false }
+  })
+}))
+
+vi.mock('@/services/v2/service-orders/service-orders-service', () => ({
+  serviceOrdersService: {
+    useListPlansQuery: () => ({ data: mocks.plans })
+  }
+}))
+
+const flushPromises = () => Promise.resolve().then(() => Promise.resolve())
+
+const createDeferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+const mountPricingCalculationBlock = (props = {}) =>
+  mount(PricingCalculationBlock, {
+    props: {
+      plan: 'pro',
+      ...props
+    },
+    global: {
+      stubs: {
+        PlanCardHeader: {
+          template: '<section><slot name="action" /></section>'
+        },
+        BillingCycleToggle: {
+          name: 'BillingCycleToggle',
+          props: ['modelValue', 'disabled'],
+          emits: ['update:modelValue'],
+          template: '<button />'
+        },
+        PricingSummary: {
+          template: '<div />'
+        }
+      }
+    }
+  })
+
+describe('pricing-calculation-block', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.prepareCheckoutSession.mockReset()
+    mocks.initializePlans.mockReset()
+    mocks.setPlanParam.mockReset()
+    mocks.sharedBillingCycle.value = 'monthly'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('emits the initial billing cycle without preparing a new checkout session', () => {
+    mocks.sharedBillingCycle.value = 'yearly'
+
+    const wrapper = mountPricingCalculationBlock()
+
+    expect(wrapper.emitted('update:billingCycle')?.at(-1)).toEqual(['yearly'])
+    expect(mocks.prepareCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('clears the current checkout session as soon as billing cycle changes', async () => {
+    const wrapper = mountPricingCalculationBlock()
+    const toggle = wrapper.findComponent({ name: 'BillingCycleToggle' })
+
+    await toggle.vm.$emit('update:modelValue', 'yearly')
+
+    expect(wrapper.emitted('update:checkoutSessionClientSecret')?.at(-1)).toEqual([''])
+    expect(mocks.prepareCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps the latest billing-cycle checkout session when older preparation resolves later', async () => {
+    const yearlyPreparation = createDeferred()
+    const monthlyPreparation = createDeferred()
+    mocks.prepareCheckoutSession.mockImplementation(({ preferredCycle }) => {
+      if (preferredCycle === 'yearly') return yearlyPreparation.promise
+      if (preferredCycle === 'monthly') return monthlyPreparation.promise
+      return Promise.resolve('')
+    })
+
+    const wrapper = mountPricingCalculationBlock()
+    const toggle = wrapper.findComponent({ name: 'BillingCycleToggle' })
+
+    await toggle.vm.$emit('update:modelValue', 'yearly')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(mocks.prepareCheckoutSession).toHaveBeenCalledWith({
+      plan: 'pro',
+      preferredCycle: 'yearly',
+      draftServiceOrderId: null,
+      signup: false
+    })
+
+    await toggle.vm.$emit('update:modelValue', 'monthly')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(mocks.prepareCheckoutSession).toHaveBeenLastCalledWith({
+      plan: 'pro',
+      preferredCycle: 'monthly',
+      draftServiceOrderId: null,
+      signup: false
+    })
+
+    monthlyPreparation.resolve('cs_monthly')
+    await flushPromises()
+    yearlyPreparation.resolve('cs_yearly')
+    await flushPromises()
+
+    expect(wrapper.emitted('update:checkoutSessionClientSecret')?.at(-1)).toEqual(['cs_monthly'])
+  })
+
+  it('marks checkout preparation as signup when used in signup context', async () => {
+    mocks.prepareCheckoutSession.mockResolvedValue('cs_yearly')
+
+    const wrapper = mountPricingCalculationBlock({ context: 'signup' })
+    const toggle = wrapper.findComponent({ name: 'BillingCycleToggle' })
+
+    await toggle.vm.$emit('update:modelValue', 'yearly')
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(mocks.prepareCheckoutSession).toHaveBeenCalledWith({
+      plan: 'pro',
+      preferredCycle: 'yearly',
+      draftServiceOrderId: null,
+      signup: true
+    })
+  })
+})

--- a/src/tests/views/signup-additional-data-view.test.js
+++ b/src/tests/views/signup-additional-data-view.test.js
@@ -1,0 +1,298 @@
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AdditionalDataView from '@/views/Signup/AdditionalDataView.vue'
+
+const mocks = vi.hoisted(() => ({
+  preparePaidSignupCheckout: vi.fn(),
+  submitSignupPlanFromDraftOrCreate: vi.fn(),
+  prepareSignupCheckout: vi.fn(),
+  ensurePlansList: vi.fn(),
+  warmStripe: vi.fn(),
+  clearAdditionalDataFormState: vi.fn(),
+  clearPlans: vi.fn(),
+  initializePlans: vi.fn(),
+  removeQueries: vi.fn(),
+  captureException: vi.fn(),
+  plansData: {
+    value: [
+      {
+        id: 2,
+        sku: 'pro',
+        pricings: [{ id: 20, periodicity: 'monthly', priceValue: 10 }]
+      }
+    ]
+  },
+  storedPlan: { value: 'hobby' },
+  storedBillingCycle: { value: 'monthly' },
+  accountStore: {
+    accountData: { id: 123, email: 'user@example.com' }
+  }
+}))
+
+vi.mock('@/composables/signup-checkout-preparation', () => ({
+  preparePaidSignupCheckout: mocks.preparePaidSignupCheckout,
+  submitSignupPlanFromDraftOrCreate: mocks.submitSignupPlanFromDraftOrCreate
+}))
+
+vi.mock('@/composables/usePlansService', () => ({
+  usePlansList: () => ({ data: mocks.plansData }),
+  ensurePlansList: mocks.ensurePlansList
+}))
+
+vi.mock('@/stores/account', () => ({
+  useAccountStore: () => mocks.accountStore
+}))
+
+vi.mock('@/composables/useServiceOrders', () => ({
+  useServiceOrders: () => ({
+    prepareSignupCheckout: mocks.prepareSignupCheckout,
+    isLoading: { value: false }
+  })
+}))
+
+vi.mock('@/composables/useAdditionalDataFormState', () => ({
+  useAdditionalDataFormState: () => ({
+    clear: mocks.clearAdditionalDataFormState
+  })
+}))
+
+vi.mock('@/composables/usePlans', () => ({
+  usePlans: () => ({
+    initialize: mocks.initializePlans,
+    plan: mocks.storedPlan,
+    billingCycle: mocks.storedBillingCycle,
+    clear: mocks.clearPlans
+  })
+}))
+
+vi.mock('@/composables/useWarmStripe', () => ({
+  useWarmStripe: () => ({ warmStripe: mocks.warmStripe })
+}))
+
+vi.mock('@/helpers/account-data', () => ({
+  loadUserAndAccountInfo: vi.fn()
+}))
+
+vi.mock('@/helpers/persist-onboarding-data', () => ({
+  persistOnboardingData: vi.fn()
+}))
+
+vi.mock('@/composables/post-payment-flag', () => ({
+  markAwaitingActiveServiceOrder: vi.fn()
+}))
+
+vi.mock('@/services/v2/base/query/queryClient', () => ({
+  queryClient: {
+    removeQueries: mocks.removeQueries
+  }
+}))
+
+vi.mock('@/services/v2/base/query/queryKeys', () => ({
+  queryKeys: {
+    serviceOrders: { all: ['service-orders'] },
+    billing: { all: ['billing'] },
+    plans: { all: ['plans'] }
+  }
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: mocks.captureException
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+const flushPromises = () => Promise.resolve().then(() => Promise.resolve())
+
+const createDeferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+const AdditionalDataFormStub = defineComponent({
+  emits: ['plan-change'],
+  data: () => ({
+    plan: 'hobby',
+    meta: { valid: true },
+    loading: false
+  }),
+  methods: {
+    selectPlan(plan, billingCycle) {
+      this.plan = plan
+      mocks.storedPlan.value = plan
+      mocks.storedBillingCycle.value = billingCycle
+      this.$emit('plan-change', { plan, billingCycle })
+    },
+    submitForm() {
+      return Promise.resolve()
+    }
+  },
+  template: `
+    <div>
+      <button
+        data-testid="select-pro"
+        @click="selectPlan('pro', 'yearly')"
+      />
+      <button
+        data-testid="select-pro-monthly"
+        @click="selectPlan('pro', 'monthly')"
+      />
+      <button
+        data-testid="select-hobby"
+        @click="selectPlan('hobby', 'monthly')"
+      />
+    </div>
+  `
+})
+
+const mountAdditionalDataView = () =>
+  mount(AdditionalDataView, {
+    global: {
+      provide: {
+        tracker: {
+          signUp: {}
+        }
+      },
+      stubs: {
+        CardBox: {
+          template: '<section><slot name="content" /><slot name="footer" /></section>'
+        },
+        AdditionalDataFormBlock: AdditionalDataFormStub,
+        ChoosingPlanContainer: {
+          template: `
+            <div>
+              <button
+                data-testid="checkout-session-prepared"
+                @click="$emit('checkout-session-prepared', {
+                  clientSecret: 'cs_yearly',
+                  billingCycle: 'yearly'
+                })"
+              />
+              <button
+                data-testid="payment-element-ready"
+                @click="$emit('payment-element-ready')"
+              />
+            </div>
+          `,
+          emits: ['checkout-session-prepared', 'payment-element-ready']
+        },
+        PlanSuccessBlock: {
+          template: '<div />'
+        },
+        ActionButton: {
+          template: '<button data-testid="continue" @click="$emit(\'click\')" />',
+          emits: ['click']
+        }
+      }
+    }
+  })
+
+describe('Signup AdditionalDataView checkout preparation', () => {
+  beforeEach(() => {
+    mocks.preparePaidSignupCheckout.mockReset()
+    mocks.submitSignupPlanFromDraftOrCreate.mockReset()
+    mocks.prepareSignupCheckout.mockReset()
+    mocks.ensurePlansList.mockReset()
+    mocks.warmStripe.mockReset()
+    mocks.clearAdditionalDataFormState.mockReset()
+    mocks.clearPlans.mockReset()
+    mocks.initializePlans.mockReset()
+    mocks.removeQueries.mockReset()
+    mocks.captureException.mockReset()
+    mocks.plansData.value = [
+      {
+        id: 2,
+        sku: 'pro',
+        pricings: [{ id: 20, periodicity: 'monthly', priceValue: 10 }]
+      }
+    ]
+    mocks.storedPlan.value = 'hobby'
+    mocks.storedBillingCycle.value = 'monthly'
+    mocks.accountStore.accountData = { id: 123, email: 'user@example.com' }
+    mocks.preparePaidSignupCheckout.mockResolvedValue({
+      clientSecret: 'cs_test',
+      draftServiceOrderId: 321
+    })
+    mocks.ensurePlansList.mockResolvedValue(mocks.plansData.value)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts Pro checkout preparation immediately when the plan selection changes', async () => {
+    const wrapper = mountAdditionalDataView()
+
+    await wrapper.get('[data-testid="select-pro"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.preparePaidSignupCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 123,
+        plan: 'pro',
+        billingCycle: 'yearly',
+        plans: mocks.plansData.value,
+        prepareSignupCheckout: mocks.prepareSignupCheckout
+      })
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('submits Hobby without waiting for an obsolete Pro checkout preparation', async () => {
+    const preparation = createDeferred()
+    mocks.preparePaidSignupCheckout.mockReturnValueOnce(preparation.promise)
+    mocks.submitSignupPlanFromDraftOrCreate.mockResolvedValue({
+      draftServiceOrderId: 'so_hobby',
+      serviceOrder: { serviceOrderId: 'so_hobby' }
+    })
+    const wrapper = mountAdditionalDataView()
+
+    await wrapper.get('[data-testid="select-pro"]').trigger('click')
+    await wrapper.get('[data-testid="select-hobby"]').trigger('click')
+
+    await wrapper.get('[data-testid="actions-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.submitSignupPlanFromDraftOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: 'hobby',
+        prepareSignupCheckout: mocks.prepareSignupCheckout
+      })
+    )
+
+    preparation.resolve({
+      clientSecret: 'cs_stale',
+      draftServiceOrderId: 'so_stale',
+      serviceOrder: { serviceOrderId: 'so_stale', status: 'DRAFT' }
+    })
+    await flushPromises()
+  })
+
+  it('reuses checkout sessions prepared by the billing-cycle toggle when returning to checkout', async () => {
+    const wrapper = mountAdditionalDataView()
+
+    await wrapper.get('[data-testid="select-pro-monthly"]').trigger('click')
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    expect(mocks.preparePaidSignupCheckout).toHaveBeenCalledTimes(1)
+
+    mocks.storedBillingCycle.value = 'yearly'
+    await wrapper.get('[data-testid="checkout-session-prepared"]').trigger('click')
+    await wrapper.get('[data-testid="payment-element-ready"]').trigger('click')
+
+    await wrapper.get('[data-testid="actions-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.preparePaidSignupCheckout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/views/Billing/BillsView.vue
+++ b/src/views/Billing/BillsView.vue
@@ -19,6 +19,7 @@
         v-if="subscriptionState.isHobby"
         :loading="preparingPlan === 'pro'"
         @upgrade="openUpgradeToPro"
+        @upgrade-intent="handleUpgradeIntent"
       />
       <CurrentInvoiceCard
         v-else
@@ -263,6 +264,9 @@
   const selectedPlan = ref(null)
   const lockedCycle = ref(null)
   const checkoutSessionClientSecret = ref('')
+  const checkoutPreparationKey = ref('')
+  let checkoutPreparationVersion = 0
+  let currentCheckoutPreparationPromise = null
   const preparingPlan = ref(null)
   const downgradeTarget = ref({
     toPlan: 'hobby',
@@ -302,9 +306,68 @@
   watch(showPlanInfoDrawer, (visible) => {
     if (!visible) {
       checkoutSessionClientSecret.value = ''
+      checkoutPreparationKey.value = ''
       drawerMode.value = 'subscribe'
     }
   })
+
+  const buildPreparationKey = (plan, cycle) => `${plan}:${cycle || 'monthly'}`
+
+  const prepareCheckoutAhead = ({ plan, preferredCycle = null, force = false } = {}) => {
+    const cycle = preferredCycle || storedBillingCycle.value || 'monthly'
+    const key = buildPreparationKey(plan, cycle)
+
+    if (
+      !force &&
+      checkoutPreparationKey.value === key &&
+      checkoutSessionClientSecret.value &&
+      !currentCheckoutPreparationPromise
+    ) {
+      return Promise.resolve(checkoutSessionClientSecret.value)
+    }
+
+    if (currentCheckoutPreparationPromise && checkoutPreparationKey.value === key) {
+      return currentCheckoutPreparationPromise
+    }
+
+    const version = ++checkoutPreparationVersion
+    checkoutPreparationKey.value = key
+    if (force) checkoutSessionClientSecret.value = ''
+
+    const promise = prepareCheckoutSession({ plan, preferredCycle: cycle })
+      .then((secret) => {
+        if (version === checkoutPreparationVersion) {
+          checkoutSessionClientSecret.value = secret
+        }
+        return secret
+      })
+      .finally(() => {
+        if (currentCheckoutPreparationPromise === promise) {
+          currentCheckoutPreparationPromise = null
+        }
+      })
+
+    currentCheckoutPreparationPromise = promise
+    return promise
+  }
+
+  const schedulePrepareForPro = (preferredCycle = null) => {
+    if (
+      subscription.isPro.value &&
+      subscription.billingCycle.value === (preferredCycle || storedBillingCycle.value)
+    ) {
+      return
+    }
+    const cycle = preferredCycle || storedBillingCycle.value || 'monthly'
+    const key = buildPreparationKey('pro', cycle)
+    if (
+      checkoutPreparationKey.value === key &&
+      (checkoutSessionClientSecret.value || currentCheckoutPreparationPromise)
+    ) {
+      return
+    }
+    prepareCheckoutAhead({ plan: 'pro', preferredCycle: cycle }).catch(Sentry.captureException)
+  }
 
   const { defaultPaymentMethod } = useBillingPaymentMethods()
 
@@ -418,19 +481,19 @@
       source: 'subscription-card'
     })
     showChangePlanDrawer.value = true
+    schedulePrepareForPro(initialCycle)
   }
 
   const openDrawerWithCheckoutSession = async ({ plan, preferredCycle, lockedCycle: locked }) => {
     if (preparingPlan.value) return
-    checkoutSessionClientSecret.value = ''
     drawerMode.value = 'subscribe'
     selectedPlan.value = plan
     lockedCycle.value = locked
-    showPlanInfoDrawer.value = true
     preparingPlan.value = plan
     try {
-      const secret = await prepareCheckoutSession({ plan, preferredCycle })
+      const secret = await prepareCheckoutAhead({ plan, preferredCycle })
       checkoutSessionClientSecret.value = secret
+      showPlanInfoDrawer.value = true
       trackBilling('checkoutStarted', {
         plan,
         billingCycle: preferredCycle || storedBillingCycle.value,
@@ -452,10 +515,13 @@
         detail,
         closable: true
       })
-      showPlanInfoDrawer.value = false
     } finally {
       preparingPlan.value = null
     }
+  }
+
+  const handleUpgradeIntent = () => {
+    schedulePrepareForPro('monthly')
   }
 
   // Stripe rejected the previously issued client secret (session expired or
@@ -465,13 +531,16 @@
   const handleStaleCheckoutSession = async ({ plan, billingCycle: cycle } = {}) => {
     const targetPlan = plan || selectedPlan.value
     if (!targetPlan) return
+    const targetCycle = cycle || storedBillingCycle.value || null
     checkoutSessionClientSecret.value = ''
+    checkoutPreparationKey.value = ''
     try {
       const fresh = await recoverFromStaleSession({
         plan: targetPlan,
-        preferredCycle: cycle || storedBillingCycle.value || null
+        preferredCycle: targetCycle
       })
       checkoutSessionClientSecret.value = fresh
+      checkoutPreparationKey.value = buildPreparationKey(targetPlan, targetCycle)
     } catch (err) {
       Sentry.captureException(err)
       toast.add({

--- a/src/views/Billing/components/UpgradeToProCard.vue
+++ b/src/views/Billing/components/UpgradeToProCard.vue
@@ -2,6 +2,8 @@
   <CardBox
     title="Upgrade to Pro"
     class="w-full min-[1100px]:w-1/2"
+    @mouseenter="signalUpgradeIntent"
+    @focusin="signalUpgradeIntent"
   >
     <template #content>
       <div class="p-6 flex flex-col gap-6 justify-between h-full">
@@ -58,11 +60,18 @@
     }
   })
 
-  const emit = defineEmits(['upgrade'])
+  const emit = defineEmits(['upgrade', 'upgrade-intent'])
 
   const features = PRO_UPGRADE_HIGHLIGHTS
 
   const pricingAndPlansUrl = 'https://www.azion.com/en/pricing/'
+
+  let intentSignalled = false
+  const signalUpgradeIntent = () => {
+    if (intentSignalled) return
+    intentSignalled = true
+    emit('upgrade-intent')
+  }
 
   const handleUpgradeClick = () => {
     if (props.loading) return

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -16,7 +16,10 @@
         >
           <template #content>
             <div class="p-6 overflow-visible">
-              <AdditionalDataFormBlock ref="additionalDataRef" />
+              <AdditionalDataFormBlock
+                ref="additionalDataRef"
+                @plan-change="handlePlanChange"
+              />
             </div>
           </template>
 
@@ -33,21 +36,27 @@
           </template>
         </CardBox>
         <div
-          v-else-if="isCheckoutStep"
+          v-if="shouldMountCheckout"
           class="w-full"
+          :class="{ 'checkout-stage-hidden': isCheckoutPremounting }"
+          :inert="isCheckoutPremounting"
+          :aria-hidden="isCheckoutPremounting"
         >
           <!-- Checkout Component -->
           <ChoosingPlanContainer
             :plan="selectedPlan"
             :checkoutSessionClientSecret="checkoutSessionClientSecret"
-            ref="checkoutRef"
+            :draftServiceOrderId="draftServiceOrderId"
             @onSuccess="handleCheckoutSuccess"
             @onError="handleCheckoutError"
             @onBack="handleGoBack"
+            @payment-element-ready="handleCheckoutElementReady"
+            @stale-session="handleStaleCheckoutSession"
+            @checkout-session-prepared="handleCheckoutSessionPrepared"
           />
         </div>
         <PlanSuccessBlock
-          v-else-if="isSuccessStep"
+          v-if="isSuccessStep"
           :plan="selectedPlan"
           @onStart="handleStartFromSuccess"
         />
@@ -90,12 +99,16 @@
   import ChoosingPlanContainer from '@/templates/signup-block/choosing-plan-container.vue'
   import PlanSuccessBlock from '@/templates/signup-block/plan-success-block.vue'
   import ActionButton from '@aziontech/webkit/actions/button'
-  import { computed, inject, onMounted, ref, watch } from 'vue'
+  import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
   import { useRouter } from 'vue-router'
   import { usePlans } from '@/composables/usePlans'
-  import { usePlansList, ensurePlansList, getPlanPricingId } from '@/composables/usePlansService'
+  import { usePlansList, ensurePlansList } from '@/composables/usePlansService'
   import { useAccountStore } from '@/stores/account'
   import { useServiceOrders } from '@/composables/useServiceOrders'
+  import {
+    preparePaidSignupCheckout,
+    submitSignupPlanFromDraftOrCreate
+  } from '@/composables/signup-checkout-preparation'
   import { useAdditionalDataFormState } from '@/composables/useAdditionalDataFormState'
   import { markAwaitingActiveServiceOrder } from '@/composables/post-payment-flag'
   import * as Sentry from '@sentry/vue'
@@ -117,30 +130,38 @@
   const { warmStripe } = useWarmStripe()
   const {
     initialize: initializePlans,
+    plan: storedPlan,
     billingCycle: storedBillingCycle,
     clear: clearPlans
   } = usePlans()
   const accountStore = useAccountStore()
   // Auto-fetch on mount when the cache entry is stale/missing (staleTime
-  // 1h). The view reads `plansData.value` reactively in helpers like
-  // `getPlanIdFromName`; the explicit `ensurePlansList()` below guarantees
-  // the catalogue is loaded before the SO call needs it.
+  // 1h). The view reads `plansData.value` reactively when preparing the
+  // checkout; the explicit `ensurePlansList()` below guarantees the catalogue
+  // is loaded before the SO call needs it.
   const { data: plansData } = usePlansList()
-  const {
-    loadAccountServiceOrders,
-    submitServiceOrder,
-    isLoading: isLoadingServiceOrder,
-    isSubmitting: isSubmittingServiceOrder
-  } = useServiceOrders()
+  const { prepareSignupCheckout, isLoading: isLoadingServiceOrder } = useServiceOrders()
 
   const additionalDataRef = ref(null)
   const currentStep = ref('additional-data') // 'additional-data' | 'checkout' | 'success'
   const selectedPlan = ref(null)
   const checkoutSessionClientSecret = ref('')
+  const draftServiceOrderId = ref(null)
+  const checkoutElementReady = ref(false)
+  const checkoutPreparationKey = ref('')
+  const isSubmitActionLoading = ref(false)
+  const isAwaitingCheckoutReveal = ref(false)
 
   const isAdditionalDataStep = computed(() => currentStep.value === 'additional-data')
   const isCheckoutStep = computed(() => currentStep.value === 'checkout')
   const isSuccessStep = computed(() => currentStep.value === 'success')
+  const shouldMountCheckout = computed(
+    () =>
+      selectedPlan.value === 'pro' &&
+      Boolean(checkoutSessionClientSecret.value) &&
+      !isSuccessStep.value
+  )
+  const isCheckoutPremounting = computed(() => shouldMountCheckout.value && !isCheckoutStep.value)
   const isDisabledSubmit = computed(() => {
     const metaValid = additionalDataRef.value?.meta?.valid
     return !metaValid || isSubmitLoading.value
@@ -148,18 +169,15 @@
 
   const isSubmitLoading = computed(() => {
     const formLoading = additionalDataRef.value?.loading
-    const serviceOrderLoading = isLoadingServiceOrder.value || isSubmittingServiceOrder.value
-    return formLoading || serviceOrderLoading
+    return (
+      formLoading ||
+      isLoadingServiceOrder.value ||
+      isSubmitActionLoading.value ||
+      isAwaitingCheckoutReveal.value
+    )
   })
 
   const submitButtonLabel = computed(() => 'Continue')
-  const getPlanIdFromName = (planName) => {
-    if (!plansData.value?.length) return null
-    const foundPlan = plansData.value.find(
-      (planItem) => planItem.sku?.toLowerCase() === planName?.toLowerCase()
-    )
-    return foundPlan?.id || null
-  }
 
   const invalidateBillingCaches = () => {
     queryClient.removeQueries({ queryKey: queryKeys.serviceOrders.all })
@@ -167,23 +185,241 @@
     queryClient.removeQueries({ queryKey: queryKeys.plans.all })
   }
 
+  const DEFAULT_BILLING_CYCLE = 'monthly'
+  const CHECKOUT_PREPARE_DEBOUNCE_MS = 150
+  const CHECKOUT_READY_TIMEOUT_MS = 15000
+
+  let checkoutPlansPromise = null
+  let checkoutPreparationTimer = null
+  let checkoutPreparationVersion = 0
+  let currentCheckoutPreparationPromise = null
+  const checkoutReadyResolvers = new Set()
+
+  initializePlans({ defaultPlan: 'hobby', defaultBillingCycle: DEFAULT_BILLING_CYCLE })
+
+  const ensureCheckoutPlans = async () => {
+    if (plansData.value?.length) return plansData.value
+
+    if (!checkoutPlansPromise) {
+      checkoutPlansPromise = ensurePlansList().catch((err) => {
+        checkoutPlansPromise = null
+        throw err
+      })
+    }
+
+    return checkoutPlansPromise
+  }
+
+  const rememberDraftServiceOrder = ({ accountId, result }) => {
+    const serviceOrder = result?.serviceOrder ?? null
+    const serviceOrderId = result?.draftServiceOrderId || serviceOrder?.serviceOrderId || null
+    if (!serviceOrderId || accountId !== accountStore.accountData?.id) return
+
+    draftServiceOrderId.value = serviceOrderId
+  }
+
+  const resolveCheckoutReadyWaiters = () => {
+    checkoutReadyResolvers.forEach((resolve) => resolve())
+    checkoutReadyResolvers.clear()
+  }
+
+  const handleCheckoutElementReady = () => {
+    checkoutElementReady.value = true
+    resolveCheckoutReadyWaiters()
+  }
+
+  const handleCheckoutSessionPrepared = ({ clientSecret, billingCycle } = {}) => {
+    if (!clientSecret || selectedPlan.value !== 'pro') return
+
+    const cycle = billingCycle || storedBillingCycle.value || DEFAULT_BILLING_CYCLE
+    checkoutPreparationKey.value = `pro:${cycle}`
+    checkoutSessionClientSecret.value = clientSecret
+    checkoutElementReady.value = false
+  }
+
+  const waitForCheckoutElementReady = () => {
+    if (checkoutElementReady.value) return Promise.resolve()
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        checkoutReadyResolvers.delete(done)
+        resolve()
+      }, CHECKOUT_READY_TIMEOUT_MS)
+
+      const done = () => {
+        clearTimeout(timeout)
+        resolve()
+      }
+
+      checkoutReadyResolvers.add(done)
+    })
+  }
+
+  const resetPreparedCheckout = () => {
+    checkoutPreparationVersion += 1
+    checkoutPreparationKey.value = ''
+    checkoutSessionClientSecret.value = ''
+    checkoutElementReady.value = false
+    if (!isCheckoutStep.value) {
+      selectedPlan.value = null
+    }
+  }
+
+  const isCurrentCheckoutPreparation = ({ accountId, key, version }) =>
+    version === checkoutPreparationVersion &&
+    key === checkoutPreparationKey.value &&
+    accountId === accountStore.accountData?.id
+
+  const runCheckoutPreparation = async ({ accountId, plan, billingCycle, key, version }) => {
+    try {
+      const plans = await ensureCheckoutPlans()
+      const result = await preparePaidSignupCheckout({
+        accountId,
+        plan,
+        billingCycle,
+        plans,
+        prepareSignupCheckout
+      })
+
+      rememberDraftServiceOrder({ accountId, result })
+
+      if (!isCurrentCheckoutPreparation({ accountId, key, version })) {
+        return null
+      }
+
+      selectedPlan.value = plan
+      checkoutSessionClientSecret.value = result.clientSecret
+      checkoutElementReady.value = false
+
+      return result
+    } catch (err) {
+      if (version === checkoutPreparationVersion) {
+        checkoutSessionClientSecret.value = ''
+        checkoutElementReady.value = false
+      }
+      throw err
+    }
+  }
+
+  const prepareProCheckout = ({ billingCycle, force = false } = {}) => {
+    const plan = 'pro'
+    const cycle = billingCycle || storedBillingCycle.value || DEFAULT_BILLING_CYCLE
+    const key = `${plan}:${cycle}`
+    const accountId = accountStore.accountData?.id
+
+    if (
+      !force &&
+      checkoutPreparationKey.value === key &&
+      checkoutSessionClientSecret.value &&
+      !currentCheckoutPreparationPromise
+    ) {
+      return Promise.resolve({
+        clientSecret: checkoutSessionClientSecret.value,
+        draftServiceOrderId: draftServiceOrderId.value,
+        serviceOrder: null
+      })
+    }
+
+    if (currentCheckoutPreparationPromise && checkoutPreparationKey.value === key) {
+      return currentCheckoutPreparationPromise
+    }
+
+    const version = ++checkoutPreparationVersion
+    checkoutPreparationKey.value = key
+    checkoutSessionClientSecret.value = ''
+    checkoutElementReady.value = false
+    selectedPlan.value = plan
+
+    const trackedPreparation = runCheckoutPreparation({
+      accountId,
+      plan,
+      billingCycle: cycle,
+      key,
+      version
+    }).finally(() => {
+      if (currentCheckoutPreparationPromise === trackedPreparation) {
+        currentCheckoutPreparationPromise = null
+      }
+    })
+    currentCheckoutPreparationPromise = trackedPreparation
+
+    return currentCheckoutPreparationPromise
+  }
+
+  const scheduleProCheckoutPreparation = () => {
+    if (checkoutPreparationTimer) {
+      clearTimeout(checkoutPreparationTimer)
+      checkoutPreparationTimer = null
+    }
+
+    const accountId = accountStore.accountData?.id
+    const plan = storedPlan.value || additionalDataRef.value?.plan
+    const billingCycle = storedBillingCycle.value || DEFAULT_BILLING_CYCLE
+
+    if (!isAdditionalDataStep.value || !accountId) return
+
+    if (plan !== 'pro') {
+      resetPreparedCheckout()
+      return
+    }
+
+    const key = `${plan}:${billingCycle}`
+    if (
+      checkoutPreparationKey.value === key &&
+      (checkoutSessionClientSecret.value || currentCheckoutPreparationPromise)
+    ) {
+      return
+    }
+
+    checkoutPreparationTimer = setTimeout(() => {
+      checkoutPreparationTimer = null
+      prepareProCheckout({ billingCycle }).catch(Sentry.captureException)
+    }, CHECKOUT_PREPARE_DEBOUNCE_MS)
+  }
+
+  const handlePlanChange = ({ plan, billingCycle } = {}) => {
+    if (!isAdditionalDataStep.value || !accountStore.accountData?.id) return
+
+    if (checkoutPreparationTimer) {
+      clearTimeout(checkoutPreparationTimer)
+      checkoutPreparationTimer = null
+    }
+
+    if (plan !== 'pro') {
+      resetPreparedCheckout()
+      return
+    }
+
+    prepareProCheckout({ billingCycle: billingCycle || DEFAULT_BILLING_CYCLE }).catch(
+      Sentry.captureException
+    )
+  }
+
   // Handlers
   const onSubmit = async () => {
     const plan = additionalDataRef.value?.plan
     const accountId = accountStore.accountData?.id
-    const billingCycle = storedBillingCycle.value || 'yearly'
+    const billingCycle = storedBillingCycle.value || DEFAULT_BILLING_CYCLE
 
     if (!plan || !accountId) return
 
     trackSignUp('planSelected', { plan, billingCycle })
-
-    const planId = getPlanIdFromName(plan)
-    if (!planId) return
+    isSubmitActionLoading.value = true
 
     if (plan === 'hobby') {
       try {
         await persistOnboardingData({ plan })
-        await submitServiceOrder({ accountId, planId })
+        const plans = await ensureCheckoutPlans()
+        const result = await submitSignupPlanFromDraftOrCreate({
+          accountId,
+          plan,
+          billingCycle,
+          plans,
+          prepareSignupCheckout
+        })
+        if (result?.draftServiceOrderId) {
+          draftServiceOrderId.value = null
+        }
 
         invalidateBillingCaches()
         await loadUserAndAccountInfo({ force: true })
@@ -191,37 +427,31 @@
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('Failed to activate hobby plan:', err)
+      } finally {
+        isSubmitActionLoading.value = false
       }
       return
     }
 
-    const planPricingId = getPlanPricingId(plansData.value, plan, billingCycle)
-    if (!planPricingId) return
-
-    checkoutSessionClientSecret.value = ''
-    selectedPlan.value = plan
-    trackSignUp('checkoutStarted', { plan, billingCycle })
-    currentStep.value = 'checkout'
-
     try {
-      const serviceOrderResponse = await submitServiceOrder({ accountId, planId, planPricingId })
-      const secret =
-        serviceOrderResponse?.payment?.clientSecret ||
-        serviceOrderResponse?.data?.clientSecret ||
-        ''
-
-      if (!secret) {
-        // eslint-disable-next-line no-console
-        console.error('Unable to initialize payment. Please try again.')
-        currentStep.value = 'additional-data'
-        return
+      isAwaitingCheckoutReveal.value = true
+      const result = await prepareProCheckout({ billingCycle, force: false })
+      if (result?.draftServiceOrderId) {
+        draftServiceOrderId.value = result.draftServiceOrderId
       }
-
-      checkoutSessionClientSecret.value = secret
+      if (!checkoutSessionClientSecret.value) {
+        throw new Error('Unable to initialize payment. Please try again.')
+      }
+      await waitForCheckoutElementReady()
+      trackSignUp('checkoutStarted', { plan, billingCycle })
+      currentStep.value = 'checkout'
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Failed to submit service order:', err)
       currentStep.value = 'additional-data'
+    } finally {
+      isAwaitingCheckoutReveal.value = false
+      isSubmitActionLoading.value = false
     }
   }
 
@@ -280,6 +510,16 @@
     console.error('Checkout error:', error)
   }
 
+  const handleStaleCheckoutSession = async ({ billingCycle } = {}) => {
+    const cycle = billingCycle || storedBillingCycle.value || DEFAULT_BILLING_CYCLE
+    try {
+      await prepareProCheckout({ billingCycle: cycle, force: true })
+    } catch (err) {
+      Sentry.captureException(err)
+      handleCheckoutError(err)
+    }
+  }
+
   const handleStartFromSuccess = () => {
     invalidateBillingCaches()
     router.push({ name: 'home' })
@@ -291,23 +531,36 @@
     clearPlans()
   })
 
+  watch(
+    [
+      () => storedPlan.value,
+      () => storedBillingCycle.value,
+      () => plansData.value,
+      () => accountStore.accountData?.id,
+      () => currentStep.value
+    ],
+    scheduleProCheckoutPreparation,
+    { immediate: true }
+  )
+
   onMounted(async () => {
-    initializePlans()
     // Warm Stripe.js while the user fills the additional-data form so the Pro
     // checkout step (the very next screen) reuses the already-downloaded
     // client instead of blocking on a cold js.stripe.com load.
     warmStripe()
-    // Cache-aware: uses the existing plans entry when fresh, fetches only
-    // when stale/missing. Replaces the previous `refetch()` call that
-    // always hit the network.
-    await ensurePlansList()
-    const accountId = accountStore.accountData?.id
-    if (accountId) {
-      const { draft } = await loadAccountServiceOrders(accountId)
-      if (draft?.clientSecret) {
-        checkoutSessionClientSecret.value = draft.clientSecret
-      }
+    // Cache-aware: uses existing plans when fresh. The checkout prepare
+    // endpoint now resolves/reuses any DRAFT service order server-side.
+    await ensureCheckoutPlans()
+    scheduleProCheckoutPreparation()
+  })
+
+  onBeforeUnmount(() => {
+    if (checkoutPreparationTimer) {
+      clearTimeout(checkoutPreparationTimer)
+      checkoutPreparationTimer = null
     }
+    checkoutPreparationVersion += 1
+    checkoutReadyResolvers.clear()
   })
 </script>
 
@@ -330,5 +583,15 @@
   .step-fade-enter-from,
   .step-fade-leave-to {
     opacity: 0;
+  }
+
+  .checkout-stage-hidden {
+    position: fixed;
+    top: 0;
+    left: -200vw;
+    width: min(100vw, 960px);
+    height: 800px;
+    opacity: 0;
+    pointer-events: none;
   }
 </style>


### PR DESCRIPTION
## Summary
- Use the new `POST /v4/service_orders/signup/checkout/prepare` path for signup plan selection so the frontend avoids the old service-order discovery plus create/update/submit sequence before showing Stripe.
- Prepare Pro checkout as soon as the user selects Pro on the previous signup screen, warm Stripe.js, and pre-mount the Payment Element hidden until Stripe reports ready.
- Keep Hobby/free signup as service-order based but payment-free, with default signup selection set to Hobby/monthly.
- Keep Billing/change-plan on the existing billing flow, only using the new signup endpoint when the checkout context is `signup`.
- Add stale-session recovery and monthly/yearly propagation so going back and forward does not discard already-prepared checkout sessions.
- Remove redundant `defineModel` imports from Vue components to eliminate the compiler macro warning seen during local startup.
- Add focused tests for plan defaults, endpoint payloads, pre-mounted Stripe readiness, signup checkout preparation, billing-cycle changes, and Stripe client memoization.

## Why
The goal is to make the credit-card form appear ready when the user advances from plan selection to checkout. Previously too much work happened only after opening the card step: service-order lookup, draft/create/update, Stripe client load, and Payment Element mount. This moves slow work to the preceding screen and reuses the prepared session when possible.

The `defineModel` cleanup is included because it was part of the local validation feedback from this same work: Vue treats `defineModel` as a compiler macro and no longer expects it in imports.

## Technical Notes
- `usePlans.initialize(defaults)` allows signup-only defaults. URL params still win, and partial signup URLs are completed with missing defaults.
- Signup Pro uses `prepareSignupCheckout`; Billing keeps `ensureServiceOrdersList` plus draft/update/upgrade logic to avoid creating signup drafts for active customers.
- Payment Element uses a DOM ref mount and emits `element-ready`; `AdditionalDataView` waits for readiness before revealing checkout.
- Stripe client loading is memoized by environment/token and `warmStripeClient()` remains fire-and-forget.
- `defineModel` usage remains as compiler macros; only imports from `vue` were removed.

## Validation
- Commit hook ran `eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore`: 0 errors, 67 warnings from existing architecture rules.
- Commit hook ran `TZ=UTC vitest run --coverage`: 252 files passed, 1420 tests passed, 2 files/5 tests skipped.
- `git show --check --stat --oneline HEAD`: clean.

## Operational Notes
- Draft PR because backend endpoint rollout and stage validation are coupled with service-order-api PR 115.
- Left `azion/stage/azion.json` out of this PR because its diff is only whitespace/newline formatting and has no relation to checkout behavior.