### PR TITLE
feat: submit HubSpot sign-up after additional-data is persisted

### DIFF
--- a/src/router/routes/signup-routes/index.js
+++ b/src/router/routes/signup-routes/index.js
@@ -1,9 +1,6 @@
 import * as SignupService from '@/services/signup-services'
-import { inject } from 'vue'
 import { useAccountStore } from '@/stores/account'
 import SignupView from '@/views/Signup/SignupView.vue'
-import { getFirstSessionUrl } from '@/helpers/first-session-url'
-import { trackSignUpSafely } from '@/helpers/track-auth-event'
 
 /** @type {import('vue-router').RouteRecordRaw} */
 export const signupRoutes = {
@@ -36,22 +33,6 @@ export const signupRoutes = {
         const accountStore = useAccountStore()
 
         if (accountStore.hasActiveUserId && accountStore.needsOnboarding) {
-          const signupTypeFlags = accountStore.getSignupTypeFlags()
-          const ssoMethod = accountStore.ssoSignUpMethod
-          const isEmailSignup = signupTypeFlags.signup_email
-
-          if (ssoMethod || isEmailSignup) {
-            /** @type {import('@/plugins/analytics/AnalyticsTrackerAdapter').AnalyticsTrackerAdapter} */
-            const tracker = inject('tracker')
-
-            trackSignUpSafely({
-              tracker,
-              method: ssoMethod || 'email',
-              signupTypeFlags,
-              firstSessionUrl: getFirstSessionUrl()
-            })
-          }
-
           next()
         } else {
           next({ name: 'home' })

--- a/src/views/Signup/AdditionalDataView.vue
+++ b/src/views/Signup/AdditionalDataView.vue
@@ -115,6 +115,8 @@
   import { loadUserAndAccountInfo } from '@/helpers/account-data'
   import { useWarmStripe } from '@/composables/useWarmStripe'
   import { persistOnboardingData } from '@/helpers/persist-onboarding-data'
+  import { trackSignUpSafely } from '@/helpers/track-auth-event'
+  import { getFirstSessionUrl } from '@/helpers/first-session-url'
   import { queryClient } from '@/services/v2/base/query/queryClient'
   import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
@@ -125,6 +127,18 @@
     Promise.resolve()
       .then(() => tracker?.signUp?.[method]?.(payload)?.track?.())
       .catch(Sentry.captureException)
+  }
+  // Submit the sign-up to HubSpot once the additional-data has been persisted,
+  // mirroring the login flow (see trackSignInSafely in sign-in-block). Reads the
+  // freshly loaded account data from the store, so call it after
+  // loadUserAndAccountInfo.
+  const trackSignUpToHubspot = () => {
+    trackSignUpSafely({
+      tracker,
+      method: accountStore.ssoSignUpMethod || 'email',
+      signupTypeFlags: accountStore.getSignupTypeFlags(),
+      firstSessionUrl: getFirstSessionUrl()
+    })
   }
   const { clear: clearAdditionalDataFormState } = useAdditionalDataFormState()
   const { warmStripe } = useWarmStripe()
@@ -423,6 +437,7 @@
 
         invalidateBillingCaches()
         await loadUserAndAccountInfo({ force: true })
+        trackSignUpToHubspot()
         handleProceedToCheckout()
       } catch (err) {
         // eslint-disable-next-line no-console
@@ -492,6 +507,7 @@
       await persistOnboardingData({ plan: selectedPlan.value })
       invalidateBillingCaches()
       await loadUserAndAccountInfo({ force: true })
+      trackSignUpToHubspot()
     } catch (err) {
       Sentry.captureException(err)
     }


### PR DESCRIPTION
## Descrição

Move o request de sign-up do HubSpot do guard de rota (`beforeEnter`) da
additional-data para o `AdditionalDataView`, fazendo-o disparar **após o submit
dos dados**, seguindo o mesmo padrão já usado no login (`trackSignInSafely`).

### Contexto
Antes, o `trackSignUpSafely` (que internamente chama `hubspotService.submitForm`)
era disparado na **entrada** da rota `additional-data` — ou seja, antes do usuário
preencher e enviar o formulário. Isso enviava o lead ao HubSpot sem os dados
preenchidos e em um momento incorreto do fluxo.

### Mudanças
- **`src/router/routes/signup-routes/index.js`**: remove o `trackSignUpSafely` do
  `beforeEnter` e os imports não utilizados (`inject`, `getFirstSessionUrl`,
  `trackSignUpSafely`). A lógica de navegação do guard permanece idêntica.
- **`src/views/Signup/AdditionalDataView.vue`**: adiciona o helper
  `trackSignUpToHubspot()`, chamado **após** `loadUserAndAccountInfo({ force: true })`
  nos dois pontos em que os dados são persistidos:
  - Plano **hobby** → em `onSubmit`, após `persistOnboardingData`.
  - Plano **pro** → em `handleCheckoutSuccess`, após o pagamento confirmar.

### Resultado
- O request ao HubSpot ocorre uma única vez por usuário, sempre depois que os
  dados do formulário foram persistidos (garantindo `firstname`/`lastname`/`company`
  atualizados no payload).
- Sem disparo duplicado.
- Move o `inject('tracker')` para o `setup()` do componente, onde o `inject`
  funciona de forma garantida (antes estava num guard de rota, o que é frágil).
