### PR TITLE
fix: prevent infinite height growth on data set Monaco editor

### DIFF
--- a/src/views/DataStream/FormFields/blocks/RenderTemplateSection.vue
+++ b/src/views/DataStream/FormFields/blocks/RenderTemplateSection.vue
@@ -54,7 +54,8 @@
           language="json"
           :theme="theme"
           :options="dataSetMonacoOptions"
-          class="min-h-[300px] surface-border border rounded-sm overflow-hidden"
+          height="300px"
+          class="surface-border border rounded-sm overflow-hidden"
           data-testid="data-stream-form__data-settings__data-set-field"
         />
         <Button

--- a/src/views/DataStream/FormFields/blocks/RenderTemplateSection.vue
+++ b/src/views/DataStream/FormFields/blocks/RenderTemplateSection.vue
@@ -58,24 +58,26 @@
           class="surface-border border rounded-sm overflow-hidden"
           data-testid="data-stream-form__data-settings__data-set-field"
         />
-        <Button
-          kind="outlined"
-          v-if="isCustomTemplate"
-          icon="pi pi-pencil"
-          label="Edit Template"
-          size="small"
-          @click="openEditTemplateDrawer"
-          class="absolute top-10 right-2 bg-[#171717]"
-        />
-        <Button
-          kind="outlined"
-          v-else
-          icon="pi pi-copy"
-          label="Duplicate Template"
-          size="small"
-          @click="openDuplicateTemplateDrawer"
-          class="absolute top-10 right-2 bg-[#171717]"
-        />
+        <div class="absolute top-10 right-2">
+          <Button
+            kind="outlined"
+            v-if="isCustomTemplate"
+            icon="pi pi-pencil"
+            label="Edit Template"
+            size="small"
+            @click="openEditTemplateDrawer"
+            class="bg-[#171717]"
+          />
+          <Button
+            kind="outlined"
+            v-else
+            icon="pi pi-copy"
+            label="Duplicate Template"
+            size="small"
+            @click="openDuplicateTemplateDrawer"
+            class="bg-[#171717]"
+          />
+        </div>
         <small
           class="text-xs text-color-secondary font-normal leading-5"
           data-testid="data-stream-form__data-settings__data-set-description"


### PR DESCRIPTION
## Bug fix

### What was the problem?

No formulário de criação/edição de Data Stream, o `vue-monaco-editor` da seção **Render Template > Data Set** (`src/views/DataStream/FormFields/blocks/RenderTemplateSection.vue`) crescia indefinidamente em altura, quebrando o layout do formulário.

### Expected behavior

O editor Monaco deve manter uma altura fixa de 300px, independentemente do conteúdo do Data Set.

### How was it solved

Causa raiz: o `@guolao/vue-monaco-editor` define internamente o wrapper com `height: "100%"` e força `automaticLayout: true`. Dentro do pai `flex flex-col` sem altura fixa, o `min-h-[300px]` do Tailwind apenas estabelece o piso — o `ResizeObserver` do Monaco entra em loop de medição com o wrapper em altura percentual, crescendo indefinidamente.

Substituído o `min-h-[300px]` (Tailwind) pelo prop explícito `height="300px"` no componente `vue-monaco-editor`, ancorando o wrapper em altura absoluta e quebrando o loop de medição.

### How to test

1. Acesse **Data Stream > Create**
2. Na seção **Render Template**, selecione qualquer template (ex: um template do Azion ou um template custom)
3. Verifique que o editor Monaco do **Data Set** mantém altura fixa de 300px
4. Troque entre templates com diferentes tamanhos de payload e confirme que a altura não cresce