### PR TITLE
perf: remove Roboto/Proto font-family preloads, disabled teste:unit in the local commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,3 @@
 
 yarn lint
 yarn format
-yarn test:unit:coverage

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       type="font/ttf"
       crossorigin
     />
+    <!--
     <link
       rel="preload"
       href="https://fonts.azion.com/proto-mono/ProtoMono-Regular.ttf"
@@ -34,20 +35,7 @@
       type="font/ttf"
       crossorigin
     />
-    <link
-      rel="preload"
-      href="https://fonts.azion.com/roboto/roboto-regular.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="https://fonts.azion.com/roboto/roboto-medium.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
+    -->
   </head>
   <body class="min-w-[360px]">
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
     />
     <title>Azion Console</title>
 
-    <!-- Font preloads -->
     <link
       rel="preload"
       href="https://fonts.azion.com/sora/Sora-VariableFont_wght.ttf"
@@ -27,15 +26,6 @@
       type="font/ttf"
       crossorigin
     />
-    <!--
-    <link
-      rel="preload"
-      href="https://fonts.azion.com/proto-mono/ProtoMono-Regular.ttf"
-      as="font"
-      type="font/ttf"
-      crossorigin
-    />
-    -->
   </head>
   <body class="min-w-[360px]">
     <div id="app"></div>


### PR DESCRIPTION
## Summary
- remove Roboto font family pre-load
- remove Proto font family pre-loadd (it is secondary font)
- remove test:unit:coverage from commit