### PR TITLE
fix: variable row editing and secret handling

### DIFF
--- a/src/components/list-table/ListTable.vue
+++ b/src/components/list-table/ListTable.vue
@@ -229,9 +229,32 @@
     return props.frozenColumns?.includes(field)
   }
 
+  function isInteractiveRowTarget(event) {
+    const target = event?.originalEvent?.target
+    const element = target instanceof Element ? target : target?.parentElement
+    if (!element) return false
+
+    return !!element.closest(
+      [
+        'button',
+        'a',
+        'input',
+        'select',
+        'textarea',
+        '[role="button"]',
+        '[data-testid="data-table-actions-column-body-actions"]',
+        '[data-testid="data-table-actions-column-body-action"]',
+        '.p-button',
+        '.p-menu',
+        '.disabled-click-row'
+      ].join(',')
+    )
+  }
+
   function handleRowClick(event) {
     if (props.disabledList) return
     if (!props.enableEditClick) return
+    if (isInteractiveRowTarget(event)) return
     if (props.frozenColumns?.length) return null
 
     return editItemSelected(event.originalEvent, event.data)

--- a/src/services/v2/variables/variables-adapter.js
+++ b/src/services/v2/variables/variables-adapter.js
@@ -6,11 +6,30 @@ const transformMap = {
   key: (value) => value.key,
   value: (value) => ({
     isSecret: value.secret,
-    content: value.value
+    content: value.secret ? (value.value ?? '********') : value.value
   }),
   lastEditor: (value) => value.last_editor,
   lastModified: (value) => formatDateToDayMonthYearHour(value.updated_at),
   lastModify: (value) => convertToRelativeTime(value.updated_at)
+}
+
+const transformItem = (data) => {
+  if (!data) return null
+  return adaptServiceDataResponse([data], null, transformMap)[0]
+}
+
+const transformFormItem = (data) => {
+  const variable = transformItem(data)
+  if (!variable) return null
+
+  const isSecret = variable.value?.isSecret ?? false
+
+  return {
+    id: variable.id,
+    key: variable.key,
+    value: isSecret ? '' : (variable.value?.content ?? variable.value),
+    secret: isSecret
+  }
 }
 
 export const VariablesAdapter = {
@@ -19,10 +38,9 @@ export const VariablesAdapter = {
     return adaptServiceDataResponse(data, null, transformMap)
   },
 
-  transformItem(data) {
-    if (!data) return null
-    return adaptServiceDataResponse([data], null, transformMap)[0]
-  },
+  transformItem,
+
+  transformFormItem,
 
   transformPayload(payload) {
     return {

--- a/src/services/v2/variables/variables-service.js
+++ b/src/services/v2/variables/variables-service.js
@@ -30,22 +30,6 @@ export class VariablesService extends BaseService {
     })
   }
 
-  getVariableFromCache = (id) => {
-    if (!id) return undefined
-
-    return super.getFromCache({
-      queryKey: queryKeys.variables.all,
-      id,
-      select: (item) => ({
-        id: item.id,
-        key: item.key,
-        value: item.value?.content ?? item.value,
-        secret: item.value?.isSecret ?? false
-      }),
-      listPath: 'body'
-    })
-  }
-
   load = async ({ id }) => {
     const { data } = await this.http.request({
       method: 'GET',
@@ -53,14 +37,7 @@ export class VariablesService extends BaseService {
       config: { baseURL: '/api' }
     })
 
-    const variable = VariablesAdapter.transformItem(data)
-
-    return {
-      id: variable.id,
-      key: variable.key,
-      value: variable.value?.content ?? variable.value,
-      secret: variable.value?.isSecret ?? false
-    }
+    return VariablesAdapter.transformFormItem(data)
   }
 
   create = async (payload) => {
@@ -73,14 +50,7 @@ export class VariablesService extends BaseService {
 
     this.queryClient.removeQueries({ queryKey: queryKeys.variables.all })
 
-    const variable = VariablesAdapter.transformItem(data)
-
-    return {
-      id: variable.id,
-      key: variable.key,
-      value: variable.value?.content ?? variable.value,
-      secret: variable.value?.isSecret ?? false
-    }
+    return VariablesAdapter.transformFormItem(data)
   }
 
   edit = async (payload) => {

--- a/src/tests/services/v2/variables/variables-adapter.test.js
+++ b/src/tests/services/v2/variables/variables-adapter.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { VariablesAdapter } from '@/services/v2/variables/variables-adapter'
+
+const secretVariable = {
+  uuid: 'secret-id',
+  key: 'SECRET_KEY',
+  value: '********',
+  secret: true,
+  last_editor: 'user@azion.com',
+  updated_at: '2026-06-01T12:00:00Z'
+}
+
+const regularVariable = {
+  uuid: 'regular-id',
+  key: 'REGULAR_KEY',
+  value: 'regular-value',
+  secret: false,
+  last_editor: 'user@azion.com',
+  updated_at: '2026-06-01T12:00:00Z'
+}
+
+describe('VariablesAdapter', () => {
+  it('keeps secret mask in list rows', () => {
+    const [result] = VariablesAdapter.transformList([secretVariable])
+
+    expect(result.value).toEqual({
+      isSecret: true,
+      content: '********'
+    })
+  })
+
+  it('uses a secret mask in list rows when API omits the secret value', () => {
+    const [result] = VariablesAdapter.transformList([{ ...secretVariable, value: undefined }])
+
+    expect(result.value).toEqual({
+      isSecret: true,
+      content: '********'
+    })
+  })
+
+  it('does not expose current secret value for edit forms', () => {
+    const result = VariablesAdapter.transformFormItem(secretVariable)
+
+    expect(result).toEqual({
+      id: 'secret-id',
+      key: 'SECRET_KEY',
+      value: '',
+      secret: true
+    })
+  })
+
+  it('returns regular variables with id and value for form flows', () => {
+    const result = VariablesAdapter.transformFormItem(regularVariable)
+
+    expect(result).toEqual({
+      id: 'regular-id',
+      key: 'REGULAR_KEY',
+      value: 'regular-value',
+      secret: false
+    })
+  })
+})

--- a/src/tests/views/variables-form-fields.test.js
+++ b/src/tests/views/variables-form-fields.test.js
@@ -1,0 +1,112 @@
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import FormFieldsVariables from '@/views/Variables/FormFields/FormFieldsVariables.vue'
+import { createFormHarness } from '@/tests/kit/vee-validate-setup'
+
+const FieldTextStub = defineComponent({
+  props: {
+    name: String,
+    disabled: Boolean,
+    placeholder: String,
+    description: String
+  },
+  template: `
+    <input
+      :data-testid="name"
+      :data-disabled="String(disabled)"
+      :placeholder="placeholder"
+      :data-description="description"
+    />
+  `
+})
+
+const FieldSwitchBlockStub = defineComponent({
+  props: {
+    name: String,
+    disabled: Boolean
+  },
+  template: '<button :data-testid="name" :data-disabled="String(disabled)" />'
+})
+
+const mountFormFields = ({ initialValues, secretChangeValueOnly, disabled = false }) => {
+  const FormHarness = createFormHarness({ initialValues })
+
+  return mount(FormHarness, {
+    slots: {
+      default: {
+        render: () =>
+          h(FormFieldsVariables, {
+            disabled,
+            secretChangeValueOnly
+          })
+      }
+    },
+    global: {
+      stubs: {
+        FormHorizontal: {
+          template: '<section><slot name="inputs" /></section>'
+        },
+        FieldText: FieldTextStub,
+        FieldSwitchBlock: FieldSwitchBlockStub,
+        InlineMessage: {
+          template: '<div><slot /></div>'
+        }
+      }
+    }
+  })
+}
+
+describe('FormFieldsVariables', () => {
+  it('locks key and secret fields when editing an existing secret', () => {
+    const wrapper = mountFormFields({
+      initialValues: { key: 'SECRET_KEY', value: '', secret: true },
+      secretChangeValueOnly: true
+    })
+
+    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
+      'true'
+    )
+    expect(
+      wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
+    ).toBe('true')
+    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')).toBe(
+      'NEW_SECRET_VALUE'
+    )
+  })
+
+  it('does not lock fields only because the current form value is secret', () => {
+    const wrapper = mountFormFields({
+      initialValues: { key: 'VARIABLE_KEY', value: 'value', secret: true },
+      secretChangeValueOnly: false
+    })
+
+    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
+      'false'
+    )
+    expect(
+      wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
+    ).toBe('false')
+    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')).toBe(
+      'VARIABLE_VALUE'
+    )
+  })
+
+  it('locks all fields while edit data is loading', () => {
+    const wrapper = mountFormFields({
+      initialValues: {},
+      disabled: true,
+      secretChangeValueOnly: false
+    })
+
+    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
+      'true'
+    )
+    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('data-disabled')).toBe(
+      'true'
+    )
+    expect(
+      wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
+    ).toBe('true')
+  })
+})

--- a/src/tests/views/variables-form-fields.test.js
+++ b/src/tests/views/variables-form-fields.test.js
@@ -64,15 +64,15 @@ describe('FormFieldsVariables', () => {
       secretChangeValueOnly: true
     })
 
-    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
-      'true'
-    )
+    expect(
+      wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')
+    ).toBe('true')
     expect(
       wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
     ).toBe('true')
-    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')).toBe(
-      'NEW_SECRET_VALUE'
-    )
+    expect(
+      wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')
+    ).toBe('NEW_SECRET_VALUE')
   })
 
   it('does not lock fields only because the current form value is secret', () => {
@@ -81,15 +81,15 @@ describe('FormFieldsVariables', () => {
       secretChangeValueOnly: false
     })
 
-    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
-      'false'
-    )
+    expect(
+      wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')
+    ).toBe('false')
     expect(
       wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
     ).toBe('false')
-    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')).toBe(
-      'VARIABLE_VALUE'
-    )
+    expect(
+      wrapper.get('[data-testid="variables-form__value-field"]').attributes('placeholder')
+    ).toBe('VARIABLE_VALUE')
   })
 
   it('locks all fields while edit data is loading', () => {
@@ -99,12 +99,12 @@ describe('FormFieldsVariables', () => {
       secretChangeValueOnly: false
     })
 
-    expect(wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')).toBe(
-      'true'
-    )
-    expect(wrapper.get('[data-testid="variables-form__value-field"]').attributes('data-disabled')).toBe(
-      'true'
-    )
+    expect(
+      wrapper.get('[data-testid="variables-form__key-field"]').attributes('data-disabled')
+    ).toBe('true')
+    expect(
+      wrapper.get('[data-testid="variables-form__value-field"]').attributes('data-disabled')
+    ).toBe('true')
     expect(
       wrapper.get('[data-testid="variables-form__secret-field"]').attributes('data-disabled')
     ).toBe('true')

--- a/src/views/Variables/CreateView.vue
+++ b/src/views/Variables/CreateView.vue
@@ -45,7 +45,7 @@
     toast.actions = {
       link: {
         label: 'View Variables',
-        callback: () => response.redirectToUrl(`/variables/edit/${response.uuid}`)
+        callback: () => response.redirectToUrl(`/variables/edit/${response.id}`)
       }
     }
     response.showToastWithActions(toast)

--- a/src/views/Variables/EditView.vue
+++ b/src/views/Variables/EditView.vue
@@ -16,11 +16,11 @@
   const route = useRoute()
   const breadcrumbs = useBreadcrumbs()
   const variableName = ref('Edit Variable')
-
-  const cachedVariable = variablesService.getVariableFromCache(route.params?.id) ?? {}
+  const isSecretChangeValueOnly = ref(false)
 
   const setVariableName = (variable) => {
     variableName.value = variable.key
+    isSecretChangeValueOnly.value = variable.secret === true
     breadcrumbs.update(route.meta.breadCrumbs ?? [], route, variable.key)
   }
 
@@ -66,14 +66,16 @@
         :editService="variablesService.edit"
         :loadService="variablesService.load"
         updatedRedirect="list-variables"
-        :initialValues="cachedVariable"
         :schema="validationSchema"
         @loaded-service-object="setVariableName"
         @on-edit-success="handleTrackEditEvent"
         @on-edit-fail="handleTrackFailEditEvent"
       >
-        <template #form>
-          <FormFieldsVariables />
+        <template #form="{ loading }">
+          <FormFieldsVariables
+            :disabled="loading"
+            :secretChangeValueOnly="isSecretChangeValueOnly"
+          />
         </template>
         <template #action-bar="{ onSubmit, onCancel, loading }">
           <ActionBarTemplate

--- a/src/views/Variables/FormFields/FormFieldsVariables.vue
+++ b/src/views/Variables/FormFields/FormFieldsVariables.vue
@@ -4,11 +4,30 @@
   import FieldText from '@aziontech/webkit/field-text'
   import InlineMessage from '@aziontech/webkit/inlinemessage'
 
+  import { computed } from 'vue'
   import { useField } from 'vee-validate'
+
   defineOptions({ name: 'form-fields-variables' })
+
+  const props = defineProps({
+    secretChangeValueOnly: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  })
 
   const { value: key } = useField('key')
   const { value: value } = useField('value')
+
+  const valueDescription = computed(() =>
+    props.secretChangeValueOnly
+      ? 'Enter a new value for this secret. The current secret value is not exposed.'
+      : 'Enter the data associated with the variable key.'
+  )
 </script>
 
 <template>
@@ -26,6 +45,7 @@
         description="Give a name or identifier for the variable. Accepts upper-case letters, numbers, and
         underscore."
         data-testid="variables-form__key-field"
+        :disabled="disabled || secretChangeValueOnly"
         sensitive
       />
 
@@ -33,10 +53,11 @@
         label="Value"
         required
         name="value"
-        placeholder="VARIABLE_VALUE"
+        :placeholder="secretChangeValueOnly ? 'NEW_SECRET_VALUE' : 'VARIABLE_VALUE'"
         :value="value"
-        description="Enter the data associated with the variable key."
+        :description="valueDescription"
         data-testid="variables-form__value-field"
+        :disabled="disabled"
         sensitive
       />
       <div class="flex flex-col sm:max-w-lg w-full gap-2">
@@ -47,6 +68,7 @@
             auto
             :isCard="false"
             title="Secret"
+            :disabled="disabled || secretChangeValueOnly"
             data-testid="variables-form__secret-field"
           />
         </div>

--- a/src/views/Variables/ListView.vue
+++ b/src/views/Variables/ListView.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { onBeforeRouteLeave, useRouter } from 'vue-router'
+  import { useRouter } from 'vue-router'
   import ContentBlock from '@/templates/content-block'
   import PageHeadingBlock from '@/templates/page-heading-block'
   import { columnBuilder } from '@/components/list-table/columns/column-builder'
@@ -15,7 +15,6 @@
   defineOptions({ name: 'variables-view' })
 
   const router = useRouter()
-  const enableRedirect = ref(true)
   const listTableRef = ref()
 
   const handleNavigateToCreate = () => {
@@ -74,20 +73,11 @@
     ]
   })
 
-  const checkIfIsEditable = (item) => {
+  const handleTrackEditEvent = () => {
     tracker.product.clickToEdit({
       productName: 'Variable'
     })
-    enableRedirect.value = !item.value.isSecret
   }
-
-  onBeforeRouteLeave((to, from, next) => {
-    if (enableRedirect.value) {
-      return next()
-    }
-    enableRedirect.value = true
-    return next(false)
-  })
 
   const handleTrackEvent = () => {
     tracker.product.clickToCreate({
@@ -119,7 +109,6 @@
         :listService="variablesService.list"
         :columns="getColumns"
         :actions="actions"
-        :frozenColumns="['key']"
         editPagePath="/variables/edit"
         exportFileName="Variables"
         :lazy="false"
@@ -132,7 +121,7 @@
           documentationService: documentationCatalog.variables
         }"
         @click-to-create="handleNavigateToCreate"
-        @on-before-go-to-edit="checkIfIsEditable"
+        @on-before-go-to-edit="handleTrackEditEvent"
         @on-before-go-to-add-page="handleTrackEvent"
       />
     </template>


### PR DESCRIPTION
## Summary
- Make variable rows open the edit screen correctly from the list, while keeping table actions from triggering navigation.
- Separate normal variable edits from secret-only value updates without exposing secret values from the API.
- Fix the create redirect to use the returned `id`.

## Testing
- Added unit tests for the variable adapter secret masking and form transformation.
- Added unit tests for the variables form fields locking behavior in secret and loading states.
- Ran the targeted unit test suite, and local build passed.