### PR TITLE
[NO-ISSUE] perf: gate prefetch by route and make scheduler non-blocking

### DIFF
--- a/azion/production/azion.json
+++ b/azion/production/azion.json
@@ -88,6 +88,16 @@
       "origin-id": 249764,
       "origin-key": "6ac11a1c-cd32-4702-b610-af5e09b7af11",
       "name": "origin-help-center"
+    },
+    {
+      "origin-id": 262195,
+      "origin-key": "dbbccbca-fffe-4ee4-a22e-cef7e73d2dfd",
+      "name": "origin-edge-api"
+    },
+    {
+      "origin-id": 257880,
+      "origin-key": "efea9f31-424a-4c14-b868-3b99a961f154",
+      "name": "console-to-beholder"
     }
   ],
   "rules-engine": {
@@ -222,6 +232,21 @@
         "id": 500742,
         "name": "Set Origin for Help Center",
         "phase": "request"
+      },
+      {
+        "id": 570856,
+        "name": "Route Edge API Requests",
+        "phase": "request"
+      },
+      {
+        "id": 537351,
+        "name": "Run Function SSE - to - SSE Beholder Proxy |",
+        "phase": "request"
+      },
+      {
+        "id": 498020,
+        "name": "Debug",
+        "phase": "response"
       }
     ]
   },

--- a/src/router/hooks/afterEachRoute.js
+++ b/src/router/hooks/afterEachRoute.js
@@ -30,8 +30,10 @@ export default function afterEachRoute(to, from, failure) {
     .catch(Sentry.captureException)
 
   const isOnboardingStep = to.name === 'additional-data'
+  const isPublicRoute = to.meta?.isPublic === true
+  const shouldSkipPrefetch = isOnboardingStep || isPublicRoute
 
-  if (!isOnboardingStep) {
+  if (!shouldSkipPrefetch) {
     sessionManager.afterLogin()
   }
 }

--- a/src/router/hooks/guards/accountGuard.js
+++ b/src/router/hooks/guards/accountGuard.js
@@ -22,7 +22,6 @@ export async function accountGuard({ to, accountStore, tracker }) {
       // by the time the redirect decision below executes. Without this, the
       // guard would race the contract/billing fetches.
       await loadAccountHydration()
-      sessionManager.afterLogin()
 
       const accountId = accountStore.accountData?.id
       const serviceOrdersResponse = await ensureServiceOrdersList(accountId).catch(() => null)

--- a/src/services/v2/base/query/prefetchScheduler.js
+++ b/src/services/v2/base/query/prefetchScheduler.js
@@ -1,14 +1,74 @@
+const DEFAULT_BATCH_SIZE = 3
+const LOW_MEMORY_BATCH_SIZE = 1
+const LOW_MEMORY_THRESHOLD_GB = 4
+const IDLE_CALLBACK_TIMEOUT_MS = 5000
+const IDLE_FALLBACK_DELAY_MS = 2000
+const YIELD_TO_MAIN_DELAY_MS = 0
+
+const SLOW_CONNECTION_TYPES = ['slow-2g', '2g']
+
+const LOAD_EVENT = 'load'
+const VISIBILITY_CHANGE_EVENT = 'visibilitychange'
+const DOCUMENT_READY_COMPLETE = 'complete'
+
+const isBrowser = () => typeof window !== 'undefined'
+const isDocumentAvailable = () => typeof document !== 'undefined'
+const isNavigatorAvailable = () => typeof navigator !== 'undefined'
+
+const isDocumentReady = () => document.readyState === DOCUMENT_READY_COMPLETE
+
+const waitForLoad = () =>
+  new Promise((resolve) => {
+    if (!isDocumentAvailable() || isDocumentReady()) {
+      return resolve()
+    }
+    window.addEventListener(LOAD_EVENT, () => resolve(), { once: true })
+  })
+
+const waitForVisible = () =>
+  new Promise((resolve) => {
+    if (!isDocumentAvailable() || !document.hidden) {
+      return resolve()
+    }
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        document.removeEventListener(VISIBILITY_CHANGE_EVENT, onVisibilityChange)
+        resolve()
+      }
+    }
+    document.addEventListener(VISIBILITY_CHANGE_EVENT, onVisibilityChange)
+  })
+
+const supportsIdleCallback = () => isBrowser() && 'requestIdleCallback' in window
+
 const scheduleIdleTask = (callback) => {
-  if ('requestIdleCallback' in window) {
-    requestIdleCallback(callback)
+  if (!isBrowser()) return
+  if (supportsIdleCallback()) {
+    window.requestIdleCallback(callback, { timeout: IDLE_CALLBACK_TIMEOUT_MS })
   } else {
-    setTimeout(callback, 1)
+    setTimeout(callback, IDLE_FALLBACK_DELAY_MS)
   }
 }
 
-const yieldToMain = () => new Promise((resolve) => setTimeout(resolve, 0))
+const isSlowConnection = (connection) =>
+  Boolean(connection?.saveData) || SLOW_CONNECTION_TYPES.includes(connection?.effectiveType)
 
-const runInBatches = async (tasks, batchSize = 5) => {
+const shouldSkip = () => {
+  if (!isNavigatorAvailable()) return false
+  return isSlowConnection(navigator.connection)
+}
+
+const isLowMemoryDevice = () => {
+  if (!isNavigatorAvailable()) return false
+  const memory = navigator.deviceMemory
+  return Boolean(memory) && memory < LOW_MEMORY_THRESHOLD_GB
+}
+
+const pickBatchSize = (requested) => (isLowMemoryDevice() ? LOW_MEMORY_BATCH_SIZE : requested)
+
+const yieldToMain = () => new Promise((resolve) => setTimeout(resolve, YIELD_TO_MAIN_DELAY_MS))
+
+const runInBatches = async (tasks, batchSize) => {
   const pending = [...tasks]
 
   while (pending.length) {
@@ -21,6 +81,11 @@ const runInBatches = async (tasks, batchSize = 5) => {
   }
 }
 
-export const schedulePrefetch = (tasks, batchSize = 5) => {
-  scheduleIdleTask(() => runInBatches(tasks, batchSize))
+export const schedulePrefetch = async (tasks, batchSize = DEFAULT_BATCH_SIZE) => {
+  if (!tasks?.length || shouldSkip()) return
+
+  await waitForLoad()
+  await waitForVisible()
+
+  scheduleIdleTask(() => runInBatches(tasks, pickBatchSize(batchSize)))
 }

--- a/src/tests/router/hooks/after-each-route.test.js
+++ b/src/tests/router/hooks/after-each-route.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn()
+}))
+
+vi.mock('@/services/v2/base/auth', () => ({
+  sessionManager: {
+    afterLogin: vi.fn()
+  }
+}))
+
+vi.mock('@/stores/loading', () => ({
+  useLoadingStore: () => ({ finishLoading: vi.fn() })
+}))
+
+vi.mock('@/stores/account', () => ({
+  useAccountStore: vi.fn()
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return { ...actual, inject: vi.fn() }
+})
+
+const buildTracker = () => {
+  const pageTrack = vi.fn()
+  return {
+    tracker: {
+      product: { pageLoad: vi.fn(() => ({ track: pageTrack })) },
+      identify: vi.fn(),
+      page: vi.fn().mockResolvedValue(undefined)
+    },
+    pageTrack
+  }
+}
+
+describe('afterEachRoute prefetch gate', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    const { sessionManager } = await import('@/services/v2/base/auth')
+    const { useAccountStore } = await import('@/stores/account')
+    const { inject } = await import('vue')
+
+    sessionManager.afterLogin.mockClear()
+    useAccountStore.mockReturnValue({ hasActiveUserId: true, userId: 'user-1' })
+    inject.mockReturnValue(buildTracker().tracker)
+  })
+
+  it('skips afterLogin on the additional-data onboarding step', async () => {
+    const { default: afterEachRoute } = await import('@/router/hooks/afterEachRoute')
+    const { sessionManager } = await import('@/services/v2/base/auth')
+
+    afterEachRoute(
+      { name: 'additional-data', fullPath: '/signup/additional-data', meta: { isPublic: true } },
+      {},
+      null
+    )
+
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
+  })
+
+  it('skips afterLogin on public routes (signup, login, etc.)', async () => {
+    const { default: afterEachRoute } = await import('@/router/hooks/afterEachRoute')
+    const { sessionManager } = await import('@/services/v2/base/auth')
+
+    afterEachRoute(
+      { name: 'signup', fullPath: '/signup', meta: { isPublic: true } },
+      {},
+      null
+    )
+
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
+  })
+
+  it('calls afterLogin on private internal routes (e.g. home)', async () => {
+    const { default: afterEachRoute } = await import('@/router/hooks/afterEachRoute')
+    const { sessionManager } = await import('@/services/v2/base/auth')
+
+    afterEachRoute({ name: 'home', fullPath: '/', meta: { isPublic: false } }, {}, null)
+
+    expect(sessionManager.afterLogin).toHaveBeenCalledOnce()
+  })
+
+  it('does not call afterLogin when user is not logged in', async () => {
+    const { default: afterEachRoute } = await import('@/router/hooks/afterEachRoute')
+    const { sessionManager } = await import('@/services/v2/base/auth')
+    const { useAccountStore } = await import('@/stores/account')
+    useAccountStore.mockReturnValue({ hasActiveUserId: false, userId: null })
+
+    afterEachRoute({ name: 'home', fullPath: '/', meta: { isPublic: false } }, {}, null)
+
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/router/hooks/guards/account-guard.test.js
+++ b/src/tests/router/hooks/guards/account-guard.test.js
@@ -31,6 +31,7 @@ vi.mock('@/services/v2/service-orders/service-orders-constants', () => ({
 describe('accountGuard hasSession check', () => {
   it('should redirect to login without calling API when hasSession=false', async () => {
     const { loadAccountHydration } = await import('@/helpers/account-data')
+    const { sessionManager } = await import('@/services/v2/base/auth')
 
     const result = await accountGuard({
       to: { meta: { isPublic: false }, fullPath: '/products' },
@@ -39,12 +40,15 @@ describe('accountGuard hasSession check', () => {
     })
 
     expect(loadAccountHydration).not.toHaveBeenCalled()
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
     expect(result).toBe('/login')
   })
 
   it('should attempt session restore when hasSession=true', async () => {
     const { loadAccountHydration } = await import('@/helpers/account-data')
+    const { sessionManager } = await import('@/services/v2/base/auth')
     loadAccountHydration.mockResolvedValue(undefined)
+    sessionManager.afterLogin.mockClear()
 
     const result = await accountGuard({
       to: { meta: { isPublic: false }, fullPath: '/products' },
@@ -59,6 +63,7 @@ describe('accountGuard hasSession check', () => {
     })
 
     expect(loadAccountHydration).toHaveBeenCalled()
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
     expect(result).toBeUndefined()
   })
 
@@ -104,8 +109,10 @@ describe('accountGuard onboarding prefetch', () => {
   it('prefetches plans when redirecting to additional-data (needsOnboarding=true)', async () => {
     const { loadAccountHydration } = await import('@/helpers/account-data')
     const { ensurePlansList } = await import('@/composables/usePlansService')
+    const { sessionManager } = await import('@/services/v2/base/auth')
     loadAccountHydration.mockResolvedValue(undefined)
     ensurePlansList.mockClear()
+    sessionManager.afterLogin.mockClear()
 
     const result = await accountGuard({
       to: { meta: { isPublic: false }, name: 'home', fullPath: '/' },
@@ -120,6 +127,7 @@ describe('accountGuard onboarding prefetch', () => {
     })
 
     expect(ensurePlansList).toHaveBeenCalledOnce()
+    expect(sessionManager.afterLogin).not.toHaveBeenCalled()
     expect(result).toEqual({ name: 'additional-data' })
   })
 


### PR DESCRIPTION
## Summary

- Move o gate de prefetch para ser disparado apenas a partir do `afterEachRoute`, que agora pula tanto `/additional-data` quanto rotas públicas (`meta.isPublic`). Remove a chamada prematura de `sessionManager.afterLogin()` no `accountGuard`, que disparava o prefetch + a conexão SSE antes mesmo da decisão de redirect.
- Reescreve o `prefetchScheduler` para não travar a UI: aguarda `window.load` + visibilidade da aba, usa `requestIdleCallback` com `timeout: 5000`, cai para `setTimeout(2000ms)` em Safari, batches default de 3, aborta em `saveData`/`slow-2g`/`2g` e força `batchSize=1` em `deviceMemory < 4`.

## Root cause

`sessionManager.afterLogin()` (que dispara o prefetch de ~22 services + abre o SSE) era chamado **dentro do `accountGuard`** logo após `loadAccountHydration`, antes da decisão de redirect para `/additional-data`. A flag `hasPrefetched` no `sessionManager` tornava a 2ª chamada (no `afterEachRoute`, que já tinha lógica para pular onboarding) um no-op, então o gate existente nunca surtia efeito. Durante o onboarding, 22 requisições disparavam em paralelo competindo com o formulário de pagamento.

Além disso, o scheduler usava `setTimeout(cb, 1)` como fallback em Safari (efetivamente síncrono), não esperava o `load` event e não respeitava preferências de rede/dispositivo do usuário.

## Changes

- `src/router/hooks/guards/accountGuard.js` — remove `sessionManager.afterLogin()` da linha 25
- `src/router/hooks/afterEachRoute.js` — estende gate para `to.meta.isPublic`
- `src/services/v2/base/query/prefetchScheduler.js` — reescrito com `waitForLoad`, `waitForVisible`, heurísticas de `navigator.connection` e `navigator.deviceMemory`, constantes nomeadas
- `src/tests/router/hooks/guards/account-guard.test.js` — assert que `afterLogin` nunca é chamado pelo guard
- `src/tests/router/hooks/after-each-route.test.js` — novo arquivo cobrindo gate: público / `additional-data` / privada normal / sem login
- `azion/production/azion.json` — production origins + rules

## Test plan

- [ ] `yarn test:unit:headless --run src/tests/router/hooks/guards/account-guard.test.js src/tests/router/hooks/after-each-route.test.js` passa (18/18)
- [ ] Login com `needsOnboarding=true` → redirect para `/additional-data`. Confirmar na aba **Network** do DevTools que **não há** requests para `edge-applications`, `workloads`, etc., nem conexão `EventSource /sse`
- [ ] Concluir onboarding → ao chegar em `/home`, o prefetch das listas dispara após `window.load`, em batches de 3, e o SSE conecta
- [ ] Login direto em rota privada (e.g. `/edge-applications`) sem onboarding → prefetch e SSE disparam após chegar na rota
- [ ] DevTools → Network conditions com `Slow 3G` + `Save-Data` ativado → nenhum request de prefetch é feito
- [ ] Aba em background no momento do login → prefetch só dispara quando a aba volta ao foco
- [ ] Safari (sem `requestIdleCallback`) → fallback de 2s não trava UI no login