### PR TITLE
[NO-ISSUE] fix: share button silently failing on reactive filter state

### DIFF
--- a/src/helpers/__tests__/structured-clone.prop.test.js
+++ b/src/helpers/__tests__/structured-clone.prop.test.js
@@ -97,4 +97,18 @@ describe('Feature: real-time-events-refactor, Property 9: structuredClone type p
       { numRuns: 100 }
     )
   })
+
+  // Regression: structuredClone throws DataCloneError on Proxy objects, which
+  // is what Vue's reactive()/ref() wrap state in. Cloning filterData.value for
+  // the share link must not throw — it must fall back to the JSON round-trip.
+  it('clones Proxy-wrapped objects (Vue reactive) without throwing', () => {
+    fc.assert(
+      fc.property(arbPlainObject, (obj) => {
+        const proxy = new Proxy(obj, {})
+        expect(() => safeStructuredClone(proxy)).not.toThrow()
+        expect(safeStructuredClone(proxy)).toEqual(obj)
+      }),
+      { numRuns: 100 }
+    )
+  })
 })

--- a/src/helpers/structured-clone.js
+++ b/src/helpers/structured-clone.js
@@ -6,12 +6,23 @@
  * structuredClone handles Date, Map, Set and other non-JSON-safe types
  * correctly and is ~2x faster for typical objects.
  *
+ * Note: structuredClone throws DataCloneError on values it can't serialize —
+ * most notably Proxy objects, which is exactly what Vue's reactive()/ref()
+ * wrap state in. Passing a reactive object straight to structuredClone (e.g.
+ * cloning filterData.value for the share link) therefore throws. We catch that
+ * and fall back to the JSON round-trip, which reads through the proxy and
+ * produces a plain clone.
+ *
  * @param {*} obj - The value to clone
  * @returns {*} A deep clone of the input
  */
 export default function safeStructuredClone(obj) {
   if (typeof globalThis.structuredClone === 'function') {
-    return globalThis.structuredClone(obj)
+    try {
+      return globalThis.structuredClone(obj)
+    } catch {
+      /* DataCloneError (e.g. Vue reactive Proxy) — fall back to JSON below */
+    }
   }
   return JSON.parse(JSON.stringify(obj))
 }

--- a/src/views/RealTimeEventsV2/TabsView.vue
+++ b/src/views/RealTimeEventsV2/TabsView.vue
@@ -322,21 +322,34 @@
   // settles before the click handler returns — and so future enhancements
   // (analytics, focus restoration) can chain off the resolved promise.
   const handleShare = async () => {
-    let viewState = {}
-    let eventsTab = null
+    try {
+      let viewState = {}
+      let eventsTab = null
 
-    if (tabPanelBlockRef.value?.getCurrentShareState) {
-      viewState = tabPanelBlockRef.value.getCurrentShareState()
-    }
-
-    if (activeTabId.value && isEventsTabId(activeTabId.value)) {
-      const tab = eventsTabs.value.find((entry) => entry.id === activeTabId.value)
-      if (tab) {
-        eventsTab = { id: tab.id, label: tab.label, dataset: tab.dataset }
+      if (tabPanelBlockRef.value?.getCurrentShareState) {
+        viewState = tabPanelBlockRef.value.getCurrentShareState()
       }
-    }
 
-    await shareCurrentView({ viewState, eventsTab })
+      if (activeTabId.value && isEventsTabId(activeTabId.value)) {
+        const tab = eventsTabs.value.find((entry) => entry.id === activeTabId.value)
+        if (tab) {
+          eventsTab = { id: tab.id, label: tab.label, dataset: tab.dataset }
+        }
+      }
+
+      await shareCurrentView({ viewState, eventsTab })
+    } catch (err) {
+      // Surface failures that happen before shareCurrentView's own try/catch
+      // (e.g. building the share state) instead of letting the async handler
+      // reject silently — which looks like "the button does nothing".
+      toast.add({
+        closable: true,
+        severity: 'error',
+        summary: 'Error generating share URL',
+        detail: String(err).slice(0, 100),
+        life: 5000
+      })
+    }
   }
 
   // ── Watch pendingEventsTabState from useSessionManager (Share_State import) ──


### PR DESCRIPTION
## Feature

### Description

Corrige o botão **Share** (Copy share link) do Real-Time Events V2, que ao ser clicado não copiava nada e não dava nenhum feedback.

**Causa raiz:** `structuredClone` lança `DataCloneError` quando recebe um `Proxy`, e o Vue (`ref`/`reactive`) embrulha o estado em Proxy. O `getCurrentShareState()` clonava o `filterData.value` reativo via `safeStructuredClone`, que só caía no fallback JSON quando `structuredClone` **não existia** — não quando ele **lançava**. Como `handleShare` é `async` sem try/catch, a exceção rejeitava a promise silenciosamente.

**Alterações:**
- `safeStructuredClone` agora tenta o `structuredClone` nativo e, em caso de erro (ex.: Proxy reativo), faz fallback para o round-trip JSON — mantendo o suporte a `Date`/`Map`/`Set` no caminho normal.
- `handleShare` ganhou try/catch com toast de erro, para que qualquer falha apareça em vez de morrer em silêncio.
- Teste de regressão garantindo que clonar um objeto via Proxy não lança.

### How to test

1. Acesse **Real-Time Events** (V2).
2. (Opcional) Aplique um ou mais filtros / selecione um dataset.
3. Clique no botão de **Share** (ícone de compartilhar, tooltip "Copy share link").
4. **Esperado:** toast "Share URL copied to clipboard" e, ao colar (Cmd/Ctrl+V), a URL contém `?shareState=...`.
5. Abra essa URL em outra aba → a view (filtros/dataset) é restaurada.

### UI Changes (if applicable)

Sem mudanças visuais. Apenas comportamento: o botão de share passa a copiar o link (e exibe toast de sucesso/erro).

