### PR TITLE
[NO-ISSUE] feat: prefill login email input from url query param

### DIFF
--- a/src/templates/sign-in-block/index.vue
+++ b/src/templates/sign-in-block/index.vue
@@ -221,8 +221,17 @@
     }
   }
 
+  const prefillEmailFromUrl = () => {
+    const { email: emailFromUrl } = route.query
+
+    if (emailFromUrl) {
+      email.value = emailFromUrl
+    }
+  }
+
   onMounted(() => {
     verifyErrorsOnUrl()
+    prefillEmailFromUrl()
   })
 
   const showSocialIdps = ref(true)


### PR DESCRIPTION
## Summary
Na tela de login, quando a URL contém o query param `email`, o valor passa a ser preenchido automaticamente no input de email ao carregar a tela.

Exemplo:
```
/login?email=herbert.julio%2Bstg32@azion.com&plan=hobby&activated=true
```
O input de email já vem preenchido com `herbert.julio+stg32@azion.com`.

## Root cause
O input de email iniciava sempre vazio (`initialValues: { email: '' }`) e o query param `email` não era lido para pré-preencher o campo no `sign-in-block`.

## Changes
- `src/templates/sign-in-block/index.vue`: adicionada função `prefillEmailFromUrl()` chamada no `onMounted`, que lê `route.query.email` e seta o valor no campo `email` (vee-validate). O Vue Router já decodifica o param, então valores com `+` (`%2B`) são preenchidos corretamente.

## Test plan
- [ ] Acessar `/login?email=herbert.julio%2Bstg32@azion.com&plan=hobby&activated=true` e confirmar que o input de email vem preenchido com `herbert.julio+stg32@azion.com`
- [ ] Acessar `/login` sem o param `email` e confirmar que o input continua vazio
- [ ] Confirmar que a validação do campo de email segue funcionando normalmente