### PR TITLE
[NO-ISSUE] chore: tweak plan copy for monthly suffix and annual toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@analytics/segment": "^2.1.0",
     "@aziontech/icons": "^1.4.0",
     "@aziontech/theme": "^2.1.1",
-    "@aziontech/webkit": "^3.3.0",
+    "@aziontech/webkit": "^3.3.3",
     "@guolao/vue-monaco-editor": "^1.6.0",
     "@jsonforms/core": "3.7.0",
     "@jsonforms/vue": "3.7.0",

--- a/src/templates/checkout-block/billing-cycle-toggle.vue
+++ b/src/templates/checkout-block/billing-cycle-toggle.vue
@@ -30,7 +30,7 @@
 
   const CYCLE_OPTIONS = [
     { label: 'Monthly', value: 'monthly' },
-    { label: 'Yearly', value: 'yearly' }
+    { label: 'Annual', value: 'yearly' }
   ]
 
   const props = defineProps({

--- a/src/templates/checkout-block/pricing-summary.vue
+++ b/src/templates/checkout-block/pricing-summary.vue
@@ -32,7 +32,7 @@
             size="small"
             prefix="-$"
             :value="formattedYearlyDiscount"
-            suffix="per month"
+            suffix="/mo"
             :showSuffix="true"
           />
         </div>

--- a/src/templates/signup-block/plan-selection-drawer.vue
+++ b/src/templates/signup-block/plan-selection-drawer.vue
@@ -146,7 +146,7 @@
 
   const CYCLE_OPTIONS = [
     { label: 'Monthly', value: 'monthly' },
-    { label: 'Yearly', value: 'yearly' }
+    { label: 'Annual', value: 'yearly' }
   ]
 
   // In billing context, Pro users only have a meaningful single direction:
@@ -267,11 +267,11 @@
 
   const getCardPrefix = (planValue) => (isPricedPlan(planValue) ? '$' : '')
 
-  const getCardSuffix = (planValue) => (isPricedPlan(planValue) ? 'per month' : '')
+  const getCardSuffix = (planValue) => (isPricedPlan(planValue) ? '/mo' : '')
 
   const getPricingDetails = (planValue) => {
     if (isPricedPlan(planValue)) {
-      return localBillingCycle.value === 'yearly' ? 'Billed annually' : 'Billed monthly'
+      return localBillingCycle.value === 'yearly' ? 'Billed annually · Save 20%' : 'Billed monthly'
     }
     return getComparisonInfo(planValue)?.description ?? ''
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
   resolved "https://registry.yarnpkg.com/@aziontech/theme/-/theme-2.1.1.tgz#e0d99cd9fe51453e9e44caf8d392fb34a6640299"
   integrity sha512-d877nA5y9XJNY1MM4jEBWBhVAozcXtBEHBR3lFYpoq48jNER04Vyr6AjHUtXHAoiflSrk7QRchbF2hTFC5IguQ==
 
-"@aziontech/webkit@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@aziontech/webkit/-/webkit-3.3.0.tgz#c525988ce9cefdb2e4267d6107d69af03a53caae"
-  integrity sha512-6PyfFPB26QRjbkb1rIrk5BqHwl9Ao29hBIg8yZ+F+MDKhyuhJTXMGStsYa6S3IkpJVBtter3PaxH5G/lYWSX3w==
+"@aziontech/webkit@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@aziontech/webkit/-/webkit-3.3.3.tgz#6ac48ad206a6b47f1ff449ec65d9f2b763af2c89"
+  integrity sha512-NXu0VcGXG45EkfGF8bVR7Ardt0L9MTaXYMZCuwv+FThAL9VnrARdIoFQrgQA+C/1fAQmqPHuXoA3uQxdMva3rw==
   dependencies:
     "@vueuse/core" "^10.11.1"
     clsx "^2.1.1"


### PR DESCRIPTION
## Summary
- Tighten plan copy across the signup drawer and the checkout/payment-confirmation step.
- Bump `@aziontech/webkit` from `^3.3.0` to `^3.3.3` to pick up the latest design-system fixes used in these screens.
- Label-only copy changes; the underlying `value: 'yearly'` is unchanged, so `usePlans`, URL params, and persisted storage are not affected.

## Changes
- `src/templates/signup-block/plan-selection-drawer.vue`
  - Cycle toggle option label `Yearly` → `Annual`.
  - Card suffix for priced plans `per month` → `/mo`.
  - Pricing details for yearly cycle `Billed annually` → `Billed annually · Save 20%`.
- `src/templates/checkout-block/billing-cycle-toggle.vue`
  - Cycle toggle option label `Yearly` → `Annual` (payment-confirmation toggle).
- `src/templates/checkout-block/pricing-summary.vue`
  - Discount currency suffix `per month` → `/mo`.
- `package.json` / `yarn.lock`
  - Bump `@aziontech/webkit` `^3.3.0` → `^3.3.3`.

## Test plan
- [ ] Open the signup plan-selection drawer → cycle toggle shows `Monthly / Annual`; Pro card price renders as `$X/mo`; selecting `Annual` shows `Billed annually · Save 20%` (and `Billed monthly` when in Monthly).
- [ ] Reach the checkout/payment-confirmation step (signup → Pro) → cycle toggle shows `Monthly / Annual`; yearly discount line on the pricing summary renders with `-$X/mo`.
- [ ] Switching cycles still updates the prepared checkout session correctly (no contract change on `value: 'yearly'`).
- [ ] Smoke-test pages that consume `@aziontech/webkit` (signup drawer, checkout, billing) to confirm no regressions from the `^3.3.0` → `^3.3.3` bump.