### PR TITLE
[ENG-46114] fix: update Show Other Plans link to support page

### DIFF
--- a/src/helpers/azion-documentation-window-opener.js
+++ b/src/helpers/azion-documentation-window-opener.js
@@ -13,7 +13,7 @@ export const AZION_BLOG = 'https://www.azion.com/en/blog/'
 export const AZION_DISCORD = 'https://discord.com/invite/Yp9N7RMVZy'
 export const AZION_GITHUB = 'https://github.com/aziontech/azion-console-kit'
 export const AZION_X = 'https://x.com/aziontech'
-export const AZION_PLAN = 'https://www.azion.com/en/professional-services&id=#plans'
+export const AZION_PLAN = 'https://www.azion.com/en/support/'
 export const AZION_INTEGRATIONS =
   'https://www.azion.com/en/documentation/products/marketplace/integrations/'
 export const AZION_FORMJSON_DOCUMENTATION =

--- a/src/tests/helpers/azion-documentation-window-opener.test.js
+++ b/src/tests/helpers/azion-documentation-window-opener.test.js
@@ -129,10 +129,7 @@ describe('AzionDocumentationWindowOpener', () => {
 
     sut.openShowMorePlan()
 
-    expect(openWindowSpy).toHaveBeenCalledWith(
-      'https://www.azion.com/en/professional-services&id=#plans',
-      '_blank'
-    )
+    expect(openWindowSpy).toHaveBeenCalledWith('https://www.azion.com/en/support/', '_blank')
   })
 
   it('should open a new window with Azion Integrations link', () => {


### PR DESCRIPTION
## Summary
Atualiza o destino do link **"Show Other Plans"** no card *Service Plan* (Billing → Bills) da antiga página de Professional Services para a nova página de Support.

## Root cause
A constante `AZION_PLAN` em `src/helpers/azion-documentation-window-opener.js` apontava para `https://www.azion.com/en/professional-services&id=#plans`, que não reflete mais o destino correto para a listagem de Service Plans.

## Changes
- `src/helpers/azion-documentation-window-opener.js`: `AZION_PLAN` agora aponta para `https://www.azion.com/en/support/`.
- `src/tests/helpers/azion-documentation-window-opener.test.js`: expectativa do teste atualizada para a nova URL.

O comportamento de abertura é mantido — `openShowMorePlan()` segue usando `window.open(AZION_PLAN, '_blank')`, padrão idêntico aos demais openers do arquivo.

## Test plan
- [x] `yarn test:unit` — suíte `azion-documentation-window-opener` passa (13/13)
- [ ] Validação manual em dev/staging: Billing → Bills → card Service Plan → "Show Other Plans" abre `https://www.azion.com/en/support/`
- [ ] Revalidar visualmente após a correção do bug de JS na página de Support (tratado fora desta task)

> Obs.: a página de Support (`https://www.azion.com/en/support/`) está com um bug de JS em investigação que carrega conteúdo incorreto. Isso é tratado fora desta task — o destino final permanece correto.