### PR TITLE
[ENG-46141] fix: adjustment to the nomenclature for the "Business" and "Enterprise" plan types

### DIFF
--- a/src/services/contract-services/load-contract-service-plan.js
+++ b/src/services/contract-services/load-contract-service-plan.js
@@ -11,8 +11,8 @@ export const loadContractServicePlan = async ({ clientId }) => {
 }
 
 const PLAN_MAP = {
-  business: 'Support Enterprise',
-  enterprise: 'Support Mission Critical',
+  business: 'Business',
+  enterprise: 'Enterprise',
   missioncritical: 'Mission Critical',
   mission_critical: 'Mission Critical'
 }

--- a/src/tests/services/contract-services/load-contract-service-plan.test.js
+++ b/src/tests/services/contract-services/load-contract-service-plan.test.js
@@ -146,7 +146,7 @@ describe.concurrent('ContractServices', () => {
 
     expect(response).toEqual({
       isDeveloperSupportPlan: false,
-      yourServicePlan: 'Support Enterprise'
+      yourServicePlan: 'Business'
     })
   })
 
@@ -164,7 +164,7 @@ describe.concurrent('ContractServices', () => {
 
     expect(response).toEqual({
       isDeveloperSupportPlan: false,
-      yourServicePlan: 'Support Mission Critical'
+      yourServicePlan: 'Enterprise'
     })
   })
 


### PR DESCRIPTION
## Bug fix

### Description

Adjusts the nomenclature mapping for the "Business" and "Enterprise" plan types in `loadContractServicePlan`.

The `PLAN_MAP` was mapping the `business` and `enterprise` plan slugs to support-tier labels (`Support Enterprise` and `Support Mission Critical`), which did not match the actual plan names shown to the user. The mapping now returns the correct, self-titled plan names:

- `business` → `Business` (was `Support Enterprise`)
- `enterprise` → `Enterprise` (was `Support Mission Critical`)

The `missioncritical` / `mission_critical` mappings remain unchanged.

### How to test

1. Sign in with an account whose contract resolves to a **Business** plan and confirm the displayed service plan reads **"Business"** (previously "Support Enterprise").
2. Repeat with an **Enterprise** contract and confirm it reads **"Enterprise"** (previously "Support Mission Critical").
3. Confirm **Mission Critical** and **Developer** plans are still displayed correctly (no regression).

### UI Changes (if applicable)

The service plan label shown in the UI now reflects the correct plan name ("Business" / "Enterprise") instead of the previous support-tier wording.
