### PR TITLE
[NO-ISSUE] fix: exclude draft service order from onboarding gate

### DIFF
--- a/src/router/hooks/guards/accountGuard.js
+++ b/src/router/hooks/guards/accountGuard.js
@@ -3,7 +3,7 @@ import { setRedirectRoute } from '@/helpers'
 import { sessionManager } from '@/services/v2/base/auth'
 import { ensurePlansList } from '@/composables/usePlansService'
 import { ensureServiceOrdersList } from '@/composables/useServiceOrdersList'
-import { SO_TERMINAL_STATUSES } from '@/services/v2/service-orders/service-orders-constants'
+import { SO_ENTITLED_STATUSES } from '@/services/v2/service-orders/service-orders-constants'
 
 /** @type {import('vue-router').NavigationGuardWithThis} */
 export async function accountGuard({ to, accountStore, tracker }) {
@@ -27,8 +27,8 @@ export async function accountGuard({ to, accountStore, tracker }) {
       const accountId = accountStore.accountData?.id
       const serviceOrdersResponse = await ensureServiceOrdersList(accountId).catch(() => null)
       const serviceOrders = serviceOrdersResponse?.data ?? []
-      const hasActivePlan = serviceOrders.some(
-        (so) => so.status && !SO_TERMINAL_STATUSES.includes(so.status)
+      const hasActivePlan = serviceOrders.some((so) =>
+        SO_ENTITLED_STATUSES.includes(so.status)
       )
       accountStore.setHasActivePlan(hasActivePlan)
 

--- a/src/tests/router/hooks/guards/account-guard.test.js
+++ b/src/tests/router/hooks/guards/account-guard.test.js
@@ -25,7 +25,7 @@ vi.mock('@/composables/useServiceOrdersList', () => ({
 }))
 
 vi.mock('@/services/v2/service-orders/service-orders-constants', () => ({
-  SO_TERMINAL_STATUSES: ['CANCELED', 'EXPIRED']
+  SO_ENTITLED_STATUSES: ['ACTIVE', 'PAST_DUE', 'BLOCKED']
 }))
 
 describe('accountGuard hasSession check', () => {
@@ -186,5 +186,72 @@ describe('accountGuard onboarding prefetch', () => {
     })
 
     expect(result).toEqual({ name: 'additional-data' })
+  })
+})
+
+describe('accountGuard hasActivePlan derivation', () => {
+  beforeEach(async () => {
+    const { loadAccountHydration } = await import('@/helpers/account-data')
+    const { ensureServiceOrdersList } = await import('@/composables/useServiceOrdersList')
+    loadAccountHydration.mockReset()
+    loadAccountHydration.mockResolvedValue(undefined)
+    ensureServiceOrdersList.mockReset()
+  })
+
+  const runGuard = async (orders, setHasActivePlan) => {
+    const { ensureServiceOrdersList } = await import('@/composables/useServiceOrdersList')
+    ensureServiceOrdersList.mockResolvedValueOnce({ data: orders })
+
+    await accountGuard({
+      to: { meta: { isPublic: false }, name: 'home', fullPath: '/' },
+      accountStore: {
+        hasActiveUserId: false,
+        hasSession: true,
+        needsOnboarding: false,
+        accountData: { id: 1 },
+        setHasActivePlan
+      },
+      tracker: { reset: vi.fn() }
+    })
+  }
+
+  it('treats DRAFT-only as no active plan so onboarding still triggers', async () => {
+    const setHasActivePlan = vi.fn()
+    await runGuard([{ status: 'DRAFT' }], setHasActivePlan)
+    expect(setHasActivePlan).toHaveBeenCalledWith(false)
+  })
+
+  it('treats ACTIVE as active plan', async () => {
+    const setHasActivePlan = vi.fn()
+    await runGuard([{ status: 'ACTIVE' }], setHasActivePlan)
+    expect(setHasActivePlan).toHaveBeenCalledWith(true)
+  })
+
+  it('treats PAST_DUE and BLOCKED as active plan (still entitled)', async () => {
+    const setHasActivePlanPastDue = vi.fn()
+    await runGuard([{ status: 'PAST_DUE' }], setHasActivePlanPastDue)
+    expect(setHasActivePlanPastDue).toHaveBeenCalledWith(true)
+
+    const setHasActivePlanBlocked = vi.fn()
+    await runGuard([{ status: 'BLOCKED' }], setHasActivePlanBlocked)
+    expect(setHasActivePlanBlocked).toHaveBeenCalledWith(true)
+  })
+
+  it('treats CANCELED and EXPIRED as no active plan', async () => {
+    const setHasActivePlan = vi.fn()
+    await runGuard([{ status: 'CANCELED' }, { status: 'EXPIRED' }], setHasActivePlan)
+    expect(setHasActivePlan).toHaveBeenCalledWith(false)
+  })
+
+  it('treats DRAFT + CANCELED as no active plan', async () => {
+    const setHasActivePlan = vi.fn()
+    await runGuard([{ status: 'DRAFT' }, { status: 'CANCELED' }], setHasActivePlan)
+    expect(setHasActivePlan).toHaveBeenCalledWith(false)
+  })
+
+  it('treats DRAFT + ACTIVE as active plan (ACTIVE wins)', async () => {
+    const setHasActivePlan = vi.fn()
+    await runGuard([{ status: 'DRAFT' }, { status: 'ACTIVE' }], setHasActivePlan)
+    expect(setHasActivePlan).toHaveBeenCalledWith(true)
   })
 })


### PR DESCRIPTION
## Summary
- Onboarding gate em `accountGuard` estava aceitando qualquer SO não-terminal como "tem plano", incluindo **DRAFT** — usuário com checkout incompleto pulava o onboarding indevidamente.
- Troca o filtro de `!SO_TERMINAL_STATUSES.includes(status)` (DRAFT/ACTIVE/PAST_DUE/BLOCKED) por `SO_ENTITLED_STATUSES.includes(status)` (apenas ACTIVE/PAST_DUE/BLOCKED).

## Root cause
[src/router/hooks/guards/accountGuard.js](src/router/hooks/guards/accountGuard.js) usava a negação de `SO_TERMINAL_STATUSES` para identificar SO ativa. Como DRAFT também é não-terminal, qualquer usuário com `first_login=true` + SO em DRAFT (checkout pendente) era marcado com `hasActivePlan=true` e o `needsOnboarding` retornava `false`, redirecionando para `/home` ao invés de `/signup/additional-data`.

## Changes
- `src/router/hooks/guards/accountGuard.js` — usa `SO_ENTITLED_STATUSES` em vez de negar `SO_TERMINAL_STATUSES`.
- `src/tests/router/hooks/guards/account-guard.test.js` — atualiza mock dos constants e adiciona 6 casos cobrindo: DRAFT-only (false), ACTIVE (true), PAST_DUE/BLOCKED (true), CANCELED/EXPIRED (false), DRAFT+CANCELED (false), DRAFT+ACTIVE (true).

## Test plan
- [x] `yarn test:unit:headless --run src/tests/router/hooks/guards/account-guard.test.js` → 14/14 passing
- [ ] Manual: usuário com `first_login=true` e SO em DRAFT (checkout interrompido) ao acessar `/` é redirecionado para `/signup/additional-data`
- [ ] Manual: usuário com `first_login=true` e SO em ACTIVE (Hobby completou onboarding) ao acessar `/` permanece em `/home`
- [ ] Manual: usuário com `first_login=false` mantém comportamento atual independente do status do SO