### PR TITLE
[ENG-46609] fix: prevent long email overflow in profile menu

### DIFF
--- a/src/layout/components/menu-profile/index.vue
+++ b/src/layout/components/menu-profile/index.vue
@@ -88,7 +88,7 @@
                   >{{ user.full_name }}</span
                 >
                 <span
-                  class="text-xs"
+                  class="text-xs break-all"
                   data-testid="profile-block__settings-menu__email"
                   >{{ user.email }}</span
                 >
@@ -242,7 +242,7 @@
             >{{ user.full_name }}</span
           >
           <span
-            class="text-xs"
+            class="text-xs break-all"
             data-testid="profile-block__mobile-settings-menu__email"
             >{{ user.email }}</span
           >

--- a/src/layout/components/menu-profile/index.vue
+++ b/src/layout/components/menu-profile/index.vue
@@ -34,8 +34,8 @@
             <span
               class="text-sm font-medium"
               data-testid="profile-block__profile-menu__user-name"
-              >{{ user.name }}</span
-            >
+              >{{ user.name }}
+            </span>
             <div class="flex gap-2">
               <span
                 class="text-xs"
@@ -80,15 +80,16 @@
           }"
         >
           <template #start>
-            <div class="flex flex-row items-center">
-              <div class="flex flex-col gap-1 px-2 py-2.5">
+            <div class="flex flex-row items-center min-w-0">
+              <div class="flex flex-col gap-1 px-2 py-2.5 min-w-0">
                 <span
                   class="text-sm font-medium leading-none"
                   data-testid="profile-block__settings-menu__full-name"
                   >{{ user.full_name }}</span
                 >
                 <span
-                  class="text-xs break-all"
+                  class="text-xs truncate"
+                  :title="user.email"
                   data-testid="profile-block__settings-menu__email"
                   >{{ user.email }}</span
                 >
@@ -234,15 +235,16 @@
     </template>
 
     <template #end>
-      <div class="flex flex-row items-center">
-        <div class="flex flex-col gap-1 px-2 py-2.5">
+      <div class="flex flex-row items-center min-w-0">
+        <div class="flex flex-col gap-1 px-2 py-2.5 min-w-0">
           <span
             class="text-sm font-medium leading-none"
             data-testid="profile-block__mobile-settings-menu__full-name"
             >{{ user.full_name }}</span
           >
           <span
-            class="text-xs break-all"
+            class="text-xs truncate"
+            :title="user.email"
             data-testid="profile-block__mobile-settings-menu__email"
             >{{ user.email }}</span
           >


### PR DESCRIPTION
## Bug fix

### What was the problem?

Long email addresses without break opportunities (e.g. `yodelling.hummingbird.daer@hidingmail.net`) overflowed the account/profile menu. The email `<span>` had no word-break handling, so in the constrained-width containers — notably the mobile popup menu fixed at `w-[280px]` — the text spilled outside the container boundaries.
<img width="1440" height="1163" alt="image" src="https://github.com/user-attachments/assets/95f46fd3-178a-4b08-8ee8-5cfbb61cb10b" />


### Expected behavior

<img width="1438" height="828" alt="Captura de Tela 2026-07-13 às 14 58 42" src="https://github.com/user-attachments/assets/2bd72423-c962-49ec-8cd6-b82b8bc65fb1" />

The email address stays contained within the menu, wrapping across lines as needed instead of overflowing.

### How was it solved

Added the Tailwind `break-all` class to both email `<span>` elements in `src/layout/components/menu-profile/index.vue`:

- Settings menu (sidebar/desktop) — `profile-block__settings-menu__email`
- Mobile popup menu — `profile-block__mobile-settings-menu__email`

`break-all` lets long, unbroken strings break at any character so they fit inside the container.

### How to test

1. Log in with (or mock) a user whose email is long and unbroken, e.g. `yodelling.hummingbird.daer@hidingmail.net`.
2. **Desktop:** click the avatar in the header to open the profile popup and check the settings section — the email wraps within the menu instead of overflowing.
3. **Mobile (≤768px width):** open the bottom profile sidebar and check the settings section — the email wraps within the 280px-wide container.
4. Confirm no horizontal overflow or text spilling outside the menu in either view.
