### PR TITLE
[NO-ISSUE] feat: default signup heading plan from localstorage

### DIFF
--- a/src/templates/signup-block/form-signup-block.vue
+++ b/src/templates/signup-block/form-signup-block.vue
@@ -78,21 +78,24 @@
   import Button from '@aziontech/webkit/button'
   import PrimeDivider from '@aziontech/webkit/divider'
   import LoginWithEmailBlock from '@/templates/signup-block/login-with-email-block'
+  import { usePlans } from '@/composables/usePlans'
   import { computed, ref } from 'vue'
-  import { useRoute, useRouter } from 'vue-router'
+  import { useRouter } from 'vue-router'
 
   const props = defineProps({
     signupService: { required: true, type: Function },
     resendEmailService: { required: true, type: Function }
   })
 
-  const route = useRoute()
   const router = useRouter()
+  const { plan, initialize: initializePlans } = usePlans()
+  initializePlans({ defaultPlan: 'hobby' })
+
   const showLoginFromEmail = ref(true)
   const showActivation = ref(true)
 
   const signupHeading = computed(() =>
-    route.query.plan === 'pro' ? 'Sign Up for the Pro Plan' : 'Sign Up for a Free Account'
+    plan.value === 'pro' ? 'Sign Up for the Pro Plan' : 'Sign Up for a Free Account'
   )
 
   const showActivationEmail = () => {


### PR DESCRIPTION
## Summary
- The `/signup` heading ("Sign Up for the Pro Plan" vs "Sign Up for a Free Account") was driven only by `route.query.plan`, so users coming back without the URL param lost their previous selection.
- It now reads from `usePlans`, which already implements the precedence URL → localStorage (client-scoped) → default `hobby`. The default falls back to `hobby` when neither URL nor storage has a plan.
- Aligns the first signup screen with the second step (`additional-data-form-block.vue`), which already used `usePlans`.

## Root cause
`form-signup-block.vue` computed the heading directly from `route.query.plan`, ignoring the `plans:v1` localStorage entry that `usePlans` persists across the onboarding flow.

## Changes
- `src/templates/signup-block/form-signup-block.vue`
  - Replaced `useRoute` with `usePlans`.
  - Initialize plans on mount with `defaultPlan: 'hobby'`.
  - `signupHeading` now reacts to `plan.value` instead of `route.query.plan`.

## Test plan
- [ ] Open `/signup` with no URL param and no stored plan → heading shows "Sign Up for a Free Account".
- [ ] Open `/signup?plan=pro` → heading shows "Sign Up for the Pro Plan".
- [ ] With `plan: 'pro'` in localStorage (`client:guest:plans:v1`) and no URL param → heading shows "Sign Up for the Pro Plan".
- [ ] With `plan: 'pro'` in localStorage and URL `?plan=hobby` → heading shows "Sign Up for a Free Account" (URL wins).
- [ ] After clearing localStorage and stripping the URL param → heading falls back to "Sign Up for a Free Account".