### PR TITLE
fix: restore signup checkout external scroll

### DIFF
--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="relative flex lg:h-full flex-col lg:overflow-hidden pt-6 w-full lg:w-[600px]">
-    <div class="checkout-scroll-area flex flex-1 flex-col gap-6 px-4 lg:px-8 pb-6 overflow-y-auto">
+  <div class="relative flex flex-col pt-6 w-full lg:w-[600px]">
+    <div class="flex flex-col gap-6 px-4 lg:px-8 pb-6">
       <PricingCalculationBlock
         ref="pricingCalculationRef"
         :plan="plan"
@@ -208,35 +208,3 @@
     billingCycle
   })
 </script>
-
-<style scoped>
-  .checkout-scroll-area {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
-  }
-
-  .checkout-scroll-area::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  .checkout-scroll-area::-webkit-scrollbar-thumb {
-    background-color: transparent;
-    border-radius: 4px;
-  }
-
-  .checkout-scroll-area:hover,
-  .checkout-scroll-area:focus-within {
-    scrollbar-color: var(--border-default) transparent;
-  }
-
-  .checkout-scroll-area:hover::-webkit-scrollbar-thumb,
-  .checkout-scroll-area:focus-within::-webkit-scrollbar-thumb {
-    background-color: var(--border-default);
-  }
-
-  .checkout-scroll-area:hover::-webkit-scrollbar-thumb:hover,
-  .checkout-scroll-area:focus-within::-webkit-scrollbar-thumb:hover {
-    background-color: var(--text-color-secondary);
-  }
-</style>

--- a/src/templates/signup-block/choosing-plan-container.vue
+++ b/src/templates/signup-block/choosing-plan-container.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border lg:h-[800px]">
-    <div class="flex lg:h-full lg:min-h-0 lg:overflow-hidden flex-col-reverse lg:flex-row">
+  <div class="w-full max-w-5xl mx-auto bg-surface rounded border surface-border">
+    <div class="flex flex-col-reverse lg:flex-row">
       <CheckoutPlanBlock
         ref="planBlockRef"
         :plan="plan"


### PR DESCRIPTION
## Summary

Restores the signup checkout layout that expands naturally and relies on the page scroll instead of creating an internal scroll area around the Stripe/card form.

This reapplies the layout behavior from the original checkout acceleration commit that was overwritten when the PR was updated with `dev`/`#3555`:

- remove the fixed desktop height from `ChoosingPlanContainer`
- remove the desktop overflow lock from the signup checkout wrapper
- remove `overflow-y-auto` and the `checkout-scroll-area` styling from `CheckoutPlanBlock`

The Billing drawer keeps its own scroll behavior unchanged because it is a fixed drawer surface and still benefits from an internal scroll area.

## Validation

- `node_modules/.bin/eslint src/templates/signup-block/choosing-plan-container.vue src/templates/checkout-block/checkout-plan-block.vue --ext .vue,.js,.jsx,.cjs,.mjs --no-fix` passed
- `git diff --check` passed

Could not run the targeted Vitest files locally because this shell fails loading Rollup's native optional package with a macOS code-signing error under Node v24 before tests execute.