### PR TITLE
[NO-ISSUE] feat: mobile carousel for plan selection cards

### DIFF
--- a/src/components/Carousel.vue
+++ b/src/components/Carousel.vue
@@ -1,0 +1,278 @@
+<template>
+  <div
+    ref="rootRef"
+    class="carousel"
+    role="region"
+    aria-roledescription="carousel"
+    :aria-label="ariaLabel"
+  >
+    <div
+      ref="viewportRef"
+      class="carousel-viewport"
+      :class="{ 'is-grabbing': isDragging }"
+      :style="viewportStyle"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+      @pointerleave="onPointerLeave"
+      @scroll.passive="onScroll"
+    >
+      <div
+        v-for="(_, idx) in slidesCount"
+        :key="idx"
+        class="carousel-slide shrink-0"
+        :style="slideStyle"
+        :aria-roledescription="'slide'"
+        :aria-label="`${idx + 1} of ${slidesCount}`"
+      >
+        <slot
+          :name="`slide-${idx}`"
+          :index="idx"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+  defineOptions({
+    name: 'BaseCarousel'
+  })
+
+  const props = defineProps({
+    slidesCount: {
+      type: Number,
+      required: true
+    },
+    slidesPerView: {
+      type: Number,
+      default: 1
+    },
+    spaceBetween: {
+      type: Number,
+      default: 16
+    },
+    maxSlideWidth: {
+      type: Number,
+      default: 0
+    },
+    initialIndex: {
+      type: Number,
+      default: 0
+    },
+    snap: {
+      type: Boolean,
+      default: true
+    },
+    snapAlign: {
+      type: String,
+      default: 'center',
+      validator: (value) => ['start', 'center', 'end'].includes(value)
+    },
+    enableMouseDrag: {
+      type: Boolean,
+      default: true
+    },
+    ariaLabel: {
+      type: String,
+      default: 'Carousel'
+    }
+  })
+
+  const emit = defineEmits(['slideChange'])
+
+  const rootRef = ref(null)
+  const viewportRef = ref(null)
+
+  const isDragging = ref(false)
+  const dragStartX = ref(0)
+  const dragStartScroll = ref(0)
+  const pointerId = ref(null)
+  const activeIndex = ref(0)
+  const canScrollLeft = ref(false)
+  const canScrollRight = ref(false)
+  let scrollFrame = null
+  let resizeObserver = null
+
+  const FADE_SIZE = 32
+
+  const slideStyle = computed(() => {
+    const gap = props.spaceBetween
+    const base = `calc((100% - ${gap * (props.slidesPerView - 1)}px) / ${props.slidesPerView})`
+    return {
+      width: props.maxSlideWidth > 0 ? `min(${base}, ${props.maxSlideWidth}px)` : base,
+      marginRight: `${gap}px`,
+      scrollSnapAlign: props.snap ? props.snapAlign : 'none'
+    }
+  })
+
+  const viewportStyle = computed(() => {
+    if (!canScrollLeft.value && !canScrollRight.value) return {}
+    const leftStop = canScrollLeft.value ? `${FADE_SIZE}px` : '0'
+    const rightStop = canScrollRight.value ? `calc(100% - ${FADE_SIZE}px)` : '100%'
+    const leftStart = canScrollLeft.value ? 'transparent' : 'black'
+    const rightEnd = canScrollRight.value ? 'transparent' : 'black'
+    const mask = `linear-gradient(to right, ${leftStart} 0, black ${leftStop}, black ${rightStop}, ${rightEnd} 100%)`
+    return {
+      WebkitMaskImage: mask,
+      maskImage: mask
+    }
+  })
+
+  function updateScrollEdges() {
+    const viewport = viewportRef.value
+    if (!viewport) {
+      canScrollLeft.value = false
+      canScrollRight.value = false
+      return
+    }
+    canScrollLeft.value = viewport.scrollLeft > 1
+    canScrollRight.value = viewport.scrollLeft + viewport.clientWidth < viewport.scrollWidth - 1
+  }
+
+  function onPointerDown(event) {
+    if (!props.enableMouseDrag) return
+    if (event.pointerType === 'touch') return
+    if (event.button !== undefined && event.button !== 0) return
+    if (!viewportRef.value) return
+
+    isDragging.value = true
+    dragStartX.value = event.clientX
+    dragStartScroll.value = viewportRef.value.scrollLeft
+    pointerId.value = event.pointerId
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // setPointerCapture can throw if the element isn't in DOM yet — safe to ignore
+    }
+  }
+
+  function onPointerMove(event) {
+    if (!isDragging.value || !viewportRef.value) return
+    const delta = dragStartX.value - event.clientX
+    viewportRef.value.scrollLeft = dragStartScroll.value + delta
+  }
+
+  function endDrag(event) {
+    if (!isDragging.value) return
+    if (pointerId.value !== null && event?.currentTarget) {
+      try {
+        event.currentTarget.releasePointerCapture(pointerId.value)
+      } catch {
+        // releasePointerCapture can throw if capture was lost — safe to ignore
+      }
+    }
+    isDragging.value = false
+    pointerId.value = null
+    dragStartX.value = 0
+    dragStartScroll.value = 0
+  }
+
+  function onPointerUp(event) {
+    endDrag(event)
+  }
+
+  function onPointerLeave(event) {
+    if (isDragging.value) endDrag(event)
+  }
+
+  function onScroll() {
+    if (scrollFrame) return
+    scrollFrame = window.requestAnimationFrame(() => {
+      scrollFrame = null
+      const viewport = viewportRef.value
+      if (!viewport) return
+      updateScrollEdges()
+      const slide = viewport.firstElementChild
+      if (!slide) return
+      const slideTotal = slide.getBoundingClientRect().width + props.spaceBetween
+      if (slideTotal <= 0) return
+      const next = Math.round(viewport.scrollLeft / slideTotal)
+      if (next !== activeIndex.value) {
+        activeIndex.value = next
+        emit('slideChange', next)
+      }
+    })
+  }
+
+  function scrollToIndex(idx, behavior = 'smooth') {
+    if (!viewportRef.value) return
+    const target = viewportRef.value.children?.[idx]
+    if (!target) return
+    target.scrollIntoView({ behavior, inline: props.snapAlign, block: 'nearest' })
+  }
+
+  onMounted(() => {
+    if (props.initialIndex > 0 && props.initialIndex < props.slidesCount) {
+      // 'auto' = jump without animation; runs before paint so the user never
+      // sees the first slide flash before the carousel settles on the saved one.
+      scrollToIndex(props.initialIndex, 'auto')
+      activeIndex.value = props.initialIndex
+    }
+    updateScrollEdges()
+    onScroll()
+    if (typeof ResizeObserver !== 'undefined' && viewportRef.value) {
+      resizeObserver = new ResizeObserver(() => updateScrollEdges())
+      resizeObserver.observe(viewportRef.value)
+    } else {
+      window.addEventListener('resize', updateScrollEdges)
+    }
+  })
+
+  onBeforeUnmount(() => {
+    if (scrollFrame) {
+      window.cancelAnimationFrame(scrollFrame)
+      scrollFrame = null
+    }
+    if (resizeObserver) {
+      resizeObserver.disconnect()
+      resizeObserver = null
+    } else {
+      window.removeEventListener('resize', updateScrollEdges)
+    }
+  })
+
+  defineExpose({
+    scrollToIndex,
+    activeIndex
+  })
+</script>
+
+<style scoped>
+  .carousel {
+    position: relative;
+    width: 100%;
+  }
+
+  .carousel-viewport {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    overscroll-behavior-x: contain;
+    cursor: grab;
+    padding-bottom: 4px;
+    transition:
+      -webkit-mask-image 0.2s ease,
+      mask-image 0.2s ease;
+  }
+
+  .carousel-viewport.is-grabbing {
+    cursor: grabbing;
+    scroll-snap-type: none;
+  }
+
+  .carousel-viewport::-webkit-scrollbar {
+    display: none;
+  }
+
+  .carousel-slide:last-child {
+    margin-right: 0 !important;
+  }
+</style>

--- a/src/templates/signup-block/plan-selection-drawer.vue
+++ b/src/templates/signup-block/plan-selection-drawer.vue
@@ -27,7 +27,79 @@
         />
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
+      <div
+        v-if="isMobile"
+        class="plan-carousel-wrapper"
+      >
+        <Carousel
+          :slidesCount="planOptions.length"
+          :slidesPerView="1"
+          :spaceBetween="16"
+          :maxSlideWidth="360"
+          :initialIndex="initialCarouselIndex"
+          snapAlign="center"
+          ariaLabel="Plans"
+        >
+          <template
+            v-for="(planOption, idx) in planOptions"
+            #[`slide-${idx}`]
+            :key="planOption.value"
+          >
+            <CardPricing
+              :planTitle="planOption.label"
+              :description="planOption.description"
+              :pricingDetails="getPricingDetails(planOption.value)"
+              :showTag="Boolean(planOption.tagLabel)"
+              :tagLabel="planOption.tagLabel || 'Popular'"
+              :value="getCardValue(planOption.value)"
+              :prefix="getCardPrefix(planOption.value)"
+              :suffix="getCardSuffix(planOption.value)"
+              :showPrefix="isPricedPlan(planOption.value)"
+              :showSuffix="isPricedPlan(planOption.value)"
+              slotPosition="middle"
+              class="h-full"
+            >
+              <template #actions>
+                <ActionButton
+                  :label="planOption.buttonLabel"
+                  :kind="resolveButtonKind(planOption.value)"
+                  size="large"
+                  :loading="isLoadingPlan(planOption.value)"
+                  :disabled="isCurrentPlanSelection(planOption.value) || Boolean(props.loadingPlan)"
+                  class="w-full"
+                  @click="handleChoosePlan(planOption.value)"
+                />
+              </template>
+
+              <div class="flex flex-col gap-2">
+                <p
+                  v-if="planOption?.sectionTitle"
+                  class="text-xs leading-none text-[var(--text-muted)]"
+                >
+                  {{ planOption?.sectionTitle }}
+                </p>
+                <ul class="flex flex-col gap-2">
+                  <li
+                    v-for="feature in getIconFeatures(planOption)"
+                    :key="feature.title"
+                    class="flex items-center gap-2.5 text-xs leading-none text-color"
+                  >
+                    <span class="inline-flex items-center justify-center size-5 shrink-0">
+                      <i :class="[feature.icon, 'text-base text-color']" />
+                    </span>
+                    <span>{{ feature.title }}</span>
+                  </li>
+                </ul>
+              </div>
+            </CardPricing>
+          </template>
+        </Carousel>
+      </div>
+
+      <div
+        v-else
+        class="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch"
+      >
         <CardPricing
           v-for="planOption in planOptions"
           :key="planOption.value"
@@ -88,7 +160,9 @@
   import ActionButton from '@aziontech/webkit/button'
   import SegmentedButton from '@aziontech/webkit/segmented-button'
   import { usePlans } from '@/composables/usePlans'
+  import { useResize } from '@/composables/useResize'
   import { getComparisonInfo } from '@/views/Billing/plan-comparison-features'
+  import Carousel from '@/components/Carousel.vue'
 
   defineOptions({
     name: 'plan-selection-drawer'
@@ -142,7 +216,8 @@
   })
 
   const emit = defineEmits(['update:visible', 'select', 'billing-cycle-toggled'])
-  const { setParam } = usePlans()
+  const { setParam, plan: storedPlan } = usePlans()
+  const { isMobile } = useResize()
 
   const CYCLE_OPTIONS = [
     { label: 'Monthly', value: 'monthly' },
@@ -232,6 +307,18 @@
       ...option,
       buttonLabel: isCurrentPlanSelection(option.value) ? 'Selected Plan' : option.buttonLabel
     }))
+  })
+
+  // Mobile carousel opens on the plan the user previously chose (persisted in
+  // localStorage via usePlans) so a returning user is not always shown Hobby
+  // first. Falls back to the active subscription, then to the first option.
+  const initialCarouselIndex = computed(() => {
+    const preferred = storedPlan.value || props.currentPlan
+    if (!preferred) return 0
+    const idx = planOptions.value.findIndex(
+      (option) => option.value?.toLowerCase() === preferred.toLowerCase()
+    )
+    return idx >= 0 ? idx : 0
   })
 
   const getPlanData = (planValue) => {


### PR DESCRIPTION
## Summary

Replaces the stacked vertical layout of the plan selection cards on mobile with a horizontal swipeable carousel, while keeping the existing 3-column grid on desktop (`md+`).

The carousel is a local component (no external library) backed by **native CSS scroll-snap**. It opens on the plan the user previously chose (persisted in `localStorage` by `usePlans`), so returning users land on their last selection instead of always starting on Hobby.

## Root cause

On mobile, the change-plan drawer rendered all plan cards stacked vertically, forcing a long scroll just to compare options. There was no signal that more cards existed beyond the first one, and the experience felt cramped compared to the dedicated mobile carousel patterns used elsewhere in the product.

## Changes

- **New `src/components/Carousel.vue`** — generic, reusable, zero-dependency carousel
  - Horizontal scroll via native `overflow-x: auto` + `scroll-snap-type: x mandatory` (smooth, native momentum on iOS)
  - Mouse drag-to-scroll for desktop (Pointer Events with `setPointerCapture`); snap is temporarily disabled during drag and restored on release
  - **Dynamic edge fade mask** (`linear-gradient` via `mask-image`) — fade is applied only on the side where more content exists, so the first card is sharp on the left and the last card is sharp on the right
  - `slidesPerView`, `spaceBetween`, `maxSlideWidth`, `snapAlign` (`start`/`center`/`end`), `initialIndex`, `enableMouseDrag` props
  - Emits `slideChange` (computed from scroll position via `requestAnimationFrame`)
  - Exposes `scrollToIndex(idx, behavior)` for programmatic navigation
  - Scrollbar hidden cross-browser; ARIA roles (`region`, `tablist`-friendly), keyboard scroll inherited from native scroller
  - `ResizeObserver` recalculates scroll edges on viewport changes

- **`src/templates/signup-block/plan-selection-drawer.vue`**
  - On mobile (`isMobile` from `useResize`): renders the cards inside `<Carousel>` with `slidesPerView: 1`, `maxSlideWidth: 360`, `snapAlign: center`
  - On desktop: original `grid grid-cols-1 md:grid-cols-3` preserved
  - New computed `initialCarouselIndex`: priority is `storedPlan` (localStorage via `usePlans`) → `currentPlan` prop → first option

## Test plan

- [ ] Open the Change Plan drawer on mobile width (≤ 768px) — cards render as a horizontal carousel, not stacked vertically
- [ ] Swipe left/right on touch — snaps to next/previous card
- [ ] Drag horizontally with the mouse on desktop emulation — snaps on release
- [ ] First card: no fade on the left edge, fade visible on the right
- [ ] Last card: no fade on the right edge, fade visible on the left
- [ ] Middle card: fade visible on both edges
- [ ] Pre-set `plans:v1` in `localStorage` to `{ plan: 'pro' }`, reload, open drawer on mobile — carousel opens on the Pro card
- [ ] Without anything in `localStorage` but a Pro subscription active, open drawer in Billing context — carousel opens on Pro
- [ ] Without `localStorage` and Hobby subscription — carousel opens on Hobby (first card)
- [ ] Open drawer on desktop (>= 768px) — original 3-column grid unchanged
- [ ] Resize from desktop to mobile and back with drawer open — layout swaps cleanly