### PR TITLE
[NO-ISSUE] fix: align resend email section items in account activation

### DIFF
--- a/src/templates/signup-block/account-activation.vue
+++ b/src/templates/signup-block/account-activation.vue
@@ -9,7 +9,7 @@
         folder and follow the instructions.
       </p>
     </section>
-    <section class="w-full flex flex-wrap gap-2">
+    <section class="w-full flex flex-wrap gap-2 items-center">
       <p class="text-start text-sm">Didn't receive the email?</p>
       <Button
         kind="text"


### PR DESCRIPTION
## Summary
- Adds `items-center` to the "Didn't receive the email?" section in `account-activation.vue` so the label, Resend Email button, and countdown badge align vertically on the same line.

## Root cause
- The flex section was missing vertical alignment, causing items with different heights (text, button, badge) to render misaligned when the badge appears.

## Changes
- `src/templates/signup-block/account-activation.vue`: add `items-center` utility to the resend email section wrapper.

## Test plan
- [ ] Open the account activation page after signup.
- [ ] Click **Resend Email** and confirm the countdown badge, button, and label stay vertically aligned.
- [ ] Verify no regression on the surrounding card layout.