### PR TITLE
[NO-ISSUE] feat: require terms of service acceptance on payment confirmation

### DIFF
--- a/src/templates/checkout-block/checkout-plan-block.vue
+++ b/src/templates/checkout-block/checkout-plan-block.vue
@@ -23,6 +23,8 @@
         ref="addressInformationRef"
         @readiness-change="handleAddressReadinessChange"
       />
+
+      <TermsAcceptanceBlock v-model="isTermsAccepted" />
     </div>
     <CheckoutActionFooter
       :submitting="isSubmitting"
@@ -39,6 +41,7 @@
   import AddressInformationBlock from './address-information-block.vue'
   import PaymentMethodBlock from './payment-method-block.vue'
   import PricingCalculationBlock from './pricing-calculation-block.vue'
+  import TermsAcceptanceBlock from './terms-acceptance-block.vue'
   import CheckoutActionFooter from '@/templates/checkout-block/checkout-action-footer.vue'
   import {
     isStaleCheckoutSessionError,
@@ -89,10 +92,12 @@
   const checkoutSessionClientSecret = ref(props.checkoutSessionClientSecret)
   const isPaymentFormReady = ref(false)
   const isAddressFormReady = ref(false)
+  const isTermsAccepted = ref(false)
 
   const isSubscribeDisabled = computed(() => {
     return (
       isSubmitting.value ||
+      !isTermsAccepted.value ||
       !checkoutSessionClientSecret.value ||
       !isPaymentFormReady.value ||
       !isAddressFormReady.value

--- a/src/templates/checkout-block/terms-acceptance-block.vue
+++ b/src/templates/checkout-block/terms-acceptance-block.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="flex items-start gap-3">
+    <Checkbox
+      v-model="accepted"
+      :binary="true"
+      inputId="terms-acceptance"
+    />
+    <label
+      for="terms-acceptance"
+      class="text-[13px] leading-5 font-medium text-color-secondary cursor-pointer"
+    >
+      I accept the
+      <Button
+        label="Terms of Service"
+        link
+        size="small"
+        class="p-0 align-baseline"
+        @click.stop="azionTermsAndServicesWindowOpener"
+      />
+      and the
+      <Button
+        label="Privacy Policy."
+        link
+        size="small"
+        class="p-0 align-baseline"
+        @click.stop="azionPrivacyPolicyWindowOpener"
+      />
+    </label>
+  </div>
+</template>
+
+<script setup>
+  import Checkbox from '@aziontech/webkit/checkbox'
+  import Button from '@aziontech/webkit/button'
+  import { azionPrivacyPolicyWindowOpener, azionTermsAndServicesWindowOpener } from '@/helpers'
+
+  defineOptions({ name: 'terms-acceptance-block' })
+
+  const accepted = defineModel({ type: Boolean, default: false })
+</script>

--- a/src/tests/templates/checkout-plan-block.test.js
+++ b/src/tests/templates/checkout-plan-block.test.js
@@ -20,7 +20,8 @@ const mountCheckoutPlanBlock = ({
   confirmCheckoutSession = vi.fn(),
   saveAddress = vi.fn(),
   emitPaymentReady = false,
-  emitAddressReady = false
+  emitAddressReady = false,
+  emitTermsAccepted = false
 } = {}) =>
   mount(CheckoutPlanBlock, {
     props: {
@@ -67,6 +68,13 @@ const mountCheckoutPlanBlock = ({
           methods: {
             saveAddress,
             getCountry: vi.fn(() => 'United States')
+          }
+        }),
+        TermsAcceptanceBlock: defineComponent({
+          template: '<div />',
+          emits: ['update:modelValue'],
+          mounted() {
+            if (emitTermsAccepted) this.$emit('update:modelValue', true)
           }
         }),
         CheckoutActionFooter: {
@@ -125,7 +133,8 @@ describe('checkout-plan-block', () => {
       confirmCheckoutSession,
       saveAddress,
       emitPaymentReady: true,
-      emitAddressReady: true
+      emitAddressReady: true,
+      emitTermsAccepted: true
     })
 
     await flushPromises()
@@ -144,5 +153,21 @@ describe('checkout-plan-block', () => {
       ]
     ])
     expect(mocks.toastAdd).not.toHaveBeenCalled()
+  })
+
+  it('blocks checkout submission until the terms of service are accepted', async () => {
+    const saveAddress = vi.fn()
+    const wrapper = mountCheckoutPlanBlock({
+      saveAddress,
+      emitPaymentReady: true,
+      emitAddressReady: true,
+      emitTermsAccepted: false
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="submit"]').trigger('click')
+    await flushPromises()
+
+    expect(saveAddress).not.toHaveBeenCalled()
   })
 })

--- a/src/views/Billing/Drawer/DrawerPlanInfo.vue
+++ b/src/views/Billing/Drawer/DrawerPlanInfo.vue
@@ -71,6 +71,8 @@
               @readiness-change="handleAddressReadinessChange"
             />
           </template>
+
+          <TermsAcceptanceBlock v-model="isTermsAccepted" />
         </div>
 
         <CheckoutSubmissionFooter
@@ -94,6 +96,7 @@
   import PaymentMethodSetupBlock from '@/templates/checkout-block/payment-method-setup-block.vue'
   import PaymentMethodSummary from '@/views/Billing/Drawer/blocks/PaymentMethodSummary.vue'
   import AddressInformationBlock from '@/templates/checkout-block/address-information-block.vue'
+  import TermsAcceptanceBlock from '@/templates/checkout-block/terms-acceptance-block.vue'
   import CheckoutSubmissionFooter from '@/views/Billing/Drawer/CheckoutSubmissionFooter.vue'
   import { usePlans } from '@/composables/usePlans'
   import { useBillingPaymentMethods } from '@/composables/useBillingPaymentMethods'
@@ -151,6 +154,7 @@
   const checkoutSessionClientSecret = ref(props.initialClientSecret)
   const setupIntentClientSecret = ref('')
   const useDefaultPaymentMethod = ref(true)
+  const isTermsAccepted = ref(false)
 
   const { defaultPaymentMethod: defaultPaymentCard } = useBillingPaymentMethods()
   const { createSetupIntent, setDefault: setDefaultPaymentMethod } = useUpdateDefaultPaymentMethod()
@@ -204,6 +208,7 @@
 
   const isConfirmDisabled = computed(() => {
     if (isSubmitting.value) return true
+    if (!isTermsAccepted.value) return true
     if (isChangeCycleMode.value) {
       if (showDefaultPaymentSummary.value) return false
       return !setupIntentClientSecret.value || !isPaymentFormReady.value
@@ -241,7 +246,10 @@
   watch(
     () => props.visible,
     (visible) => {
-      if (visible) setParam('plan', props.plan)
+      if (visible) {
+        isTermsAccepted.value = false
+        setParam('plan', props.plan)
+      }
     },
     { immediate: true }
   )


### PR DESCRIPTION
## Summary
Adds a required **Terms of Service / Privacy Policy** acceptance checkbox to both payment confirmation flows — onboarding checkout and the billing plan drawer. The confirmation button stays disabled until the user checks "I accept the Terms of Service and the Privacy Policy", so payment cannot be confirmed without consent.

## Changes
- **New** `src/templates/checkout-block/terms-acceptance-block.vue` — reusable checkbox + inline Terms of Service / Privacy Policy links. Links open via the existing `azionTermsAndServicesWindowOpener` / `azionPrivacyPolicyWindowOpener` helpers (consistent with the signup screen). Two-way bound via `defineModel`.
- **Onboarding** `checkout-plan-block.vue` — renders the block below the address form and gates `isSubscribeDisabled` on acceptance.
- **Billing** `DrawerPlanInfo.vue` — renders the block at the end of the form and gates `isConfirmDisabled` for all confirmation modes (subscribe / edit / change-cycle). Acceptance is reset every time the drawer opens, so consent is required each time.

## Test plan
- [x] `yarn vitest run src/tests/templates/checkout-plan-block.test.js` — 4/4 passing (added a regression test asserting submit is blocked until terms are accepted; updated the stub to emit acceptance for the happy-path flow)
- [x] ESLint clean on all changed files
- [ ] Manual: onboarding payment step — Subscribe stays disabled until the checkbox is checked; both links open the correct pages
- [ ] Manual: billing plan drawer — confirm button stays disabled until checked; acceptance resets when reopening the drawer
