### PR TITLE
fix: enable click-to-edit on Edge Services list table

### DIFF
--- a/src/views/EdgeServices/ListView.vue
+++ b/src/views/EdgeServices/ListView.vue
@@ -82,6 +82,8 @@
     }
   ])
 
+  const frozenColumns = ['name']
+
   const actions = [
     {
       type: 'dialog',
@@ -167,6 +169,7 @@
         exportFileName="Edge Services"
         :csvMapper="csvMapper"
         :lazy="true"
+        :frozenColumns="frozenColumns"
         :emptyBlock="{
           title: 'No Edge Services yet',
           description:


### PR DESCRIPTION
## Summary

- Clicking a row in /edge-services no longer navigates to the edit view. The Name column (the natural click target) uses type: 'component', and ListTable's handleColumnClick / handleRowClick ignore clicks on component columns unless they're listed in frozenColumns.
- Added frozenColumns = ['name'] in src/views/EdgeServices/ListView.vue and passed it to <ListTable>, matching the pattern already used by EdgeApplications, EdgeFirewall, and other ListViews in the app.

**Root cause:**

`src/components/list-table/ListTable.vue:258-267` (handleColumnClick) returns null for component-type columns unless the column field is in frozenColumns.

EdgeServices/ListView.vue was missing this declaration, so clicking Name silently no-op'd while click-to-edit only worked on plain-text columns (ID, Last Editor, Last Modified) — which isn't discoverable.


### Test plan:

- [ ] Navigate to /edge-services
- [ ] Click an item's Name cell → routes to /edge-services/edit/:id
- [ ] Cmd/Ctrl+click Name cell → opens edit view in new tab
- [ ] Action menu (Activate / Deactivate / Delete) still works on each row
- [ ] No regression on create flow or other columns