### PR TITLE
[ENG-46121] feat: gate onboarding routing by account billing_type

### DIFF
--- a/src/router/hooks/guards/accountGuard.js
+++ b/src/router/hooks/guards/accountGuard.js
@@ -16,7 +16,7 @@ export async function accountGuard({ to, accountStore, tracker }) {
 
     try {
       // Await account identity hydration before deciding onboarding redirects.
-      // `has_service_order_plan` from account info drives the plan gate.
+      // `billing_type` from account info drives the onboarding gate.
       await loadAccountHydration()
 
       const needsOnboarding = accountStore.needsOnboarding

--- a/src/services/v2/account/account-service.js
+++ b/src/services/v2/account/account-service.js
@@ -2,6 +2,16 @@ import { BaseService } from '@/services/v2/base/query/baseService'
 import { getAccountTypeIcon, getAccountTypeName } from '@/helpers/account-type-name-mapping.js'
 import { queryKeys } from '@/services/v2/base/query/queryKeys'
 
+const resolveBillingType = (billingType) => {
+  const override = import.meta.env.VITE_BILLING_TYPE_OVERRIDE
+
+  if (override === undefined || override === '') {
+    return billingType ?? null
+  }
+
+  return override === 'null' ? null : override
+}
+
 export class AccountService extends BaseService {
   baseUrl = 'account/info'
 
@@ -26,6 +36,7 @@ export class AccountService extends BaseService {
 
     return {
       ...response,
+      billing_type: resolveBillingType(response.billing_type),
       hasServiceOrderPlan: response.has_service_order_plan === true,
       accountTypeIcon: getAccountTypeIcon(response.kind),
       accountTypeName: getAccountTypeName(response.kind)

--- a/src/stores/account.js
+++ b/src/stores/account.js
@@ -88,9 +88,9 @@ export const useAccountStore = defineStore({
     },
     needsOnboarding(state) {
       return (
-        state.account?.first_login === true &&
         state.account?.kind === 'client' &&
-        state.account?.hasServiceOrderPlan !== true
+        state.account?.first_login === true &&
+        state.account?.billing_type === null
       )
     },
     accountUtcOffset(state) {

--- a/src/tests/services/v2/account/account-service.test.js
+++ b/src/tests/services/v2/account/account-service.test.js
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AccountService } from '@/services/v2/account/account-service'
 
 describe('AccountService._adaptAccountInfo', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('maps has_service_order_plan explicitly when backend returns true', () => {
     const service = new AccountService()
 
@@ -35,5 +39,54 @@ describe('AccountService._adaptAccountInfo', () => {
     })
 
     expect(result.hasServiceOrderPlan).toBe(false)
+  })
+
+  it('passes through the backend billing_type value', () => {
+    const service = new AccountService()
+
+    const result = service._adaptAccountInfo({
+      id: 1,
+      kind: 'client',
+      billing_type: 'plan'
+    })
+
+    expect(result.billing_type).toBe('plan')
+  })
+
+  it('normalizes a missing billing_type to null', () => {
+    const service = new AccountService()
+
+    const result = service._adaptAccountInfo({
+      id: 1,
+      kind: 'client'
+    })
+
+    expect(result.billing_type).toBeNull()
+  })
+
+  it('forces billing_type to null when the override is set to null', () => {
+    vi.stubEnv('VITE_BILLING_TYPE_OVERRIDE', 'null')
+    const service = new AccountService()
+
+    const result = service._adaptAccountInfo({
+      id: 1,
+      kind: 'client',
+      billing_type: 'plan'
+    })
+
+    expect(result.billing_type).toBeNull()
+  })
+
+  it('forces billing_type to the override value when set', () => {
+    vi.stubEnv('VITE_BILLING_TYPE_OVERRIDE', 'custom')
+    const service = new AccountService()
+
+    const result = service._adaptAccountInfo({
+      id: 1,
+      kind: 'client',
+      billing_type: null
+    })
+
+    expect(result.billing_type).toBe('custom')
   })
 })

--- a/src/tests/stores/account.test.js
+++ b/src/tests/stores/account.test.js
@@ -27,39 +27,51 @@ describe('account store session state', () => {
     expect(store.hasSession).toBe(false)
   })
 
-  it('should use has_service_order_plan=true as contracted plan source of truth', () => {
+  it('should require onboarding only for a first-login client with billing_type=null', () => {
     const store = useAccountStore()
 
     store.setAccountData({
-      first_login: true,
       kind: 'client',
-      hasServiceOrderPlan: true
+      first_login: true,
+      billing_type: null
+    })
+
+    expect(store.needsOnboarding).toBe(true)
+  })
+
+  it('should not require onboarding for a first-login client that already has a billing_type', () => {
+    const store = useAccountStore()
+
+    store.setAccountData({
+      kind: 'client',
+      first_login: true,
+      billing_type: 'plan'
     })
 
     expect(store.needsOnboarding).toBe(false)
   })
 
-  it('should require onboarding when has_service_order_plan=false for first client login', () => {
+  it('should not require onboarding for a returning client even with billing_type=null', () => {
     const store = useAccountStore()
 
     store.setAccountData({
-      first_login: true,
       kind: 'client',
-      hasServiceOrderPlan: false
+      first_login: false,
+      billing_type: null
     })
 
-    expect(store.needsOnboarding).toBe(true)
+    expect(store.needsOnboarding).toBe(false)
   })
 
-  it('should not trust non-boolean has_service_order_plan values', () => {
+  it('should never require onboarding for non-client accounts', () => {
     const store = useAccountStore()
 
     store.setAccountData({
+      kind: 'reseller',
       first_login: true,
-      kind: 'client',
-      hasServiceOrderPlan: 'true'
+      billing_type: null
     })
 
-    expect(store.needsOnboarding).toBe(true)
+    expect(store.needsOnboarding).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
Onboarding routing now depends on the account `billing_type` returned by `/account/info`, instead of `has_service_order_plan`. A first-login client without a billing type is sent to the Service Order / onboarding flow; any other case logs in normally.

## Root cause / motivation
The `/account/info` endpoint now returns `billing_type`, but the frontend was still gating onboarding on `has_service_order_plan`. Per ENG-46121, the routing must follow `billing_type`: `null` → onboarding, any value (`plan`/`custom`/`internal`) → normal login.

## Onboarding truth table
The `additional-data` (Service Order) redirect happens **only** for this single case:

| kind | first_login | billing_type | → onboarding? |
|------|-------------|--------------|:---:|
| client | true | **null** | ✅ yes |
| client | true | plan/custom/internal | ❌ no |
| client | false | null | ❌ no |
| client | false | plan/custom/internal | ❌ no |
| reseller/brand/group | any | any | ❌ never |

`needsOnboarding = kind === 'client' && first_login === true && billing_type === null`

## Changes
- `src/services/v2/account/account-service.js` — adapter normalizes `billing_type` (missing → `null`) and applies the `VITE_BILLING_TYPE_OVERRIDE` env override.
- `src/stores/account.js` — `needsOnboarding` getter now gates on `billing_type === null` (with `kind === 'client'` and `first_login === true`).
- `src/router/hooks/guards/accountGuard.js` — comment updated to reflect the new gate; guard logic unchanged.
- Tests added/updated for the adapter (billing_type + override) and the store getter (full truth table).

## Temporary test control
The backend does not reliably populate `billing_type` for every account yet, so a temporary env var lets QA force the value without depending on the backend:

- `VITE_BILLING_TYPE_OVERRIDE` — empty/unset = use backend value; `null` = force onboarding; `plan`/`custom`/`internal` = force normal login.

> Note: there is no versioned `.env.example`, so QA must set this var locally to test. It is a temporary control to be removed once the backend `billing_type` is stable.

## Notes
- The blocked/defaulting account-status redirect (`billingGuard` → `paymentReviewPending`) is **untouched**.
- `hasServiceOrderPlan` is still mapped by the adapter (legit API field) but no longer drives routing — candidate for a follow-up cleanup.

## Test plan
- [ ] Client + first login + `billing_type=null` → redirected to `additional-data`.
- [ ] Client + first login + `billing_type=plan/custom/internal` → logs in normally.
- [ ] Client + returning (`first_login=false`) → logs in normally regardless of billing_type.
- [ ] Non-client account → never redirected to onboarding.
- [ ] `VITE_BILLING_TYPE_OVERRIDE=null` forces onboarding; `=plan` forces normal login.
- [ ] No regression on existing login flows; blocked/defaulting still redirect to billing.
- [ ] `yarn vitest run src/tests/services/v2/account/account-service.test.js src/tests/stores/account.test.js src/tests/router/hooks/guards/account-guard.test.js` passes.
