### PR TITLE
[NO-ISSUE] feat: track HubSpot sign-up event after additional-data submit

### DIFF
--- a/cypress/e2mock/signup/additional-data-hubspot.cy.js
+++ b/cypress/e2mock/signup/additional-data-hubspot.cy.js
@@ -1,0 +1,131 @@
+// Selectors for the additional-data onboarding form. Each radio option renders a
+// <label for="{nameField}-radio-{index}"> bound to a hidden radio input, so
+// clicking the label is the reliable way to select an option (clicking the card
+// wrapper lands on padding and does not toggle the radio). Selecting `use` then
+// `role` is also what advances the form's step gating and enables `fullName`.
+const selectors = {
+  usePersonalOption: 'label[for="use-radio-0"]',
+  roleSoftwareDeveloperOption: 'label[for="role-radio-0"]',
+  fullNameInput: '#fullName',
+  submitButton: '[data-testid="form-actions-buttons"] button'
+}
+
+const accountInfo = {
+  id: 22692,
+  name: 'Cypress User',
+  company_name: 'Azion',
+  full_name: 'Cypress User',
+  kind: 'client',
+  client_flags: ['allow_console'],
+  first_login: true,
+  is_client_only: true,
+  status: 'ONLINE'
+}
+
+const userInfo = {
+  id: 9999,
+  email: 'cypress.user@azion.com',
+  first_name: 'Cypress',
+  last_name: 'User',
+  is_account_owner: true,
+  client_id: 4321,
+  timezone: 'America/Sao_Paulo',
+  utc_offset: '-0300',
+  permissions: []
+}
+
+const jobRoleResponse = { data: { job_function: 'software-developer' } }
+
+// Persisted pinia state (account store) used to fake an authenticated session
+// without hitting the real auth backend. The account store persists only these
+// paths (see src/stores/account.js).
+const persistedAccountState = {
+  identifySignUpProvider: '',
+  hasSession: true,
+  signupTypeFlags: {
+    login_sso_google: false,
+    login_sso_github: false,
+    login_email: false,
+    signup_sso_google: false,
+    signup_sso_github: false,
+    signup_email: true
+  }
+}
+
+/**
+ * Registers all the intercepts needed to render the onboarding additional-data
+ * step and submit it. The HubSpot endpoint status code is configurable so we can
+ * assert that the onboarding flow is resilient to both success (200) and error
+ * (400) responses.
+ *
+ * @param {Object} options
+ * @param {number} options.hubspotStatusCode - status code returned by the mocked HubSpot endpoint
+ */
+const setupIntercepts = ({ hubspotStatusCode }) => {
+  // Account hydration (account guard / loadUserAndAccountInfo)
+  cy.intercept('GET', '**/account/info', { statusCode: 200, body: accountInfo }).as('accountInfo')
+  cy.intercept('GET', '**/user/me', { statusCode: 200, body: userInfo }).as('userInfo')
+  cy.intercept('GET', '**/v4/iam/account', { statusCode: 200, body: jobRoleResponse }).as('jobRole')
+
+  // Submit services
+  cy.intercept('PATCH', '**/v4/iam/account', {
+    statusCode: 200,
+    body: { data: { job_function: 'software-developer' } }
+  }).as('updateAccount')
+  cy.intercept('PATCH', '**/v4/iam/user', { statusCode: 200, body: {} }).as('patchFullname')
+  cy.intercept('POST', '**/v4/iam/users/*/additional_data', { statusCode: 201, body: {} }).as(
+    'postAdditionalData'
+  )
+
+  // HubSpot event (cross-origin to www.azion.com by default)
+  cy.intercept('POST', '**/hubspot/events', {
+    statusCode: hubspotStatusCode,
+    body: hubspotStatusCode >= 400 ? { error: 'bad request' } : { success: true }
+  }).as('hubspotEvent')
+}
+
+const visitOnboarding = () => {
+  cy.visit('/signup/additional-data', {
+    onBeforeLoad(win) {
+      win.localStorage.setItem('account', JSON.stringify(persistedAccountState))
+    }
+  })
+}
+
+const fillAndSubmitForm = () => {
+  cy.get(selectors.usePersonalOption).click()
+  cy.get(selectors.roleSoftwareDeveloperOption).click()
+  // Selecting `use` + `role` advances the step gating; wait until `fullName`
+  // becomes enabled before typing.
+  cy.get(selectors.fullNameInput).should('not.be.disabled').type('Cypress User')
+  cy.get(selectors.submitButton).click()
+}
+
+describe('Signup - additional data HubSpot event', { tags: ['@dev2'] }, () => {
+  it('fires the HubSpot sign-up event and finishes onboarding when HubSpot returns 200', () => {
+    setupIntercepts({ hubspotStatusCode: 200 })
+
+    visitOnboarding()
+    fillAndSubmitForm()
+
+    // The additional data is persisted...
+    cy.wait('@postAdditionalData')
+    // ...and the HubSpot event is fired with a sign-up payload.
+    cy.wait('@hubspotEvent').its('request.body').should('include', { eventName: 'sign_up' })
+    // The flow always finishes by redirecting the user to the home page.
+    cy.location('pathname').should('eq', '/')
+  })
+
+  it('still finishes onboarding when the HubSpot event fails with 400', () => {
+    setupIntercepts({ hubspotStatusCode: 400 })
+
+    visitOnboarding()
+    fillAndSubmitForm()
+
+    cy.wait('@postAdditionalData')
+    // The HubSpot endpoint is still called, even though it responds with 400.
+    cy.wait('@hubspotEvent').its('response.statusCode').should('eq', 400)
+    // A failing HubSpot request must not block the onboarding flow.
+    cy.location('pathname').should('eq', '/')
+  })
+})

--- a/src/templates/signup-block/additional-data-form-block.vue
+++ b/src/templates/signup-block/additional-data-form-block.vue
@@ -160,6 +160,7 @@
   import { ref, inject, computed, watch } from 'vue'
   import { useRouter } from 'vue-router'
   import { useAccountStore } from '@/stores/account'
+  import { trackSignUpSafely } from '@/helpers/track-auth-event'
   import * as yup from 'yup'
   import FieldGroupRadio from '@aziontech/webkit/field-group-radio'
   import FieldSwitchBlock from '@aziontech/webkit/field-switch-block'
@@ -475,6 +476,12 @@
 
   const loading = ref(false)
 
+  const resolveSignUpMethod = (flags) => {
+    if (flags?.signup_sso_google) return 'google'
+    if (flags?.signup_sso_github) return 'github'
+    return 'email'
+  }
+
   const submitForm = async () => {
     loading.value = true
 
@@ -499,6 +506,16 @@
       await postAddData
 
       tracker.signUp.submittedAdditionalData(values).track()
+
+      // Fire the HubSpot sign-up event now that the profile is enriched (name,
+      // role and company). It is fire-and-forget and swallows its own errors,
+      // so a HubSpot failure never impacts the onboarding flow.
+      const signupTypeFlags = accountStore.getSignupTypeFlags()
+      trackSignUpSafely({
+        tracker,
+        method: resolveSignUpMethod(signupTypeFlags),
+        signupTypeFlags
+      })
     } catch (err) {
       const errors = JSON.parse(err)
 


### PR DESCRIPTION
## Feature

### Description

Wires the previously-unused `trackSignUpSafely` helper into the additional-data onboarding submit, so the HubSpot sign-up event is finally fired — at the point where the user profile is most complete (full name, role and company).

- The event is dispatched right after `submittedAdditionalData`, deriving the sign-up `method` from the account's `signupTypeFlags` (`google` / `github` / `email`).
- It is **fire-and-forget** and swallows its own errors internally, so a HubSpot failure (e.g. a 4xx response) **never blocks or breaks the onboarding flow** — the user is still redirected to home.
- Adds a mocked Cypress e2e (`cypress/e2mock/signup/additional-data-hubspot.cy.js`) covering both outcomes:
  - **200** → event fired with `eventName: sign_up` and onboarding completes.
  - **400** → event endpoint still called, fails, and onboarding **still** completes (flow resilience).

### How to test

**Automated (mocked e2e):**
```bash
# with the dev server running on :5173
npx cypress run --e2e --spec cypress/e2mock/signup/additional-data-hubspot.cy.js
