### PR TITLE
[ENG-46653] refactor: remove DeviceAtlas variable from rules engine form fields

### DIFF
--- a/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
+++ b/src/views/EdgeApplicationsRulesEngine/FormFields/FormFieldsEdgeApplicationsRulesEngine.vue
@@ -149,7 +149,6 @@
     '${arg_}',
     '${args}',
     '${cookie_}',
-    '${da_}',
     '${device_group}',
     '${domain}',
     '${geoip_city_continent_code}',


### PR DESCRIPTION
## Feature
[ENG-46653]
### Description

Removes the `${da_}` (DeviceAtlas) variable from the variables list rendered by the Rules Engine form fields, as part of the DeviceAtlas module removal (ENG-46653). Since the module is no longer available, the variable should no longer be offered as an autocomplete/reference option when configuring rule behaviors and conditions.

### How to test

1. Go to **Edge Application → Rules Engine** and create or edit a rule.
2. Open a field that lists the available Rules Engine variables (behaviors/criteria).
3. Confirm that `${da_}` is no longer present in the list, while the other variables (`${arg_}`, `${args}`, `${cookie_}`, `${device_group}`, `${domain}`, etc.) still appear as expected.

### UI Changes (if applicable)
<img width="1438" height="828" alt="Captura de Tela 2026-07-14 às 10 15 56" src="https://github.com/user-attachments/assets/81f43c25-e727-4bff-84b3-cb4be5e8833b" />

N/A — only removes one entry from the variables suggestion list; no visual/layout change.


[ENG-46653]: https://aziontech.atlassian.net/browse/ENG-46653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ