### PR TITLE
feat: add Overview tab with Live Deployments and Version History

### DIFF
--- a/docs/testing/versioning-overview-tab.feature
+++ b/docs/testing/versioning-overview-tab.feature
@@ -1,0 +1,150 @@
+# Manual QA — Overview tab (Edge Applications & Edge Firewall)
+#
+# Como executar:
+#  1. `yarn dev` na branch feat/versioning-overview-tab
+#  2. Logar no console com uma conta que já tenha ao menos uma Edge Application
+#     e um Edge Firewall com >= 1 versão. Idealmente com deployments ativos.
+#  3. Percorrer cada cenário e marcar PASS/FAIL. Os data-testids citados são
+#     estáveis — use o DevTools para localizar elementos quando o texto variar.
+
+Feature: Aba Overview em recursos versionados
+  Como usuário do console
+  Quero ver rapidamente o estado ativo de um recurso versionado
+  Para saber quais versões estão recebendo tráfego sem entrar em cada workload
+
+  Background:
+    Given estou logado no console
+    And existe uma Edge Application com pelo menos duas versões e um deployment ativo
+    And existe um Edge Firewall com pelo menos duas versões e um deployment ativo
+
+  # ─────────────────────────────────────────────────────────────
+  # Shell da landing (ordem e visibilidade das abas)
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Ordem das abas na Edge Application
+    When abro a Edge Application no console
+    Then vejo, nessa ordem, as abas "Overview", "Versions", "Settings" e "Variables"
+    And a aba "Overview" está ativa por padrão
+
+  Scenario: Ordem das abas no Edge Firewall
+    When abro o Edge Firewall no console
+    Then vejo, nessa ordem, as abas "Overview", "Versions" e "Settings"
+    And a aba "Overview" está ativa por padrão
+
+  Scenario: Troca de aba não recarrega toda a landing
+    Given estou na aba "Overview" de uma Edge Application
+    When clico na aba "Versions"
+    Then o cabeçalho da página (título + botão de deploy) permanece visível sem re-render completo
+    And o teleport "version-lifecycle-action" continua funcionando na aba "Settings"
+
+  # ─────────────────────────────────────────────────────────────
+  # Live Deployments
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Tabela Live Deployments mostra apenas versões com tráfego
+    Given a Edge Application tem uma versão ACTIVE e outra CANDIDATE
+    When abro a aba "Overview"
+    Then a seção "Live Deployments" lista apenas a versão com traffic_role ACTIVE
+    And cada linha exibe as colunas Version, Environment, Workload e Deployed
+    And a coluna Version mostra o hash da versão e uma tag verde "Live"
+
+  Scenario: Environment vem do nome do deployment
+    Given existe um deployment chamado "prod-api" servindo a versão X
+    When abro a aba "Overview"
+    Then a linha da versão X mostra "prod-api" na coluna Environment
+
+  Scenario: Workload aparece como travessão quando não resolvido
+    Given nenhum resolver popula o workload (comportamento atual)
+    When abro a aba "Overview"
+    Then todas as linhas de Live Deployments mostram "—" na coluna Workload
+
+  Scenario: Uma versão em múltiplos deployments produz múltiplas linhas
+    Given a versão Y está ativa em dois deployments distintos
+    When abro a aba "Overview"
+    Then a tabela Live Deployments mostra duas linhas para a versão Y
+    And cada linha tem um Environment diferente
+    And nenhuma das duas linhas aparece na tabela "Version History" abaixo
+
+  Scenario: Estado vazio quando nenhuma versão está em produção
+    Given a Edge Application não tem deployment ativo
+    When abro a aba "Overview"
+    Then a seção "Live Deployments" mostra o título "No versions currently receiving traffic"
+    And mostra a mensagem "When a version is promoted to a workload, it will appear here as a live deployment."
+
+  Scenario: Live Deployments não tem toolbar de busca
+    When abro a aba "Overview"
+    Then a tabela "Live Deployments" não exibe campo de busca nem filtros
+    And as linhas dessa tabela não exibem menu de ação (kebab)
+
+  # ─────────────────────────────────────────────────────────────
+  # Version History
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Version History exclui as versões ativas
+    Given a Edge Application tem 5 versões e 2 delas estão live
+    When abro a aba "Overview"
+    Then a tabela "Version History" lista as 3 versões restantes
+    And nenhuma delas exibe a tag "Live"
+
+  Scenario: Busca em Version History filtra apenas o histórico
+    Given estou na aba "Overview" com pelo menos 3 versões no histórico
+    When digito parte do label de uma versão no campo de busca
+    Then apenas as linhas correspondentes aparecem na tabela "Version History"
+    And a tabela "Live Deployments" permanece inalterada
+
+  Scenario: Filtros e paginação em Version History
+    Given a Version History tem mais de 20 versões
+    When abro a aba "Overview"
+    Then o paginador aparece rodando 20 por página
+    And o filtro de status funciona apenas no histórico
+    And o botão de refresh reexecuta a query de versões
+
+  Scenario: Estado vazio filtrado em Version History
+    Given há versões no histórico
+    When digito um termo de busca sem correspondência
+    Then vejo "No versions match your filters" com sugestão para tentar outro termo
+
+  # ─────────────────────────────────────────────────────────────
+  # Ações via menu de linha (kebab)
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Promote de uma versão do histórico
+    Given estou na aba "Overview" com pelo menos uma versão inativa
+    When abro o menu da linha e clico em "Promote"
+    Then sou levado ao release composer com a versão pré-selecionada
+    And ao voltar, a landing continua na aba "Overview"
+
+  Scenario: Deploy da versão mais recente pela ação do heading
+    Given estou na aba "Overview"
+    When clico no botão de deploy no cabeçalho
+    Then o Deploy Drawer abre pré-configurado para essa Edge Application
+
+  # ─────────────────────────────────────────────────────────────
+  # Loading / erro
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Loading spinner enquanto a query de versões carrega
+    When abro a landing pela primeira vez com a rede lenta
+    Then vejo o spinner central com data-testid "*__loading"
+    And as tabelas só aparecem depois que a query completa
+
+  Scenario: Mensagem de erro se a query falhar
+    Given a API de versões retorna 500
+    When abro a aba "Overview"
+    Then vejo InlineMessage vermelho com "Failed to load. Try refreshing the page."
+
+  # ─────────────────────────────────────────────────────────────
+  # Design system (checar visualmente)
+  # ─────────────────────────────────────────────────────────────
+
+  Scenario: Tipografia e espaçamentos respeitam o design system
+    When comparo a aba "Overview" com o Figma
+    Then títulos das seções usam text-body-md font-semibold
+    And subtítulos usam text-body-sm text-color-secondary
+    And o gap entre seções segue --spacing-6
+    And nenhum hex/rgb aparece nas classes do bloco
+
+  Scenario: Modo escuro
+    When alterno para o tema escuro
+    Then as tabelas, tags e headers da aba "Overview" mantêm contraste adequado
+    And a tag "Live" (severity success) permanece legível

--- a/src/components/VersionListDataView/index.vue
+++ b/src/components/VersionListDataView/index.vue
@@ -105,6 +105,10 @@
       type: Number,
       default: 20
     },
+    showPaginator: {
+      type: Boolean,
+      default: true
+    },
     lazy: {
       type: Boolean,
       default: false
@@ -583,7 +587,7 @@
           <DataView
             :value="items"
             dataKey="id"
-            :paginator="true"
+            :paginator="showPaginator"
             :lazy="lazy"
             :totalRecords="lazy ? totalRecords : undefined"
             :rows="paginatorRows"

--- a/src/components/VersionListDataView/index.vue
+++ b/src/components/VersionListDataView/index.vue
@@ -128,6 +128,13 @@
     resourceType: {
       type: String,
       default: ''
+    },
+    // Hide the toolbar (search/filter/sort + `toolbar-actions` slot). Used by the
+    // Overview's Live Deployments table, which is a small, non-searchable list
+    // but must still share this component's table shell for visual consistency.
+    showToolbar: {
+      type: Boolean,
+      default: true
     }
   })
 
@@ -368,7 +375,10 @@
     class="flex flex-col gap-4 text-[var(--text-color)]"
     data-testid="version-list-data-view"
   >
-    <div class="flex flex-wrap items-center justify-between gap-2">
+    <div
+      v-if="showToolbar"
+      class="flex flex-wrap items-center justify-between gap-2"
+    >
       <div class="dataview-toolbar flex min-w-0 flex-1 flex-wrap items-center gap-2">
         <button
           v-if="isCompactViewport && hasCollapsibleFilters"

--- a/src/components/VersionListDataView/index.vue
+++ b/src/components/VersionListDataView/index.vue
@@ -678,6 +678,29 @@
                       </button>
 
                       <button
+                        v-else-if="column.key === 'deployed'"
+                        type="button"
+                        class="created-cell-button flex max-w-full min-w-0 flex-col items-start gap-0.5 border-0 bg-transparent p-0 text-left"
+                        @click="triggerRowClick(version)"
+                      >
+                        <span
+                          class="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm text-[var(--text-color)]"
+                        >
+                          {{
+                            version.deployedAt
+                              ? formatDateToDayMonthYearHour(version.deployedAt)
+                              : '--'
+                          }}
+                        </span>
+                        <span
+                          class="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[var(--text-color-secondary)]"
+                          data-sentry-mask
+                        >
+                          {{ version.deployedBy || version.lastEditor || 'azion@azion.com' }}
+                        </span>
+                      </button>
+
+                      <button
                         v-else-if="column.key === 'inUse'"
                         type="button"
                         class="in-use-cell-button inline-flex min-w-0 max-w-full items-center border-0 bg-transparent p-0 text-left"
@@ -839,6 +862,23 @@
                               data-sentry-mask
                             >
                               {{ version.lastEditor || 'azion@azion.com' }}
+                            </span>
+                          </template>
+                          <template v-else-if="col.key === 'deployed'">
+                            <span
+                              class="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm text-[var(--text-color)]"
+                            >
+                              {{
+                                version.deployedAt
+                                  ? formatDateToDayMonthYearHour(version.deployedAt)
+                                  : '--'
+                              }}
+                            </span>
+                            <span
+                              class="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[var(--text-color-secondary)]"
+                              data-sentry-mask
+                            >
+                              {{ version.deployedBy || version.lastEditor || 'azion@azion.com' }}
                             </span>
                           </template>
                           <span

--- a/src/components/base/advanced-filter-system-v2/filterAQL/azion-query-language.js
+++ b/src/components/base/advanced-filter-system-v2/filterAQL/azion-query-language.js
@@ -731,12 +731,10 @@ export default class Aql {
         if (operatorFound) {
           let stringBeforeOperator = cleaned.split(operatorFound)[0].trim()
           if (stringBeforeOperator.includes(' ')) {
-            if (
-              !(
-                (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
-                (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
-              )
-            ) {
+            if (!(
+              (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
+              (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
+            )) {
               if (!erros.includes('quote-error')) {
                 erros.push('quote-error')
               }
@@ -744,12 +742,10 @@ export default class Aql {
           }
         } else {
           if (cleaned.includes(' ') && /\s+\S+/.test(cleaned)) {
-            if (
-              !(
-                (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
-                (cleaned.startsWith("'") && cleaned.endsWith("'"))
-              )
-            ) {
+            if (!(
+              (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+              (cleaned.startsWith("'") && cleaned.endsWith("'"))
+            )) {
               if (!erros.includes('quote-error')) {
                 erros.push('quote-error')
               }
@@ -764,12 +760,10 @@ export default class Aql {
       if (operatorFound) {
         let stringBeforeOperator = cleaned.split(operatorFound)[0].trim()
         if (stringBeforeOperator.includes(' ')) {
-          if (
-            !(
-              (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
-              (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
-            )
-          ) {
+          if (!(
+            (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
+            (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
+          )) {
             if (!erros.includes('quote-error')) {
               erros.push('quote-error')
             }
@@ -777,12 +771,10 @@ export default class Aql {
         }
       } else {
         if (cleaned.includes(' ') && /\s+\S+/.test(cleaned)) {
-          if (
-            !(
-              (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
-              (cleaned.startsWith("'") && cleaned.endsWith("'"))
-            )
-          ) {
+          if (!(
+            (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+            (cleaned.startsWith("'") && cleaned.endsWith("'"))
+          )) {
             if (!erros.includes('quote-error')) {
               erros.push('quote-error')
             }

--- a/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
+++ b/src/components/base/advanced-filter-system/filterAQL/azion-query-language.js
@@ -507,12 +507,10 @@ export default class Aql {
         if (operatorFound) {
           let stringBeforeOperator = expression.split(operatorFound)[0].trim()
           if (stringBeforeOperator.includes(' ')) {
-            if (
-              !(
-                (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
-                (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
-              )
-            ) {
+            if (!(
+              (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
+              (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
+            )) {
               if (!erros.includes('quote-error')) {
                 erros.push('quote-error')
               }
@@ -520,12 +518,10 @@ export default class Aql {
           }
         } else {
           if (expression.includes(' ') && /\s+\S+/.test(expression)) {
-            if (
-              !(
-                (expression.trim().startsWith('"') && expression.trim().endsWith('"')) ||
-                (expression.trim().startsWith("'") && expression.trim().endsWith("'"))
-              )
-            ) {
+            if (!(
+              (expression.trim().startsWith('"') && expression.trim().endsWith('"')) ||
+              (expression.trim().startsWith("'") && expression.trim().endsWith("'"))
+            )) {
               if (!erros.includes('quote-error')) {
                 erros.push('quote-error')
               }
@@ -539,12 +535,10 @@ export default class Aql {
       if (operatorFound) {
         let stringBeforeOperator = queryText.split(operatorFound)[0].trim()
         if (stringBeforeOperator.includes(' ')) {
-          if (
-            !(
-              (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
-              (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
-            )
-          ) {
+          if (!(
+            (stringBeforeOperator.startsWith('"') && stringBeforeOperator.endsWith('"')) ||
+            (stringBeforeOperator.startsWith("'") && stringBeforeOperator.endsWith("'"))
+          )) {
             if (!erros.includes('quote-error')) {
               erros.push('quote-error')
             }
@@ -552,12 +546,10 @@ export default class Aql {
         }
       } else {
         if (queryText.includes(' ') && /\s+\S+/.test(queryText)) {
-          if (
-            !(
-              (queryText.trim().startsWith('"') && queryText.trim().endsWith('"')) ||
-              (queryText.trim().startsWith("'") && queryText.trim().endsWith("'"))
-            )
-          ) {
+          if (!(
+            (queryText.trim().startsWith('"') && queryText.trim().endsWith('"')) ||
+            (queryText.trim().startsWith("'") && queryText.trim().endsWith("'"))
+          )) {
             if (!erros.includes('quote-error')) {
               erros.push('quote-error')
             }

--- a/src/composables/versioning/active-versions.js
+++ b/src/composables/versioning/active-versions.js
@@ -32,7 +32,8 @@ export const activeVersionsForResource = (rows, ref) => {
           state: row?.state ?? null,
           policy: row?.deployment_policy ?? null,
           trafficRole: rowResource?.traffic_role ?? null,
-          releaseId: rowResource?.release_id ?? null
+          releaseId: rowResource?.release_id ?? null,
+          deployedAt: row?.updated_at ?? row?.created_at ?? null
         })
       }
 

--- a/src/composables/versioning/active-versions.js
+++ b/src/composables/versioning/active-versions.js
@@ -33,7 +33,7 @@ export const activeVersionsForResource = (rows, ref) => {
           policy: row?.deployment_policy ?? null,
           trafficRole: rowResource?.traffic_role ?? null,
           releaseId: rowResource?.release_id ?? null,
-          deployedAt: row?.updated_at ?? row?.created_at ?? null
+          deployedAt: row?.last_modified ?? row?.updated_at ?? row?.created_at ?? null
         })
       }
 

--- a/src/composables/versioning/overview-resource-config.js
+++ b/src/composables/versioning/overview-resource-config.js
@@ -1,0 +1,22 @@
+import { edgeAppVersionService } from '@/services/v2/edge-app/edge-app-version-service'
+import { edgeFirewallVersionService } from '@/services/v2/edge-firewall/edge-firewall-version-service'
+import { applicationWorkloadResolver } from '@/services/v2/edge-app/edge-app-workload-resolver'
+import { firewallWorkloadResolver } from '@/services/v2/edge-firewall/edge-firewall-workload-resolver'
+
+// Registry of Overview-tab configuration per versionable resource type.
+// Only the resource types listed here render the Overview tab; adding a new one
+// (e.g. function, connector) is a one-line change here plus a resolver module.
+export const OVERVIEW_RESOURCE_CONFIG = {
+  application: {
+    versionService: edgeAppVersionService,
+    workloadResolver: applicationWorkloadResolver
+  },
+  firewall: {
+    versionService: edgeFirewallVersionService,
+    workloadResolver: firewallWorkloadResolver
+  }
+}
+
+export const getOverviewConfig = (resourceType) => OVERVIEW_RESOURCE_CONFIG[resourceType] ?? null
+
+export const hasOverviewSupport = (resourceType) => Boolean(getOverviewConfig(resourceType))

--- a/src/composables/versioning/use-active-versions.js
+++ b/src/composables/versioning/use-active-versions.js
@@ -15,6 +15,7 @@ const readRef = (resourceRef) => {
 
 export function useActiveVersions(resourceRef) {
   const activeVersions = ref(new Map())
+  const isLoading = ref(true)
 
   const fetchRows = async (resource, skipCache) => {
     const rows = []
@@ -45,14 +46,20 @@ export function useActiveVersions(resourceRef) {
     const resource = readRef(resourceRef)
     if (!resource) {
       activeVersions.value = new Map()
+      isLoading.value = false
       return
     }
 
-    const rows = await fetchRows(resource, skipCache)
-    activeVersions.value = activeVersionsForResource(rows, {
-      resource_type: resource.resourceType,
-      resource_id: resource.resourceId
-    })
+    isLoading.value = true
+    try {
+      const rows = await fetchRows(resource, skipCache)
+      activeVersions.value = activeVersionsForResource(rows, {
+        resource_type: resource.resourceType,
+        resource_id: resource.resourceId
+      })
+    } finally {
+      isLoading.value = false
+    }
   }
 
   const refresh = () => load({ skipCache: true })
@@ -68,5 +75,5 @@ export function useActiveVersions(resourceRef) {
     { immediate: true }
   )
 
-  return { activeVersions, isActive, refresh }
+  return { activeVersions, isActive, isLoading, refresh }
 }

--- a/src/composables/versioning/use-live-deployments.js
+++ b/src/composables/versioning/use-live-deployments.js
@@ -1,0 +1,55 @@
+import { computed, toValue } from 'vue'
+
+/**
+ * useLiveDeployments — flattens the `activeVersions` Map produced by
+ * useActiveVersions into one row per (version, deployment) pair, enriched via a
+ * per-resource workload resolver (see overview-resource-config).
+ *
+ * Row shape (consumed by the Live Deployments table in ResourceOverviewBlock):
+ *  { versionId, version, environment, workload, deployedAt, deployment }
+ *
+ * @param {object} params
+ * @param {import('vue').Ref | () => Map} params.activeVersions — Map<versionId, {deployments}>
+ * @param {import('vue').Ref | () => Array} params.versions — raw versions array (for label enrichment)
+ * @param {object} params.workloadResolver — { resolve(deployment, ctx) → {environment,workload,deployedAt} }
+ * @param {object} [params.resolverContext] — passed to workloadResolver.resolve (e.g. { resourceId })
+ */
+export function useLiveDeployments({
+  activeVersions,
+  versions,
+  workloadResolver,
+  resolverContext
+} = {}) {
+  const liveDeployments = computed(() => {
+    const map = toValue(activeVersions)
+    if (!(map instanceof Map) || map.size === 0) return []
+
+    const versionsList = toValue(versions) ?? []
+    const versionById = new Map(versionsList.map((version) => [String(version?.id), version]))
+    const ctx = toValue(resolverContext) ?? {}
+    // Resolver may arrive as a plain object OR a ref/computed — unwrap so
+    // `resolve(...)` is always the concrete function, never a wrapped ref.
+    const resolver = toValue(workloadResolver)
+
+    const rows = []
+    for (const [versionId, entry] of map.entries()) {
+      const deployments = Array.isArray(entry?.deployments) ? entry.deployments : []
+      const version = versionById.get(String(versionId)) ?? { id: versionId }
+
+      for (const deployment of deployments) {
+        const enriched = resolver?.resolve?.(deployment, ctx) ?? {}
+        rows.push({
+          versionId: String(versionId),
+          version,
+          deployment,
+          environment: enriched.environment ?? null,
+          workload: enriched.workload ?? null,
+          deployedAt: enriched.deployedAt ?? deployment?.deployedAt ?? null
+        })
+      }
+    }
+    return rows
+  })
+
+  return { liveDeployments }
+}

--- a/src/composables/versioning/use-live-deployments.js
+++ b/src/composables/versioning/use-live-deployments.js
@@ -1,12 +1,22 @@
 import { computed, toValue } from 'vue'
 
 /**
- * useLiveDeployments — flattens the `activeVersions` Map produced by
- * useActiveVersions into one row per (version, deployment) pair, enriched via a
- * per-resource workload resolver (see overview-resource-config).
+ * useLiveDeployments — aggregates the `activeVersions` Map produced by
+ * useActiveVersions into ONE row per version, listing every deployment the
+ * version is currently pinned to. Each deployment is enriched via the shared
+ * workload resolver (see overview-resource-config).
  *
  * Row shape (consumed by the Live Deployments table in ResourceOverviewBlock):
- *  { versionId, version, environment, workload, deployedAt, deployment }
+ *   {
+ *     versionId,
+ *     version,                                   // raw version object from listVersions
+ *     deployments: Array<{                       // one entry per active deployment
+ *       id, environment, workload, deployedAt
+ *     }>,
+ *     environments: string[],                    // unique env names, ordered by first occurrence
+ *     workloads: string[],                       // unique workload names, ordered
+ *     latestDeployedAt: string | null            // most recent deployedAt across deployments
+ *   }
  *
  * @param {object} params
  * @param {import('vue').Ref | () => Map} params.activeVersions — Map<versionId, {deployments}>
@@ -33,20 +43,37 @@ export function useLiveDeployments({
 
     const rows = []
     for (const [versionId, entry] of map.entries()) {
-      const deployments = Array.isArray(entry?.deployments) ? entry.deployments : []
-      const version = versionById.get(String(versionId)) ?? { id: versionId }
+      const rawDeployments = Array.isArray(entry?.deployments) ? entry.deployments : []
+      if (rawDeployments.length === 0) continue
 
-      for (const deployment of deployments) {
+      const version = versionById.get(String(versionId)) ?? { id: versionId }
+      const deployments = []
+      const environments = []
+      const workloads = []
+      let latestDeployedAt = null
+
+      for (const deployment of rawDeployments) {
         const enriched = resolver?.resolve?.(deployment, ctx) ?? {}
-        rows.push({
-          versionId: String(versionId),
-          version,
-          deployment,
-          environment: enriched.environment ?? null,
-          workload: enriched.workload ?? null,
-          deployedAt: enriched.deployedAt ?? deployment?.deployedAt ?? null
-        })
+        const environment = enriched.environment ?? null
+        const workload = enriched.workload ?? null
+        const deployedAt = enriched.deployedAt ?? deployment?.deployedAt ?? null
+
+        deployments.push({ id: deployment?.id ?? null, environment, workload, deployedAt })
+        if (environment && !environments.includes(environment)) environments.push(environment)
+        if (workload && !workloads.includes(workload)) workloads.push(workload)
+        if (deployedAt && (!latestDeployedAt || deployedAt > latestDeployedAt)) {
+          latestDeployedAt = deployedAt
+        }
       }
+
+      rows.push({
+        versionId: String(versionId),
+        version,
+        deployments,
+        environments,
+        workloads,
+        latestDeployedAt
+      })
     }
     return rows
   })

--- a/src/composables/versioning/use-live-deployments.js
+++ b/src/composables/versioning/use-live-deployments.js
@@ -51,18 +51,27 @@ export function useLiveDeployments({
       const environments = []
       const workloads = []
       let latestDeployedAt = null
+      let latestDeployedBy = null
 
       for (const deployment of rawDeployments) {
         const enriched = resolver?.resolve?.(deployment, ctx) ?? {}
         const environment = enriched.environment ?? null
         const workload = enriched.workload ?? null
         const deployedAt = enriched.deployedAt ?? deployment?.deployedAt ?? null
+        const deployedBy = enriched.deployedBy ?? null
 
-        deployments.push({ id: deployment?.id ?? null, environment, workload, deployedAt })
+        deployments.push({
+          id: deployment?.id ?? null,
+          environment,
+          workload,
+          deployedAt,
+          deployedBy
+        })
         if (environment && !environments.includes(environment)) environments.push(environment)
         if (workload && !workloads.includes(workload)) workloads.push(workload)
         if (deployedAt && (!latestDeployedAt || deployedAt > latestDeployedAt)) {
           latestDeployedAt = deployedAt
+          latestDeployedBy = deployedBy
         }
       }
 
@@ -72,7 +81,8 @@ export function useLiveDeployments({
         deployments,
         environments,
         workloads,
-        latestDeployedAt
+        latestDeployedAt,
+        latestDeployedBy
       })
     }
     return rows

--- a/src/composables/versioning/use-resource-version-landing.js
+++ b/src/composables/versioning/use-resource-version-landing.js
@@ -4,8 +4,26 @@ import { useToast } from '@aziontech/webkit/use-toast'
 import { VERSION_ACTIONS } from '@/composables/versioning/version-machine'
 import { toDeployableVersionOptions } from '@/composables/versioning/to-version-options'
 import { getVersionCapability } from '@/composables/versioning/version-capability'
+import { useActiveVersions } from '@/composables/versioning/use-active-versions'
 import { releaseComposerRouteFromResource } from '@/templates/release-composition/release-composer-route'
 
+// Landing tab route keys — the numeric index is derived from `showOverview` so
+// callers that opt out of Overview keep VERSIONS at index 0 without regressions.
+export const LANDING_TAB_KEYS = ['overview', 'versions', 'settings', 'variables']
+
+const tabIndexer = (showOverview) => {
+  const keys = showOverview
+    ? LANDING_TAB_KEYS
+    : LANDING_TAB_KEYS.filter((key) => key !== 'overview')
+  return {
+    keys,
+    indexOf: (key) => keys.indexOf(key),
+    keyAt: (index) => keys[index] ?? keys[0]
+  }
+}
+
+// Back-compat: existing callers that read LANDING_TAB.VERSIONS/SETTINGS/VARIABLES
+// keep working — these are the indexes for the classic (no Overview) layout.
 export const LANDING_TAB = { VERSIONS: 0, SETTINGS: 1, VARIABLES: 2 }
 
 const SUCCESS_SUMMARY = {
@@ -42,8 +60,10 @@ export function useResourceVersionLanding({
   versionService,
   resourceType,
   routeName,
-  versionRouteName
+  versionRouteName,
+  showOverview = false
 }) {
+  const tabs = tabIndexer(showOverview)
   const route = useRoute()
   const router = useRouter()
   const toast = useToast()
@@ -70,7 +90,10 @@ export function useResourceVersionLanding({
     ...(capability.canDeploy
       ? { openPromoteDrawer: (payload) => openPromoteRelease(payload) }
       : {}),
-    onSuccess: () => versionsQuery.refetch?.()
+    onSuccess: () => {
+      versionsQuery.refetch?.()
+      refreshActiveVersions()
+    }
   })
 
   const loadResource = async () => {
@@ -91,6 +114,16 @@ export function useResourceVersionLanding({
   const versionsQuery = versionService.useListVersionsQuery(resourceId.value)
   const rawVersions = computed(() => versionsQuery.data.value?.body ?? [])
 
+  // Overview needs the active-versions map to render Live Deployments; kept at
+  // the landing level so both the Overview slot and the Versions slot can share
+  // the same fetch (and a single refresh after a mutation).
+  const activeVersionsResourceRef = computed(() => ({ resourceType, resourceId: resourceId.value }))
+  const {
+    activeVersions,
+    isLoading: activeVersionsLoading,
+    refresh: refreshActiveVersions
+  } = useActiveVersions(activeVersionsResourceRef)
+
   const latestVersionId = computed(() => {
     const list = rawVersions.value
     if (!list.length) return null
@@ -102,14 +135,18 @@ export function useResourceVersionLanding({
 
   const activeTab = computed({
     get: () => {
-      if (String(route.params.tab) === 'variables') return LANDING_TAB.VARIABLES
-      if (String(route.params.tab) === 'settings') return LANDING_TAB.SETTINGS
-      return LANDING_TAB.VERSIONS
+      const key = String(route.params.tab ?? '')
+      if (tabs.keys.includes(key)) return tabs.indexOf(key)
+      // Default: Overview when enabled, otherwise Versions.
+      return showOverview ? tabs.indexOf('overview') : tabs.indexOf('versions')
     },
     set: (index) => {
+      const key = tabs.keyAt(index)
       const params = { id: resourceId.value }
-      if (index === LANDING_TAB.VARIABLES) params.tab = 'variables'
-      else if (index === LANDING_TAB.SETTINGS) params.tab = 'settings'
+      // Keep URLs clean for the default tab (no `?tab=overview` in the URL when
+      // Overview is the landing default).
+      const defaultKey = showOverview ? 'overview' : 'versions'
+      if (key && key !== defaultKey) params.tab = key
       router.replace({ name: routeName, params })
     }
   })
@@ -172,7 +209,7 @@ export function useResourceVersionLanding({
   })
 
   const goToVersionsList = () => {
-    activeTab.value = LANDING_TAB.VERSIONS
+    activeTab.value = tabs.indexOf('versions')
   }
   const handleCancel = () => goToVersionsList()
 
@@ -230,6 +267,12 @@ export function useResourceVersionLanding({
     deployResourceContext,
     handleCommandSuccess,
     handleCommandError,
-    handleCancel
+    handleCancel,
+    // Overview support
+    versionsQuery,
+    rawVersions,
+    activeVersions,
+    activeVersionsLoading,
+    refreshActiveVersions
   }
 }

--- a/src/composables/versioning/use-workload-directory.js
+++ b/src/composables/versioning/use-workload-directory.js
@@ -1,0 +1,95 @@
+import { ref, watch } from 'vue'
+import { workloadService } from '@/services/v2/workload/workload-service'
+
+// Tenant-scoped directory that maps each `deployment_id` to its owning
+// workload's display name. The Overview tab uses it to fill the Workload
+// column of Live Deployments — the resource_usage endpoint (source of the
+// Live table) only exposes the deployment_id/name, not the workload link.
+//
+// One paginated pull of GET /v4/workspace/workloads is enough: each workload
+// carries a `bindings: [{ environment_id, deployment_id }]` array, so the
+// deployment→workload mapping is built entirely on the client. Cost = O(pages),
+// not O(active deployments).
+
+const PAGE_SIZE = 100
+const MAX_PAGES = 20
+
+const readWorkloadName = (workload) => {
+  const name = workload?.name
+  if (!name) return null
+  if (typeof name === 'string') return name
+  return name.text ?? null
+}
+
+const collectBindings = (workload) => {
+  const bindings = Array.isArray(workload?.bindings) ? workload.bindings : []
+  return bindings
+    .map((binding) => binding?.deployment_id)
+    .filter((deploymentId) => deploymentId != null)
+}
+
+export function useWorkloadDirectory({ enabled } = {}) {
+  const deploymentToWorkload = ref(new Map())
+  const isLoading = ref(true)
+
+  const fetchAll = async () => {
+    const directory = new Map()
+    let page = 1
+    let total = Infinity
+
+    while (page <= MAX_PAGES && directory.size < total) {
+      const result = await workloadService.listWorkloads({ page, pageSize: PAGE_SIZE })
+      const rows = Array.isArray(result?.body) ? result.body : []
+      total = Number.isFinite(result?.count) ? result.count : rows.length
+
+      for (const workload of rows) {
+        const name = readWorkloadName(workload)
+        if (!name) continue
+        for (const deploymentId of collectBindings(workload)) {
+          directory.set(String(deploymentId), name)
+        }
+      }
+
+      if (rows.length === 0) break
+      page += 1
+    }
+
+    return directory
+  }
+
+  const load = async () => {
+    isLoading.value = true
+    try {
+      deploymentToWorkload.value = await fetchAll()
+    } catch {
+      // Silently fall back to an empty directory — the Workload column will
+      // render "—" instead of blocking the Overview.
+      deploymentToWorkload.value = new Map()
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Skip the fetch entirely when the caller (e.g., resources that don't opt into
+  // the Overview registry) marks it as disabled. Defaults to always enabled.
+  watch(
+    () => (typeof enabled === 'function' ? enabled() : (enabled ?? true)),
+    (isEnabled, _prev, onCleanup) => {
+      if (!isEnabled) {
+        deploymentToWorkload.value = new Map()
+        isLoading.value = false
+        return
+      }
+      let cancelled = false
+      load().then(() => {
+        if (cancelled) return
+      })
+      onCleanup(() => {
+        cancelled = true
+      })
+    },
+    { immediate: true }
+  )
+
+  return { deploymentToWorkload, isLoading, refresh: load }
+}

--- a/src/composables/versioning/use-workload-directory.js
+++ b/src/composables/versioning/use-workload-directory.js
@@ -1,15 +1,22 @@
 import { ref, watch } from 'vue'
 import { workloadService } from '@/services/v2/workload/workload-service'
+import { environmentService } from '@/services/v2/environment/environment-service'
+import { deploymentService } from '@/services/v2/deployment/deployment-service'
 
-// Tenant-scoped directory that maps each `deployment_id` to its owning
-// workload's display name. The Overview tab uses it to fill the Workload
-// column of Live Deployments — the resource_usage endpoint (source of the
-// Live table) only exposes the deployment_id/name, not the workload link.
+// Tenant-scoped directories consumed by the Overview tab's Live Deployments
+// table. Every map is keyed by `deployment_id` so the workload-resolver
+// (called per deployment) can enrich each row in O(1):
+//   - deploymentToWorkload:    deployment_id → workload.name
+//   - deploymentToEnvironment: deployment_id → environment.name
+//   - deploymentToMeta:        deployment_id → { updatedAt, lastModifiedBy }
 //
-// One paginated pull of GET /v4/workspace/workloads is enough: each workload
-// carries a `bindings: [{ environment_id, deployment_id }]` array, so the
-// deployment→workload mapping is built entirely on the client. Cost = O(pages),
-// not O(active deployments).
+// The resource_usage endpoint (source of the live deployments) only exposes
+// `deployment_id` and the deployment's own name. Environment names live in
+// `/v4/workspace/environments`, and the deployed-at timestamp + author live on
+// each Deployment row (`/v4/deployments`). The workload→deployment bridge is
+// the `bindings[]` array carried by every workload. One paginated pull each
+// (workloads + environments + deployments) is enough for the whole tenant —
+// cost = O(pages), not O(active deployments).
 
 const PAGE_SIZE = 100
 const MAX_PAGES = 20
@@ -21,50 +28,145 @@ const readWorkloadName = (workload) => {
   return name.text ?? null
 }
 
-const collectBindings = (workload) => {
-  const bindings = Array.isArray(workload?.bindings) ? workload.bindings : []
-  return bindings
-    .map((binding) => binding?.deployment_id)
-    .filter((deploymentId) => deploymentId != null)
+// Paginate a listing that returns `{ body, count }`. Tolerates the DRF quirk of
+// answering 404 for a page beyond the last one — treats it as end-of-list on
+// pages > 1, but propagates a genuine failure on page 1.
+const paginate = async (fetchPage) => {
+  const rows = []
+  let page = 1
+  let total = Infinity
+  while (page <= MAX_PAGES && rows.length < total) {
+    let result
+    try {
+      result = await fetchPage(page)
+    } catch (err) {
+      if (page === 1) throw err
+      break
+    }
+    const batch = Array.isArray(result?.body) ? result.body : []
+    total = Number.isFinite(result?.count) ? result.count : batch.length
+    rows.push(...batch)
+    if (batch.length === 0) break
+    page += 1
+  }
+  return rows
 }
 
 export function useWorkloadDirectory({ enabled } = {}) {
   const deploymentToWorkload = ref(new Map())
+  const deploymentToEnvironment = ref(new Map())
+  const deploymentToMeta = ref(new Map())
   const isLoading = ref(true)
 
-  const fetchAll = async () => {
-    const directory = new Map()
-    let page = 1
-    let total = Infinity
+  const fetchWorkloads = () =>
+    paginate((page) =>
+      workloadService.listWorkloads({
+        page,
+        pageSize: PAGE_SIZE,
+        // Backend follows DRF snake_case; ship both to be tolerant of either
+        // wire format (axios serializes the params object verbatim).
+        page_size: PAGE_SIZE,
+        ordering: '-last_modified'
+      })
+    )
 
-    while (page <= MAX_PAGES && directory.size < total) {
-      const result = await workloadService.listWorkloads({ page, pageSize: PAGE_SIZE })
-      const rows = Array.isArray(result?.body) ? result.body : []
-      total = Number.isFinite(result?.count) ? result.count : rows.length
+  const fetchEnvironments = async () => {
+    try {
+      const result = await environmentService.listEnvironmentsService()
+      return Array.isArray(result?.body) ? result.body : []
+    } catch {
+      // Environments API failure must not block the other directories.
+      return []
+    }
+  }
 
-      for (const workload of rows) {
-        const name = readWorkloadName(workload)
-        if (!name) continue
-        for (const deploymentId of collectBindings(workload)) {
-          directory.set(String(deploymentId), name)
-        }
-      }
+  const fetchDeployments = async () => {
+    try {
+      return await paginate((page) =>
+        deploymentService.listDeploymentsService({ page, pageSize: PAGE_SIZE })
+      )
+    } catch {
+      // Deployments API failure only blanks the Deployed column; workload +
+      // environment still resolve.
+      return []
+    }
+  }
 
-      if (rows.length === 0) break
-      page += 1
+  const buildDirectories = (workloads, environments, deployments) => {
+    const workloadDir = new Map()
+    const environmentDir = new Map()
+    const metaDir = new Map()
+
+    const envIdToName = new Map()
+    for (const env of environments) {
+      if (env?.id == null) continue
+      const name = typeof env?.name === 'string' ? env.name : (env?.name?.text ?? null)
+      if (!name) continue
+      envIdToName.set(String(env.id), name)
     }
 
-    return directory
+    for (const deployment of deployments) {
+      if (deployment?.id == null) continue
+      metaDir.set(String(deployment.id), {
+        updatedAt: deployment.updated_at ?? deployment.created_at ?? null,
+        lastModifiedBy: deployment.last_modified_by ?? deployment.created_by ?? null
+      })
+    }
+
+    for (const workload of workloads) {
+      const workloadName = readWorkloadName(workload)
+      // v6 workloads may expose the mapping as `bindings: [{deployment_id, environment_id}]`
+      // OR flat as top-level `deployment_id` + `environment_id`. Handle both.
+      const bindings = Array.isArray(workload?.bindings) ? workload.bindings : []
+      const flatBinding =
+        workload?.deployment_id != null || workload?.environment_id != null
+          ? [
+              {
+                deployment_id: workload.deployment_id,
+                environment_id: workload.environment_id
+              }
+            ]
+          : []
+      const allBindings = bindings.length > 0 ? bindings : flatBinding
+
+      for (const binding of allBindings) {
+        const deploymentId = binding?.deployment_id
+        if (deploymentId == null) continue
+        const key = String(deploymentId)
+        if (workloadName) workloadDir.set(key, workloadName)
+        const envId = binding?.environment_id
+        if (envId != null) {
+          const envName = envIdToName.get(String(envId))
+          if (envName) environmentDir.set(key, envName)
+        }
+      }
+    }
+
+    return { workloadDir, environmentDir, metaDir }
   }
 
   const load = async () => {
     isLoading.value = true
     try {
-      deploymentToWorkload.value = await fetchAll()
+      const [workloads, environments, deployments] = await Promise.all([
+        fetchWorkloads(),
+        fetchEnvironments(),
+        fetchDeployments()
+      ])
+      const { workloadDir, environmentDir, metaDir } = buildDirectories(
+        workloads,
+        environments,
+        deployments
+      )
+      deploymentToWorkload.value = workloadDir
+      deploymentToEnvironment.value = environmentDir
+      deploymentToMeta.value = metaDir
     } catch {
-      // Silently fall back to an empty directory — the Workload column will
-      // render "—" instead of blocking the Overview.
+      // Silently fall back to empty directories — the affected columns render
+      // "—" instead of blocking the Overview.
       deploymentToWorkload.value = new Map()
+      deploymentToEnvironment.value = new Map()
+      deploymentToMeta.value = new Map()
     } finally {
       isLoading.value = false
     }
@@ -77,6 +179,8 @@ export function useWorkloadDirectory({ enabled } = {}) {
     (isEnabled, _prev, onCleanup) => {
       if (!isEnabled) {
         deploymentToWorkload.value = new Map()
+        deploymentToEnvironment.value = new Map()
+        deploymentToMeta.value = new Map()
         isLoading.value = false
         return
       }
@@ -91,5 +195,11 @@ export function useWorkloadDirectory({ enabled } = {}) {
     { immediate: true }
   )
 
-  return { deploymentToWorkload, isLoading, refresh: load }
+  return {
+    deploymentToWorkload,
+    deploymentToEnvironment,
+    deploymentToMeta,
+    isLoading,
+    refresh: load
+  }
 }

--- a/src/composables/versioning/version-list-columns.js
+++ b/src/composables/versioning/version-list-columns.js
@@ -39,7 +39,7 @@ export const getLiveDeploymentColumns = () => [
     key: 'deployed',
     field: 'deployed',
     label: 'Deployed',
-    size: 'minmax(180px, 1fr)',
+    size: 'minmax(220px, 1.2fr)',
     mobileLabel: 'Deployed'
   }
 ]

--- a/src/composables/versioning/version-list-columns.js
+++ b/src/composables/versioning/version-list-columns.js
@@ -1,12 +1,45 @@
-export const getVersionListColumns = () => [
+export const getVersionListColumns = ({ includeTraffic = true } = {}) => {
+  const columns = [
+    { key: 'version', label: 'Version', size: 'minmax(220px, 1.4fr)' },
+    { key: 'status', label: 'Status', size: 'minmax(140px, 0.8fr)' }
+  ]
+
+  if (includeTraffic) {
+    columns.push({
+      key: 'traffic',
+      field: 'activeTraffic',
+      label: 'Traffic',
+      size: 'minmax(160px, 0.9fr)',
+      mobileLabel: 'Traffic'
+    })
+  }
+
+  columns.push({ key: 'created', label: 'Created by', size: 'minmax(180px, 1.2fr)' })
+
+  return columns
+}
+
+export const getLiveDeploymentColumns = () => [
   { key: 'version', label: 'Version', size: 'minmax(220px, 1.4fr)' },
-  { key: 'status', label: 'Status', size: 'minmax(140px, 0.8fr)' },
   {
-    key: 'traffic',
-    field: 'activeTraffic',
-    label: 'Traffic',
-    size: 'minmax(160px, 0.9fr)',
-    mobileLabel: 'Traffic'
+    key: 'environment',
+    field: 'environment',
+    label: 'Environment',
+    size: 'minmax(160px, 1fr)',
+    mobileLabel: 'Environment'
   },
-  { key: 'created', label: 'Created by', size: 'minmax(180px, 1.2fr)' }
+  {
+    key: 'workload',
+    field: 'workload',
+    label: 'Workload',
+    size: 'minmax(200px, 1.2fr)',
+    mobileLabel: 'Workload'
+  },
+  {
+    key: 'deployed',
+    field: 'deployed',
+    label: 'Deployed',
+    size: 'minmax(180px, 1fr)',
+    mobileLabel: 'Deployed'
+  }
 ]

--- a/src/services/v2/edge-app/edge-app-workload-resolver.js
+++ b/src/services/v2/edge-app/edge-app-workload-resolver.js
@@ -1,0 +1,3 @@
+import { createNameBasedWorkloadResolver } from '@/services/v2/versioning/workload-resolver'
+
+export const applicationWorkloadResolver = createNameBasedWorkloadResolver()

--- a/src/services/v2/edge-firewall/edge-firewall-workload-resolver.js
+++ b/src/services/v2/edge-firewall/edge-firewall-workload-resolver.js
@@ -1,0 +1,3 @@
+import { createNameBasedWorkloadResolver } from '@/services/v2/versioning/workload-resolver'
+
+export const firewallWorkloadResolver = createNameBasedWorkloadResolver()

--- a/src/services/v2/versioning/workload-resolver.js
+++ b/src/services/v2/versioning/workload-resolver.js
@@ -3,24 +3,29 @@
 // deployment (from activeVersionsForResource) with the Environment /
 // Workload / Deployed columns of the Live Deployments table.
 //
-// Default (name-based) resolver: the deployment name IS the environment
-// label surfaced in the Figma. When the caller provides a
-// `ctx.deploymentToWorkload` Map (built once per session by
-// use-workload-directory), the resolver enriches `workload` too; otherwise
-// it leaves it as null and the table renders "—".
+// Names and timestamps come from the tenant-wide directories built by
+// use-workload-directory (workloadsDir/envDir/metaDir), all keyed by
+// deployment_id. The raw deployment payload from resource_usage only carries
+// `id` and `name` — the deployment's own name is intentionally NOT used for
+// the Environment column (it is the deployment's name, not the environment's).
 
 export const createNameBasedWorkloadResolver = () => ({
   resolve(deployment, ctx = {}) {
-    const directory = ctx?.deploymentToWorkload
-    const workload =
-      directory instanceof Map && deployment?.id != null
-        ? (directory.get(String(deployment.id)) ?? null)
-        : null
+    const workloadDir = ctx?.deploymentToWorkload
+    const environmentDir = ctx?.deploymentToEnvironment
+    const metaDir = ctx?.deploymentToMeta
+    const key = deployment?.id != null ? String(deployment.id) : null
+
+    const workload = key && workloadDir instanceof Map ? (workloadDir.get(key) ?? null) : null
+    const environment =
+      key && environmentDir instanceof Map ? (environmentDir.get(key) ?? null) : null
+    const meta = key && metaDir instanceof Map ? metaDir.get(key) : null
 
     return {
-      environment: deployment?.name ?? null,
+      environment,
       workload,
-      deployedAt: deployment?.deployedAt ?? null
+      deployedAt: meta?.updatedAt ?? deployment?.deployedAt ?? null,
+      deployedBy: meta?.lastModifiedBy ?? null
     }
   }
 })

--- a/src/services/v2/versioning/workload-resolver.js
+++ b/src/services/v2/versioning/workload-resolver.js
@@ -4,16 +4,22 @@
 // Workload / Deployed columns of the Live Deployments table.
 //
 // Default (name-based) resolver: the deployment name IS the environment
-// label surfaced in the Figma; the bound workload is not carried in
-// resource_usage rows yet, so `workload` is left null and the table
-// renders "—". Application and Firewall share this behavior today; a
-// future resource type may look up the workload via ctx.resourceId.
+// label surfaced in the Figma. When the caller provides a
+// `ctx.deploymentToWorkload` Map (built once per session by
+// use-workload-directory), the resolver enriches `workload` too; otherwise
+// it leaves it as null and the table renders "—".
 
 export const createNameBasedWorkloadResolver = () => ({
-  resolve(deployment /* , ctx = { resourceId } */) {
+  resolve(deployment, ctx = {}) {
+    const directory = ctx?.deploymentToWorkload
+    const workload =
+      directory instanceof Map && deployment?.id != null
+        ? (directory.get(String(deployment.id)) ?? null)
+        : null
+
     return {
       environment: deployment?.name ?? null,
-      workload: null,
+      workload,
       deployedAt: deployment?.deployedAt ?? null
     }
   }

--- a/src/services/v2/versioning/workload-resolver.js
+++ b/src/services/v2/versioning/workload-resolver.js
@@ -1,0 +1,20 @@
+// Shared factory for per-resource workload resolvers consumed by
+// useLiveDeployments in the Overview tab. A resolver enriches a raw
+// deployment (from activeVersionsForResource) with the Environment /
+// Workload / Deployed columns of the Live Deployments table.
+//
+// Default (name-based) resolver: the deployment name IS the environment
+// label surfaced in the Figma; the bound workload is not carried in
+// resource_usage rows yet, so `workload` is left null and the table
+// renders "—". Application and Firewall share this behavior today; a
+// future resource type may look up the workload via ctx.resourceId.
+
+export const createNameBasedWorkloadResolver = () => ({
+  resolve(deployment /* , ctx = { resourceId } */) {
+    return {
+      environment: deployment?.name ?? null,
+      workload: null,
+      deployedAt: deployment?.deployedAt ?? null
+    }
+  }
+})

--- a/src/templates/version-shell-block/ResourceOverviewBlock.vue
+++ b/src/templates/version-shell-block/ResourceOverviewBlock.vue
@@ -1,0 +1,228 @@
+<script setup>
+  /**
+   * ResourceOverviewBlock — shared Overview tab body for versionable resources.
+   * Renders (top-down): Metrics placeholder (out-of-scope this delivery), Live
+   * Deployments table (versions currently receiving traffic) and Version History
+   * (remaining versions with search/filter/paginate).
+   *
+   * Plug-and-play: reads getOverviewConfig(resourceType) for the workload
+   * resolver; every version-list plumbing (activeVersions, useVersionList, row
+   * menu actions) is reused from the shared versioning composables.
+   *
+   * Both tables render through the same VersionListDataView so the visual shell
+   * (header, borders, row rhythm) matches — Live Deployments hides the toolbar
+   * and row menu since it's a small, non-searchable list.
+   */
+  import { computed, inject, toRef } from 'vue'
+  import { useRouter } from 'vue-router'
+  import PrimeTag from '@aziontech/webkit/prime-tag'
+
+  import VersionListDataView from '@/components/VersionListDataView'
+  import VersionActionDialog from '@/templates/version-shell-block/components/VersionActionDialog.vue'
+  import { useVersionList } from '@/composables/versioning/use-version-list'
+  import { useLiveDeployments } from '@/composables/versioning/use-live-deployments'
+  import { useVersionMenuActions } from '@/composables/versioning/use-version-menu-actions'
+  import {
+    getVersionListColumns,
+    getLiveDeploymentColumns
+  } from '@/composables/versioning/version-list-columns'
+  import { getOverviewConfig } from '@/composables/versioning/overview-resource-config'
+  import { formatDateToDayMonthYearHour } from '@/helpers/convert-date'
+
+  defineOptions({ name: 'resource-overview-block' })
+
+  const props = defineProps({
+    resourceType: { type: String, required: true },
+    resourceId: { type: [String, Number], required: true },
+    rawVersions: { type: Array, default: () => [] },
+    activeVersions: { type: Map, default: () => new Map() },
+    activeVersionsLoading: { type: Boolean, default: false },
+    versionsQuery: { type: Object, default: null },
+    testidPrefix: { type: String, default: 'resource-overview' }
+  })
+
+  const router = useRouter()
+  const menuHost = inject('versionMenuHost', {})
+
+  const config = computed(() => getOverviewConfig(props.resourceType))
+
+  // Row-menu driver shared with the Versions tab: OPEN_CONFIGURATION on row-click
+  // navigates to the version editor; kebab actions (Archive, Delete, Promote…)
+  // open the confirmation dialog rendered below.
+  const {
+    handleRowAction,
+    dialogConfig,
+    dialogProps,
+    dialogVisible,
+    handleConfirm,
+    handleVisibility
+  } = useVersionMenuActions({
+    resourceType: toRef(props, 'resourceType'),
+    resourceId: toRef(props, 'resourceId'),
+    versionService: menuHost.versionService,
+    router,
+    openPromoteDrawer: menuHost.openPromoteDrawer,
+    onSuccess: menuHost.onSuccess
+  })
+
+  // Live Deployments rows carry a composite `id` (versionId::deploymentId) so
+  // DataView's dataKey stays unique when a version fans out to N deployments.
+  // Before handing the payload to the shared driver, restore the true version id.
+  const handleLiveRowAction = ({ action, item }) => {
+    handleRowAction({ action, item: { ...item, id: item?.versionId ?? item?.id } })
+  }
+
+  const { liveDeployments } = useLiveDeployments({
+    activeVersions: () => props.activeVersions,
+    versions: () => props.rawVersions,
+    workloadResolver: computed(() => config.value?.workloadResolver),
+    resolverContext: computed(() => ({ resourceId: props.resourceId }))
+  })
+
+  const liveColumns = getLiveDeploymentColumns()
+
+  // Reshape each row so VersionListDataView's default cell renderer picks up the
+  // per-column fields (`environment`, `workload`, `deployed`) via the `column.field`
+  // fallback in resolveDisplayValue. `id` is required — DataView uses it as
+  // dataKey — and combines version id with deployment id when a single version
+  // fans out to multiple deployments.
+  const liveItems = computed(() =>
+    liveDeployments.value.map((row) => ({
+      ...row.version,
+      id: row.deployment?.id ? `${row.versionId}::${row.deployment.id}` : row.versionId,
+      versionId: row.versionId,
+      environment: row.environment ?? '—',
+      workload: row.workload ?? '—',
+      deployedAt: row.deployedAt,
+      deployed: row.deployedAt ? formatDateToDayMonthYearHour(row.deployedAt) : '—'
+    }))
+  )
+
+  // Version History = raw versions minus those with active traffic. useVersionList
+  // owns search/filter/sort/paginator state; feed it the filtered set.
+  const historyVersions = computed(() => {
+    const active = props.activeVersions
+    return props.rawVersions.filter((version) => !active.has(String(version?.id)))
+  })
+
+  const { items, searchTerm, filterValues, sort, filters, sortOptions } = useVersionList(
+    historyVersions,
+    { activeVersions: computed(() => new Map()) }
+  )
+
+  const historyColumns = getVersionListColumns({ includeTraffic: false })
+
+  // Both tables show the skeleton until BOTH the version list AND the active-
+  // versions query have settled — otherwise, whichever finishes first would
+  // flash an empty state before its counterpart's rows arrive.
+  const isLoading = computed(
+    () => Boolean(props.versionsQuery?.isLoading?.value) || props.activeVersionsLoading
+  )
+  const isError = computed(() => Boolean(props.versionsQuery?.isError?.value))
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-[var(--spacing-6)]"
+    :data-testid="testidPrefix"
+  >
+    <!--
+      Metrics section (Requests / Errors / CPU Time per Figma node 1300-39067)
+      is out of scope this delivery and will be inserted above Live Deployments
+      in a follow-up.
+    -->
+
+    <!-- Live Deployments -->
+    <section
+      class="flex flex-col gap-[var(--spacing-3)]"
+      :data-testid="`${testidPrefix}__live`"
+    >
+      <header class="flex items-baseline gap-[var(--spacing-2)]">
+        <h3 class="m-[0] text-body-md font-semibold text-[var(--text-color)]">Live Deployments</h3>
+        <span class="text-body-sm text-[var(--text-color-secondary)]">
+          Versions currently receiving traffic.
+        </span>
+      </header>
+
+      <VersionListDataView
+        :items="liveItems"
+        :columns="liveColumns"
+        :loading="isLoading"
+        :is-error="isError"
+        :has-versions="liveDeployments.length > 0"
+        :show-row-actions="false"
+        :show-toolbar="false"
+        :resource-type="resourceType"
+        :paginator-rows="liveItems.length || 1"
+        :empty-state="{
+          title: 'No versions currently receiving traffic',
+          description:
+            'When a version is promoted to a workload, it will appear here as a live deployment.'
+        }"
+        :data-testid="`${testidPrefix}__live__table`"
+        @row-action="handleLiveRowAction"
+      >
+        <template #cell-version="{ item }">
+          <span class="inline-flex items-center gap-[var(--spacing-2)]">
+            <span class="version-hash text-body-md">{{ item.versionId }}</span>
+            <PrimeTag
+              severity="success"
+              icon="pi pi-globe"
+              value="Live"
+            />
+          </span>
+        </template>
+      </VersionListDataView>
+    </section>
+
+    <!-- Version History -->
+    <section
+      class="flex flex-col gap-[var(--spacing-3)]"
+      :data-testid="`${testidPrefix}__history`"
+    >
+      <header class="flex items-baseline gap-[var(--spacing-2)]">
+        <h3 class="m-[0] text-body-md font-semibold text-[var(--text-color)]">Version History</h3>
+        <span class="text-body-sm text-[var(--text-color-secondary)]">
+          Every other version of this resource.
+        </span>
+      </header>
+
+      <VersionListDataView
+        :items="items"
+        :columns="historyColumns"
+        :loading="isLoading"
+        :is-error="isError"
+        :has-versions="historyVersions.length > 0"
+        :search-term="searchTerm"
+        :filters="filters"
+        :filter-values="filterValues"
+        :sort="sort"
+        :sort-options="sortOptions"
+        :show-row-actions="true"
+        :resource-type="resourceType"
+        :paginator-rows="20"
+        search-placeholder="Search versions"
+        :empty-state="{
+          title: 'No versions in history yet',
+          description: 'Versions that are not currently receiving traffic will show up here.'
+        }"
+        filtered-empty-title="No versions match your filters"
+        filtered-empty-description="Try a different search term or status filter."
+        :data-testid="`${testidPrefix}__history__table`"
+        @update:search-term="searchTerm = $event"
+        @update:filter-values="filterValues = $event"
+        @update:sort="sort = $event"
+        @refresh="versionsQuery?.refetch?.()"
+        @row-action="handleRowAction"
+      />
+    </section>
+
+    <VersionActionDialog
+      v-if="dialogConfig"
+      v-bind="dialogProps"
+      :visible="dialogVisible"
+      @confirm="handleConfirm"
+      @update:visible="handleVisibility"
+    />
+  </div>
+</template>

--- a/src/templates/version-shell-block/ResourceOverviewBlock.vue
+++ b/src/templates/version-shell-block/ResourceOverviewBlock.vue
@@ -196,7 +196,7 @@
             <PrimeTag
               v-for="name in item.environments"
               :key="name"
-              severity="secondary"
+              severity="info"
               :value="name"
             />
           </span>
@@ -215,7 +215,7 @@
             <PrimeTag
               v-for="name in item.workloads"
               :key="name"
-              severity="secondary"
+              severity="info"
               :value="name"
             />
           </span>

--- a/src/templates/version-shell-block/ResourceOverviewBlock.vue
+++ b/src/templates/version-shell-block/ResourceOverviewBlock.vue
@@ -21,6 +21,7 @@
   import VersionActionDialog from '@/templates/version-shell-block/components/VersionActionDialog.vue'
   import { useVersionList } from '@/composables/versioning/use-version-list'
   import { useLiveDeployments } from '@/composables/versioning/use-live-deployments'
+  import { useWorkloadDirectory } from '@/composables/versioning/use-workload-directory'
   import { useVersionMenuActions } from '@/composables/versioning/use-version-menu-actions'
   import {
     getVersionListColumns,
@@ -72,29 +73,35 @@
     handleRowAction({ action, item: { ...item, id: item?.versionId ?? item?.id } })
   }
 
+  // Tenant-wide deployment_id → workload_name directory, fetched once and
+  // shared across every Live Deployments row. Falls back to an empty Map on
+  // error — the resolver renders "—" in that case.
+  const { deploymentToWorkload, isLoading: workloadDirectoryLoading } = useWorkloadDirectory()
+
   const { liveDeployments } = useLiveDeployments({
     activeVersions: () => props.activeVersions,
     versions: () => props.rawVersions,
     workloadResolver: computed(() => config.value?.workloadResolver),
-    resolverContext: computed(() => ({ resourceId: props.resourceId }))
+    resolverContext: computed(() => ({
+      resourceId: props.resourceId,
+      deploymentToWorkload: deploymentToWorkload.value
+    }))
   })
 
   const liveColumns = getLiveDeploymentColumns()
 
-  // Reshape each row so VersionListDataView's default cell renderer picks up the
-  // per-column fields (`environment`, `workload`, `deployed`) via the `column.field`
-  // fallback in resolveDisplayValue. `id` is required — DataView uses it as
-  // dataKey — and combines version id with deployment id when a single version
-  // fans out to multiple deployments.
+  // One row per version — Environment and Workload columns render every
+  // deployment the version is currently pinned to (see #cell-environment /
+  // #cell-workload slots below). Deployed shows the most recent timestamp.
   const liveItems = computed(() =>
     liveDeployments.value.map((row) => ({
       ...row.version,
-      id: row.deployment?.id ? `${row.versionId}::${row.deployment.id}` : row.versionId,
+      id: row.versionId,
       versionId: row.versionId,
-      environment: row.environment ?? '—',
-      workload: row.workload ?? '—',
-      deployedAt: row.deployedAt,
-      deployed: row.deployedAt ? formatDateToDayMonthYearHour(row.deployedAt) : '—'
+      environments: row.environments,
+      workloads: row.workloads,
+      deployedAt: row.latestDeployedAt,
+      deployed: row.latestDeployedAt ? formatDateToDayMonthYearHour(row.latestDeployedAt) : '—'
     }))
   )
 
@@ -116,7 +123,10 @@
   // versions query have settled — otherwise, whichever finishes first would
   // flash an empty state before its counterpart's rows arrive.
   const isLoading = computed(
-    () => Boolean(props.versionsQuery?.isLoading?.value) || props.activeVersionsLoading
+    () =>
+      Boolean(props.versionsQuery?.isLoading?.value) ||
+      props.activeVersionsLoading ||
+      workloadDirectoryLoading.value
   )
   const isError = computed(() => Boolean(props.versionsQuery?.isError?.value))
 </script>
@@ -153,7 +163,7 @@
         :show-row-actions="false"
         :show-toolbar="false"
         :resource-type="resourceType"
-        :paginator-rows="liveItems.length || 1"
+        :show-paginator="false"
         :empty-state="{
           title: 'No versions currently receiving traffic',
           description:
@@ -162,15 +172,58 @@
         :data-testid="`${testidPrefix}__live__table`"
         @row-action="handleLiveRowAction"
       >
-        <template #cell-version="{ item }">
-          <span class="inline-flex items-center gap-[var(--spacing-2)]">
-            <span class="version-hash text-body-md">{{ item.versionId }}</span>
+        <template #cell-version="{ item, onPrimaryClick }">
+          <button
+            type="button"
+            class="version-cell-button flex max-w-full min-w-0 items-center gap-[var(--spacing-2)] border-0 bg-transparent text-left text-[var(--text-color)]"
+            :data-testid="`${testidPrefix}__live__row-${item.versionId}__primary`"
+            @click="onPrimaryClick"
+          >
+            <span class="version-hash text-body-sm">{{ item.versionId }}</span>
             <PrimeTag
               severity="success"
               icon="pi pi-globe"
               value="Live"
             />
+          </button>
+        </template>
+
+        <template #cell-environment="{ item }">
+          <span
+            v-if="item.environments?.length"
+            class="inline-flex flex-wrap items-center gap-[var(--spacing-1)]"
+          >
+            <PrimeTag
+              v-for="name in item.environments"
+              :key="name"
+              severity="secondary"
+              :value="name"
+            />
           </span>
+          <span
+            v-else
+            class="cell-default"
+            >—</span
+          >
+        </template>
+
+        <template #cell-workload="{ item }">
+          <span
+            v-if="item.workloads?.length"
+            class="inline-flex flex-wrap items-center gap-[var(--spacing-1)]"
+          >
+            <PrimeTag
+              v-for="name in item.workloads"
+              :key="name"
+              severity="secondary"
+              :value="name"
+            />
+          </span>
+          <span
+            v-else
+            class="cell-default"
+            >—</span
+          >
         </template>
       </VersionListDataView>
     </section>

--- a/src/templates/version-shell-block/ResourceOverviewBlock.vue
+++ b/src/templates/version-shell-block/ResourceOverviewBlock.vue
@@ -28,7 +28,6 @@
     getLiveDeploymentColumns
   } from '@/composables/versioning/version-list-columns'
   import { getOverviewConfig } from '@/composables/versioning/overview-resource-config'
-  import { formatDateToDayMonthYearHour } from '@/helpers/convert-date'
 
   defineOptions({ name: 'resource-overview-block' })
 
@@ -73,10 +72,16 @@
     handleRowAction({ action, item: { ...item, id: item?.versionId ?? item?.id } })
   }
 
-  // Tenant-wide deployment_id → workload_name directory, fetched once and
-  // shared across every Live Deployments row. Falls back to an empty Map on
-  // error — the resolver renders "—" in that case.
-  const { deploymentToWorkload, isLoading: workloadDirectoryLoading } = useWorkloadDirectory()
+  // Tenant-wide directories used by the workload resolver to fill the
+  // Environment and Workload columns of Live Deployments. Both are keyed by
+  // deployment_id; on error each falls back to an empty Map and the resolver
+  // renders "—" in the corresponding column.
+  const {
+    deploymentToWorkload,
+    deploymentToEnvironment,
+    deploymentToMeta,
+    isLoading: workloadDirectoryLoading
+  } = useWorkloadDirectory()
 
   const { liveDeployments } = useLiveDeployments({
     activeVersions: () => props.activeVersions,
@@ -84,7 +89,9 @@
     workloadResolver: computed(() => config.value?.workloadResolver),
     resolverContext: computed(() => ({
       resourceId: props.resourceId,
-      deploymentToWorkload: deploymentToWorkload.value
+      deploymentToWorkload: deploymentToWorkload.value,
+      deploymentToEnvironment: deploymentToEnvironment.value,
+      deploymentToMeta: deploymentToMeta.value
     }))
   })
 
@@ -92,7 +99,9 @@
 
   // One row per version — Environment and Workload columns render every
   // deployment the version is currently pinned to (see #cell-environment /
-  // #cell-workload slots below). Deployed shows the most recent timestamp.
+  // #cell-workload slots below). The Deployed column reads `deployedAt` +
+  // `lastEditor` (carried via `...row.version`) and is rendered by
+  // VersionListDataView with the same two-line pattern as "Created by".
   const liveItems = computed(() =>
     liveDeployments.value.map((row) => ({
       ...row.version,
@@ -101,7 +110,7 @@
       environments: row.environments,
       workloads: row.workloads,
       deployedAt: row.latestDeployedAt,
-      deployed: row.latestDeployedAt ? formatDateToDayMonthYearHour(row.latestDeployedAt) : '—'
+      deployedBy: row.latestDeployedBy
     }))
   )
 

--- a/src/templates/version-shell-block/ResourceVersionLanding.vue
+++ b/src/templates/version-shell-block/ResourceVersionLanding.vue
@@ -1,10 +1,15 @@
 <script setup>
-  // Shared chrome for the TABBED landing screen (Versions listing + Settings =
-  // Main Settings of the latest version), used by Custom Pages and Firewall. Owns
-  // the heading (with the version-lifecycle teleport target), the two-tab shell,
-  // the "no version yet" empty state and the deploy drawer. The per-resource tab
-  // bodies arrive through the `versions` and `settings` slots; logic lives in
-  // useResourceVersionLanding.
+  // Shared chrome for the TABBED landing screen (Overview + Versions listing +
+  // Settings = Main Settings of the latest version + Variables), used by
+  // Custom Pages, Firewall and Application. Owns the heading (with the
+  // version-lifecycle teleport target), the tab shell, the "no version yet"
+  // empty state and the deploy drawer. The per-resource tab bodies arrive
+  // through the `overview`, `versions`, `settings` and `variables` slots;
+  // logic lives in useResourceVersionLanding.
+  //
+  // `showOverview` is opt-in — only resource types wired via the Overview
+  // registry (overview-resource-config) should enable it.
+  import { computed } from 'vue'
   import ProgressSpinner from '@aziontech/webkit/progressspinner'
   import InlineMessage from '@aziontech/webkit/inlinemessage'
   import PrimeButton from '@aziontech/webkit/button'
@@ -16,9 +21,7 @@
 
   defineOptions({ name: 'resource-version-landing' })
 
-  const TAB = { VERSIONS: 0, SETTINGS: 1, VARIABLES: 2 }
-
-  defineProps({
+  const props = defineProps({
     isLoading: { type: Boolean, default: false },
     loadError: { type: [Object, Error], default: null },
     title: { type: String, default: '' },
@@ -31,6 +34,7 @@
       type: String,
       default: 'Create a version on the Versions tab to start configuring this resource.'
     },
+    showOverview: { type: Boolean, default: false },
     showSettings: { type: Boolean, default: true },
     showVariables: { type: Boolean, default: false },
     testidPrefix: { type: String, required: true }
@@ -38,6 +42,20 @@
 
   const activeTab = defineModel('activeTab', { type: Number, default: 0 })
   const deployVisible = defineModel('deployVisible', { type: Boolean, default: false })
+
+  // Compute the numeric tab index per section so slots stay stable regardless of
+  // whether Overview is enabled. Order: Overview? → Versions → Settings? → Variables?
+  const tabIndexes = computed(() => {
+    let cursor = 0
+    const map = {}
+    if (props.showOverview) map.overview = cursor++
+    map.versions = cursor++
+    if (props.showSettings) map.settings = cursor++
+    if (props.showVariables) map.variables = cursor++
+    return map
+  })
+
+  const hasTabs = computed(() => props.showOverview || props.showSettings || props.showVariables)
 </script>
 
 <template>
@@ -72,11 +90,10 @@
         :entityName="entityName"
       >
         <template #default>
-          <div
-            v-if="showSettings"
-            class="flex items-center gap-[var(--spacing-3)]"
-          >
+          <div class="flex items-center gap-[var(--spacing-3)]">
+            <slot name="heading-actions" />
             <div
+              v-if="showSettings"
               id="version-lifecycle-action"
               class="flex items-center"
             />
@@ -86,24 +103,35 @@
     </template>
     <template #content>
       <TabView
-        v-if="showSettings || showVariables"
+        v-if="hasTabs"
         v-model:activeIndex="activeTab"
         :pt="{ root: { class: 'flex flex-col gap-[var(--spacing-4)]' } }"
       >
+        <TabPanel
+          v-if="showOverview"
+          header="Overview"
+          :pt="{ root: { 'data-testid': `${testidPrefix}__tab__overview` } }"
+        >
+          <slot
+            v-if="activeTab === tabIndexes.overview"
+            name="overview"
+          />
+        </TabPanel>
         <TabPanel
           header="Versions"
           :pt="{ root: { 'data-testid': `${testidPrefix}__tab__versions` } }"
         >
           <slot
-            v-if="activeTab === TAB.VERSIONS"
+            v-if="activeTab === tabIndexes.versions"
             name="versions"
           />
         </TabPanel>
         <TabPanel
+          v-if="showSettings"
           header="Settings"
           :pt="{ root: { 'data-testid': `${testidPrefix}__tab__settings` } }"
         >
-          <template v-if="activeTab === TAB.SETTINGS">
+          <template v-if="activeTab === tabIndexes.settings">
             <slot
               v-if="latestVersionId"
               name="settings"
@@ -125,7 +153,7 @@
                 icon="pi pi-plus"
                 size="small"
                 :data-testid="`${testidPrefix}__settings-empty__cta`"
-                @click="activeTab = TAB.VERSIONS"
+                @click="activeTab = tabIndexes.versions"
               />
             </div>
           </template>
@@ -136,7 +164,7 @@
           :pt="{ root: { 'data-testid': `${testidPrefix}__tab__variables` } }"
         >
           <slot
-            v-if="activeTab === TAB.VARIABLES"
+            v-if="activeTab === tabIndexes.variables"
             name="variables"
           />
         </TabPanel>

--- a/src/tests/composables/versioning/active-versions.test.js
+++ b/src/tests/composables/versioning/active-versions.test.js
@@ -52,7 +52,8 @@ describe('activeVersionsForResource', () => {
         state: 'ready',
         policy: 'single_version',
         trafficRole: 'ACTIVE',
-        releaseId: 'AREL0001'
+        releaseId: 'AREL0001',
+        deployedAt: null
       },
       {
         id: 'ADEP0002',
@@ -60,7 +61,8 @@ describe('activeVersionsForResource', () => {
         state: 'ready',
         policy: 'versioned_urls',
         trafficRole: 'CANDIDATE',
-        releaseId: 'AREL0002'
+        releaseId: 'AREL0002',
+        deployedAt: null
       }
     ])
   })
@@ -101,7 +103,8 @@ describe('activeVersionsForResource', () => {
       state: 'ready',
       policy: 'single_version',
       trafficRole: 'ACTIVE',
-      releaseId: 'AREL0003'
+      releaseId: 'AREL0003',
+      deployedAt: null
     })
 
     const byResourceId = activeVersionsForResource(appRows, {

--- a/src/tests/composables/versioning/no-version-shell-fork.test.js
+++ b/src/tests/composables/versioning/no-version-shell-fork.test.js
@@ -61,6 +61,7 @@ const COMPOSABLES_ALLOWLIST = [
   'use-version-list.js',
   'use-version-menu-actions.js',
   'use-version-row-actions.js',
+  'use-workload-directory.js',
   'use-workload-version-environments.js',
   'version-actions.js',
   'version-capability.js',

--- a/src/tests/composables/versioning/no-version-shell-fork.test.js
+++ b/src/tests/composables/versioning/no-version-shell-fork.test.js
@@ -31,6 +31,7 @@ const COMPOSABLES_DIR = 'src/composables/versioning'
 // Allowlist of shared framework files. Every entry is generic (no resource name
 // baked in). Adding a file here must be a deliberate, shared addition.
 const SHELL_ALLOWLIST = [
+  'ResourceOverviewBlock.vue',
   'ResourceVersionLanding.vue',
   'VersionEditScreen.vue',
   'VersionEditorTabsShell.vue',
@@ -44,9 +45,13 @@ const SHELL_ALLOWLIST = [
 ]
 
 const COMPOSABLES_ALLOWLIST = [
+  'active-versions.js',
+  'overview-resource-config.js',
   'to-version-options.js',
+  'use-active-versions.js',
   'use-deploy-resource-context.js',
   'use-deployment-release-drawer.js',
+  'use-live-deployments.js',
   'use-resource-version-landing.js',
   'use-version-command-bus.js',
   'use-version-command.js',
@@ -59,6 +64,7 @@ const COMPOSABLES_ALLOWLIST = [
   'use-workload-version-environments.js',
   'version-actions.js',
   'version-capability.js',
+  'version-list-columns.js',
   'version-machine.js'
 ]
 

--- a/src/tests/composables/versioning/use-live-deployments.test.js
+++ b/src/tests/composables/versioning/use-live-deployments.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { computed, ref } from 'vue'
+import { useLiveDeployments } from '@/composables/versioning/use-live-deployments'
+
+const nameBasedResolver = {
+  resolve(deployment) {
+    return {
+      environment: deployment?.name ?? null,
+      workload: null,
+      deployedAt: deployment?.deployedAt ?? null
+    }
+  }
+}
+
+describe('useLiveDeployments', () => {
+  it('returns [] when activeVersions is empty or not a Map', () => {
+    const empty = useLiveDeployments({
+      activeVersions: () => new Map(),
+      versions: () => [],
+      workloadResolver: nameBasedResolver
+    })
+    expect(empty.liveDeployments.value).toEqual([])
+
+    const bad = useLiveDeployments({
+      activeVersions: () => null,
+      versions: () => [],
+      workloadResolver: nameBasedResolver
+    })
+    expect(bad.liveDeployments.value).toEqual([])
+  })
+
+  it('produces one row per (version, deployment) pair with enrichment', () => {
+    const versions = [{ id: 'v1', label: 'Version 1' }]
+    const activeVersions = new Map([
+      [
+        'v1',
+        {
+          deployments: [
+            { id: 'd1', name: 'prod', deployedAt: '2026-01-01T00:00:00Z' },
+            { id: 'd2', name: 'staging', deployedAt: '2026-01-02T00:00:00Z' }
+          ]
+        }
+      ]
+    ])
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: () => activeVersions,
+      versions: () => versions,
+      workloadResolver: nameBasedResolver
+    })
+
+    expect(liveDeployments.value).toHaveLength(2)
+    expect(liveDeployments.value[0]).toMatchObject({
+      versionId: 'v1',
+      environment: 'prod',
+      workload: null,
+      deployedAt: '2026-01-01T00:00:00Z'
+    })
+    expect(liveDeployments.value[0].version).toMatchObject({ id: 'v1', label: 'Version 1' })
+    expect(liveDeployments.value[1].environment).toBe('staging')
+  })
+
+  it('falls back to deployment.deployedAt when the resolver omits it', () => {
+    const nullResolver = { resolve: () => ({}) }
+    const activeVersions = new Map([
+      ['v1', { deployments: [{ id: 'd1', name: 'prod', deployedAt: '2026-03-05T12:00:00Z' }] }]
+    ])
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: () => activeVersions,
+      versions: () => [],
+      workloadResolver: nullResolver
+    })
+
+    expect(liveDeployments.value[0].deployedAt).toBe('2026-03-05T12:00:00Z')
+    expect(liveDeployments.value[0].environment).toBeNull()
+    expect(liveDeployments.value[0].workload).toBeNull()
+  })
+
+  it('unwraps a computed/ref workloadResolver', () => {
+    const resolverRef = ref(nameBasedResolver)
+    const activeVersions = new Map([['v1', { deployments: [{ id: 'd1', name: 'prod' }] }]])
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: computed(() => activeVersions),
+      versions: computed(() => []),
+      workloadResolver: resolverRef
+    })
+
+    expect(liveDeployments.value[0].environment).toBe('prod')
+  })
+
+  it('skips entries where deployments is not an array', () => {
+    const activeVersions = new Map([
+      ['v1', { deployments: null }],
+      ['v2', { deployments: [{ id: 'd1', name: 'prod' }] }]
+    ])
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: () => activeVersions,
+      versions: () => [],
+      workloadResolver: nameBasedResolver
+    })
+
+    expect(liveDeployments.value).toHaveLength(1)
+    expect(liveDeployments.value[0].versionId).toBe('v2')
+  })
+})

--- a/src/tests/composables/versioning/use-live-deployments.test.js
+++ b/src/tests/composables/versioning/use-live-deployments.test.js
@@ -29,7 +29,7 @@ describe('useLiveDeployments', () => {
     expect(bad.liveDeployments.value).toEqual([])
   })
 
-  it('produces one row per (version, deployment) pair with enrichment', () => {
+  it('folds N deployments of the same version into ONE row with N environments', () => {
     const versions = [{ id: 'v1', label: 'Version 1' }]
     const activeVersions = new Map([
       [
@@ -49,15 +49,31 @@ describe('useLiveDeployments', () => {
       workloadResolver: nameBasedResolver
     })
 
-    expect(liveDeployments.value).toHaveLength(2)
-    expect(liveDeployments.value[0]).toMatchObject({
-      versionId: 'v1',
-      environment: 'prod',
-      workload: null,
-      deployedAt: '2026-01-01T00:00:00Z'
+    expect(liveDeployments.value).toHaveLength(1)
+    const [row] = liveDeployments.value
+    expect(row.versionId).toBe('v1')
+    expect(row.environments).toEqual(['prod', 'staging'])
+    expect(row.workloads).toEqual([])
+    expect(row.deployments).toHaveLength(2)
+    // latestDeployedAt is the most recent across the deployments.
+    expect(row.latestDeployedAt).toBe('2026-01-02T00:00:00Z')
+    expect(row.version).toMatchObject({ id: 'v1', label: 'Version 1' })
+  })
+
+  it('produces one row per DISTINCT version, keeping order deterministic', () => {
+    const activeVersions = new Map([
+      ['v1', { deployments: [{ id: 'd1', name: 'prod' }] }],
+      ['v2', { deployments: [{ id: 'd2', name: 'canary' }] }]
+    ])
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: () => activeVersions,
+      versions: () => [],
+      workloadResolver: nameBasedResolver
     })
-    expect(liveDeployments.value[0].version).toMatchObject({ id: 'v1', label: 'Version 1' })
-    expect(liveDeployments.value[1].environment).toBe('staging')
+
+    expect(liveDeployments.value).toHaveLength(2)
+    expect(liveDeployments.value.map((row) => row.versionId)).toEqual(['v1', 'v2'])
   })
 
   it('falls back to deployment.deployedAt when the resolver omits it', () => {
@@ -72,9 +88,9 @@ describe('useLiveDeployments', () => {
       workloadResolver: nullResolver
     })
 
-    expect(liveDeployments.value[0].deployedAt).toBe('2026-03-05T12:00:00Z')
-    expect(liveDeployments.value[0].environment).toBeNull()
-    expect(liveDeployments.value[0].workload).toBeNull()
+    expect(liveDeployments.value[0].latestDeployedAt).toBe('2026-03-05T12:00:00Z')
+    expect(liveDeployments.value[0].environments).toEqual([])
+    expect(liveDeployments.value[0].workloads).toEqual([])
   })
 
   it('unwraps a computed/ref workloadResolver', () => {
@@ -87,13 +103,14 @@ describe('useLiveDeployments', () => {
       workloadResolver: resolverRef
     })
 
-    expect(liveDeployments.value[0].environment).toBe('prod')
+    expect(liveDeployments.value[0].environments).toEqual(['prod'])
   })
 
-  it('skips entries where deployments is not an array', () => {
+  it('skips versions with no active deployments', () => {
     const activeVersions = new Map([
       ['v1', { deployments: null }],
-      ['v2', { deployments: [{ id: 'd1', name: 'prod' }] }]
+      ['v2', { deployments: [] }],
+      ['v3', { deployments: [{ id: 'd1', name: 'prod' }] }]
     ])
 
     const { liveDeployments } = useLiveDeployments({
@@ -103,6 +120,36 @@ describe('useLiveDeployments', () => {
     })
 
     expect(liveDeployments.value).toHaveLength(1)
-    expect(liveDeployments.value[0].versionId).toBe('v2')
+    expect(liveDeployments.value[0].versionId).toBe('v3')
+  })
+
+  it('deduplicates repeated environment/workload names within a version', () => {
+    const activeVersions = new Map([
+      [
+        'v1',
+        {
+          deployments: [
+            { id: 'd1', name: 'prod' },
+            { id: 'd2', name: 'prod' }
+          ]
+        }
+      ]
+    ])
+
+    const resolver = {
+      resolve(deployment) {
+        return { environment: deployment?.name ?? null, workload: 'wl-a', deployedAt: null }
+      }
+    }
+
+    const { liveDeployments } = useLiveDeployments({
+      activeVersions: () => activeVersions,
+      versions: () => [],
+      workloadResolver: resolver
+    })
+
+    expect(liveDeployments.value[0].environments).toEqual(['prod'])
+    expect(liveDeployments.value[0].workloads).toEqual(['wl-a'])
+    expect(liveDeployments.value[0].deployments).toHaveLength(2)
   })
 })

--- a/src/tests/composables/versioning/use-workload-directory.test.js
+++ b/src/tests/composables/versioning/use-workload-directory.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { nextTick } from 'vue'
 
 const listWorkloads = vi.fn()
+const listEnvironmentsService = vi.fn()
+const listDeploymentsService = vi.fn()
 
 vi.mock('@/services/v2/workload/workload-service', () => ({
   workloadService: {
@@ -9,105 +11,233 @@ vi.mock('@/services/v2/workload/workload-service', () => ({
   }
 }))
 
-// Import AFTER the mock is registered so the composable resolves the mocked
-// module instead of the real service.
+vi.mock('@/services/v2/environment/environment-service', () => ({
+  environmentService: {
+    listEnvironmentsService: (...args) => listEnvironmentsService(...args)
+  }
+}))
+
+vi.mock('@/services/v2/deployment/deployment-service', () => ({
+  deploymentService: {
+    listDeploymentsService: (...args) => listDeploymentsService(...args)
+  }
+}))
+
+// Import AFTER the mocks are registered so the composable resolves the mocked
+// modules instead of the real services.
 const { useWorkloadDirectory } = await import('@/composables/versioning/use-workload-directory')
 
 const flushLoad = async () => {
   await nextTick()
   await Promise.resolve()
   await Promise.resolve()
+  await Promise.resolve()
   await nextTick()
+}
+
+const envsFixture = {
+  body: [
+    { id: 'env-prod', name: 'Production' },
+    { id: 'env-staging', name: 'Staging' }
+  ],
+  count: 2
 }
 
 describe('useWorkloadDirectory', () => {
   beforeEach(() => {
     listWorkloads.mockReset()
+    listEnvironmentsService.mockReset()
+    listDeploymentsService.mockReset()
+    listEnvironmentsService.mockResolvedValue(envsFixture)
+    listDeploymentsService.mockResolvedValue({ body: [], count: 0 })
   })
 
-  it('builds a deployment→workload map from the workloads list', async () => {
+  it('builds a deployment→meta map with updatedAt and lastModifiedBy', async () => {
+    listWorkloads.mockResolvedValueOnce({ body: [], count: 0 })
+    listDeploymentsService.mockReset()
+    listDeploymentsService.mockResolvedValueOnce({
+      body: [
+        {
+          id: 'ADEP0001',
+          updated_at: '2026-06-10T14:32:11Z',
+          created_at: '2026-06-01T09:00:00Z',
+          last_modified_by: 'ops@example.com',
+          created_by: 'admin@example.com'
+        },
+        {
+          id: 'ADEP0002',
+          updated_at: null,
+          created_at: '2026-05-05T10:00:00Z',
+          last_modified_by: null,
+          created_by: 'admin@example.com'
+        }
+      ],
+      count: 2
+    })
+
+    const { deploymentToMeta } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(deploymentToMeta.value.get('ADEP0001')).toEqual({
+      updatedAt: '2026-06-10T14:32:11Z',
+      lastModifiedBy: 'ops@example.com'
+    })
+    // Falls back to created_at / created_by when updated_at / last_modified_by are null.
+    expect(deploymentToMeta.value.get('ADEP0002')).toEqual({
+      updatedAt: '2026-05-05T10:00:00Z',
+      lastModifiedBy: 'admin@example.com'
+    })
+  })
+
+  it('builds both deployment→workload and deployment→environment maps', async () => {
     listWorkloads.mockResolvedValueOnce({
       body: [
         {
           id: 1,
           name: { text: 'wl-prod' },
           bindings: [
-            { environment_id: 10, deployment_id: 'ADEP0001' },
-            { environment_id: 11, deployment_id: 'ADEP0002' }
+            { environment_id: 'env-prod', deployment_id: 'ADEP0001' },
+            { environment_id: 'env-staging', deployment_id: 'ADEP0002' }
           ]
         },
         {
           id: 2,
           name: { text: 'wl-staging' },
-          bindings: [{ environment_id: 20, deployment_id: 'ADEP0003' }]
+          bindings: [{ environment_id: 'env-staging', deployment_id: 'ADEP0003' }]
         }
       ],
       count: 2
     })
 
-    const { deploymentToWorkload, isLoading } = useWorkloadDirectory()
+    const { deploymentToWorkload, deploymentToEnvironment, isLoading } = useWorkloadDirectory()
     await flushLoad()
 
     expect(isLoading.value).toBe(false)
     expect(deploymentToWorkload.value.get('ADEP0001')).toBe('wl-prod')
     expect(deploymentToWorkload.value.get('ADEP0002')).toBe('wl-prod')
     expect(deploymentToWorkload.value.get('ADEP0003')).toBe('wl-staging')
-    expect(deploymentToWorkload.value.size).toBe(3)
+    expect(deploymentToEnvironment.value.get('ADEP0001')).toBe('Production')
+    expect(deploymentToEnvironment.value.get('ADEP0002')).toBe('Staging')
+    expect(deploymentToEnvironment.value.get('ADEP0003')).toBe('Staging')
   })
 
   it('accepts plain string names as well as { text } shape', async () => {
     listWorkloads.mockResolvedValueOnce({
       body: [
-        { id: 1, name: 'wl-legacy', bindings: [{ deployment_id: 'D1' }] },
-        { id: 2, name: { text: 'wl-modern' }, bindings: [{ deployment_id: 'D2' }] }
-      ],
-      count: 2
-    })
-
-    const { deploymentToWorkload } = useWorkloadDirectory()
-    await flushLoad()
-
-    expect(deploymentToWorkload.value.get('D1')).toBe('wl-legacy')
-    expect(deploymentToWorkload.value.get('D2')).toBe('wl-modern')
-  })
-
-  it('falls back to an empty Map when listWorkloads rejects', async () => {
-    listWorkloads.mockRejectedValueOnce(new Error('forbidden'))
-
-    const { deploymentToWorkload, isLoading } = useWorkloadDirectory()
-    await flushLoad()
-
-    expect(isLoading.value).toBe(false)
-    expect(deploymentToWorkload.value.size).toBe(0)
-  })
-
-  it('skips deployments with missing ids or workloads with no name', async () => {
-    listWorkloads.mockResolvedValueOnce({
-      body: [
-        { id: 1, name: { text: null }, bindings: [{ deployment_id: 'D1' }] },
+        {
+          id: 1,
+          name: 'wl-legacy',
+          bindings: [{ deployment_id: 'D1', environment_id: 'env-prod' }]
+        },
         {
           id: 2,
-          name: { text: 'ok' },
-          bindings: [{ deployment_id: null }, { deployment_id: 'D2' }]
+          name: { text: 'wl-modern' },
+          bindings: [{ deployment_id: 'D2', environment_id: 'env-staging' }]
         }
       ],
       count: 2
     })
 
-    const { deploymentToWorkload } = useWorkloadDirectory()
+    const { deploymentToWorkload, deploymentToEnvironment } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(deploymentToWorkload.value.get('D1')).toBe('wl-legacy')
+    expect(deploymentToWorkload.value.get('D2')).toBe('wl-modern')
+    expect(deploymentToEnvironment.value.get('D1')).toBe('Production')
+    expect(deploymentToEnvironment.value.get('D2')).toBe('Staging')
+  })
+
+  it('leaves environment blank when the environment_id is unknown', async () => {
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        {
+          id: 1,
+          name: { text: 'wl' },
+          bindings: [{ deployment_id: 'D1', environment_id: 'env-orphan' }]
+        }
+      ],
+      count: 1
+    })
+
+    const { deploymentToWorkload, deploymentToEnvironment } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(deploymentToWorkload.value.get('D1')).toBe('wl')
+    expect(deploymentToEnvironment.value.has('D1')).toBe(false)
+  })
+
+  it('keeps the workload map when the environments API fails', async () => {
+    listEnvironmentsService.mockReset()
+    listEnvironmentsService.mockRejectedValueOnce(new Error('forbidden'))
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        {
+          id: 1,
+          name: { text: 'wl' },
+          bindings: [{ deployment_id: 'D1', environment_id: 'env-prod' }]
+        }
+      ],
+      count: 1
+    })
+
+    const { deploymentToWorkload, deploymentToEnvironment, isLoading } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(isLoading.value).toBe(false)
+    expect(deploymentToWorkload.value.get('D1')).toBe('wl')
+    expect(deploymentToEnvironment.value.size).toBe(0)
+  })
+
+  it('falls back to empty Maps when listWorkloads rejects', async () => {
+    listWorkloads.mockRejectedValueOnce(new Error('forbidden'))
+
+    const { deploymentToWorkload, deploymentToEnvironment, isLoading } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(isLoading.value).toBe(false)
+    expect(deploymentToWorkload.value.size).toBe(0)
+    expect(deploymentToEnvironment.value.size).toBe(0)
+  })
+
+  it('skips bindings with missing ids or workloads with no name', async () => {
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        {
+          id: 1,
+          name: { text: null },
+          bindings: [{ deployment_id: 'D1', environment_id: 'env-prod' }]
+        },
+        {
+          id: 2,
+          name: { text: 'ok' },
+          bindings: [
+            { deployment_id: null, environment_id: 'env-prod' },
+            { deployment_id: 'D2', environment_id: 'env-staging' }
+          ]
+        }
+      ],
+      count: 2
+    })
+
+    const { deploymentToWorkload, deploymentToEnvironment } = useWorkloadDirectory()
     await flushLoad()
 
     expect(deploymentToWorkload.value.has('D1')).toBe(false)
     expect(deploymentToWorkload.value.get('D2')).toBe('ok')
-    expect(deploymentToWorkload.value.size).toBe(1)
+    expect(deploymentToEnvironment.value.get('D2')).toBe('Staging')
   })
 
-  it('does not call the service when enabled=false', async () => {
-    const { deploymentToWorkload, isLoading } = useWorkloadDirectory({ enabled: false })
+  it('does not call the services when enabled=false', async () => {
+    const { deploymentToWorkload, deploymentToEnvironment, isLoading } = useWorkloadDirectory({
+      enabled: false
+    })
     await flushLoad()
 
     expect(listWorkloads).not.toHaveBeenCalled()
+    expect(listEnvironmentsService).not.toHaveBeenCalled()
+    expect(listDeploymentsService).not.toHaveBeenCalled()
     expect(isLoading.value).toBe(false)
     expect(deploymentToWorkload.value.size).toBe(0)
+    expect(deploymentToEnvironment.value.size).toBe(0)
   })
 })

--- a/src/tests/composables/versioning/use-workload-directory.test.js
+++ b/src/tests/composables/versioning/use-workload-directory.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+
+const listWorkloads = vi.fn()
+
+vi.mock('@/services/v2/workload/workload-service', () => ({
+  workloadService: {
+    listWorkloads: (...args) => listWorkloads(...args)
+  }
+}))
+
+// Import AFTER the mock is registered so the composable resolves the mocked
+// module instead of the real service.
+const { useWorkloadDirectory } = await import('@/composables/versioning/use-workload-directory')
+
+const flushLoad = async () => {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('useWorkloadDirectory', () => {
+  beforeEach(() => {
+    listWorkloads.mockReset()
+  })
+
+  it('builds a deployment→workload map from the workloads list', async () => {
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        {
+          id: 1,
+          name: { text: 'wl-prod' },
+          bindings: [
+            { environment_id: 10, deployment_id: 'ADEP0001' },
+            { environment_id: 11, deployment_id: 'ADEP0002' }
+          ]
+        },
+        {
+          id: 2,
+          name: { text: 'wl-staging' },
+          bindings: [{ environment_id: 20, deployment_id: 'ADEP0003' }]
+        }
+      ],
+      count: 2
+    })
+
+    const { deploymentToWorkload, isLoading } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(isLoading.value).toBe(false)
+    expect(deploymentToWorkload.value.get('ADEP0001')).toBe('wl-prod')
+    expect(deploymentToWorkload.value.get('ADEP0002')).toBe('wl-prod')
+    expect(deploymentToWorkload.value.get('ADEP0003')).toBe('wl-staging')
+    expect(deploymentToWorkload.value.size).toBe(3)
+  })
+
+  it('accepts plain string names as well as { text } shape', async () => {
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        { id: 1, name: 'wl-legacy', bindings: [{ deployment_id: 'D1' }] },
+        { id: 2, name: { text: 'wl-modern' }, bindings: [{ deployment_id: 'D2' }] }
+      ],
+      count: 2
+    })
+
+    const { deploymentToWorkload } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(deploymentToWorkload.value.get('D1')).toBe('wl-legacy')
+    expect(deploymentToWorkload.value.get('D2')).toBe('wl-modern')
+  })
+
+  it('falls back to an empty Map when listWorkloads rejects', async () => {
+    listWorkloads.mockRejectedValueOnce(new Error('forbidden'))
+
+    const { deploymentToWorkload, isLoading } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(isLoading.value).toBe(false)
+    expect(deploymentToWorkload.value.size).toBe(0)
+  })
+
+  it('skips deployments with missing ids or workloads with no name', async () => {
+    listWorkloads.mockResolvedValueOnce({
+      body: [
+        { id: 1, name: { text: null }, bindings: [{ deployment_id: 'D1' }] },
+        {
+          id: 2,
+          name: { text: 'ok' },
+          bindings: [{ deployment_id: null }, { deployment_id: 'D2' }]
+        }
+      ],
+      count: 2
+    })
+
+    const { deploymentToWorkload } = useWorkloadDirectory()
+    await flushLoad()
+
+    expect(deploymentToWorkload.value.has('D1')).toBe(false)
+    expect(deploymentToWorkload.value.get('D2')).toBe('ok')
+    expect(deploymentToWorkload.value.size).toBe(1)
+  })
+
+  it('does not call the service when enabled=false', async () => {
+    const { deploymentToWorkload, isLoading } = useWorkloadDirectory({ enabled: false })
+    await flushLoad()
+
+    expect(listWorkloads).not.toHaveBeenCalled()
+    expect(isLoading.value).toBe(false)
+    expect(deploymentToWorkload.value.size).toBe(0)
+  })
+})

--- a/src/tests/composables/versioning/version-menu-consistency.test.js
+++ b/src/tests/composables/versioning/version-menu-consistency.test.js
@@ -40,9 +40,9 @@ import { VERSION_STATES } from '@/composables/versioning/version-machine'
  */
 const LISTINGS = [
   {
-    name: 'EdgeApplications EditView',
+    name: 'EdgeApplications VersionsTab',
     resourceType: 'application',
-    file: 'src/views/EdgeApplications/v6/EditView.vue'
+    file: 'src/views/EdgeApplications/v6/tabs/VersionsTab.vue'
   },
   {
     name: 'EdgeFirewall VersionsTab',

--- a/src/views/EdgeApplications/v6/EditView.vue
+++ b/src/views/EdgeApplications/v6/EditView.vue
@@ -1,321 +1,101 @@
 <script setup>
   /**
-   * v6 EditView — the Application screen, gated by `use_v6_configurations`.
-   * Lists every version of the Application with search/filter/sort and per-row
-   * management actions (Clone / Archive / Delete). Clicking a version — or
-   * creating/cloning one — opens its FULL editor (VersionEditView, route
-   * `edit-application-version`). The page heading carries the Deploy action +
-   * drawer.
+   * v6 EditView — the Application landing screen, gated by
+   * `use_v6_configurations`. Uses the shared ResourceVersionLanding shell
+   * (mirrors Firewall) and plugs into it three tabs: Overview + Versions +
+   * Variables. The version editor lives in a separate screen
+   * (`edit-application-version`); Deploy from the heading routes to the
+   * full-page release composer.
    *
    * The flag check stays centralized in the router (req 10.1) — this view never
    * imports user-flag.
    */
-  import { computed, ref, watch, provide } from 'vue'
-  import { useRoute, useRouter } from 'vue-router'
-  import { useToast } from '@aziontech/webkit/use-toast'
-  import ProgressSpinner from '@aziontech/webkit/progressspinner'
-  import InlineMessage from '@aziontech/webkit/inlinemessage'
   import PrimeButton from '@aziontech/webkit/button'
 
-  import { toDeployableVersionOptions } from '@/composables/versioning/to-version-options'
-
-  import ContentBlock from '@/templates/content-block'
-  import PageHeadingBlock from '@/templates/page-heading-block'
-  import VersionListDataView from '@/components/VersionListDataView'
-  import VersionActionDialog from '@/templates/version-shell-block/components/VersionActionDialog.vue'
-  import DeployDrawerBlock from '@/templates/deploy-drawer-block'
-  import { releaseComposerRouteFromResource } from '@/templates/release-composition/release-composer-route'
+  import ResourceVersionLanding from '@/templates/version-shell-block/ResourceVersionLanding.vue'
+  import ResourceOverviewBlock from '@/templates/version-shell-block/ResourceOverviewBlock.vue'
+  import VersionsTab from '@/views/EdgeApplications/v6/tabs/VersionsTab.vue'
   import ScopedVariablesTab from '@/views/Variables/v6/components/ScopedVariablesTab.vue'
-  import TabView from 'primevue/tabview'
-  import TabPanel from '@aziontech/webkit/tabpanel'
-
+  import { useResourceVersionLanding } from '@/composables/versioning/use-resource-version-landing'
   import { edgeAppService } from '@/services/v2/edge-app/edge-app-service'
   import { edgeAppVersionService } from '@/services/v2/edge-app/edge-app-version-service'
-  import { useVersionList } from '@/composables/versioning/use-version-list'
-  import { useActiveVersions } from '@/composables/versioning/use-active-versions'
-  import { getVersionListColumns } from '@/composables/versioning/version-list-columns'
-  import { useVersionMenuActions } from '@/composables/versioning/use-version-menu-actions'
 
   defineOptions({ name: 'application-v6-edit-view' })
 
-  const route = useRoute()
-  const router = useRouter()
-  const toast = useToast()
-
-  const edgeApplicationId = computed(() => String(route.params.id))
-
-  const activeTab = computed({
-    get: () => (String(route.params.tab) === 'variables' ? 1 : 0),
-    set: (index) => {
-      const params = { id: edgeApplicationId.value }
-      if (index === 1) params.tab = 'variables'
-      router.replace({ name: 'edit-application', params })
-    }
-  })
-
-  const application = ref(null)
-  const isLoadingApplication = ref(true)
-  const loadError = ref(null)
-
-  provide('edgeApplication', application)
-
-  const loadApplication = async () => {
-    if (!application.value) isLoadingApplication.value = true
-    loadError.value = null
-    try {
-      application.value = await edgeAppService.loadEdgeApplicationService({
-        id: edgeApplicationId.value
-      })
-    } catch (err) {
-      loadError.value = err
-      application.value = null
-    } finally {
-      isLoadingApplication.value = false
-    }
-  }
-
-  watch(edgeApplicationId, loadApplication, { immediate: true })
-
-  const versionsQuery = edgeAppVersionService.useListVersionsQuery(edgeApplicationId.value)
-  const rawVersions = computed(() => versionsQuery.data.value?.body ?? [])
-
-  const resourceRef = computed(() => ({
-    resourceType: 'application',
-    resourceId: edgeApplicationId.value
-  }))
-  const { activeVersions, refresh: refreshActiveVersions } = useActiveVersions(resourceRef)
-
-  const { items, searchTerm, filterValues, sort, filters, sortOptions } = useVersionList(
-    rawVersions,
-    { activeVersions }
-  )
-
-  const columns = getVersionListColumns()
-
-  const goToVersion = (versionIdOrObject) => {
-    const id = typeof versionIdOrObject === 'string' ? versionIdOrObject : versionIdOrObject?.id
-    if (!id) return
-    router.push(`/applications/edit/${edgeApplicationId.value}/versions/${id}`)
-  }
-
-  // DeployDrawerBlock stays mounted (rollback fallback); the visible/pinned models
-  // are retained but the Deploy/Promote entries now route to the full-page composer.
-  const isDeployDrawerOpen = ref(false)
-  // Version pinned by a row-menu Promote; cleared when the drawer closes.
-  const pinnedDeployVersionId = ref(null)
-  // Heading Deploy: route to the composer scoped to this Application, pinning the
-  // newest Ready version so the composer opens with a concrete selection.
-  const openRelease = () => {
-    router.push(
-      releaseComposerRouteFromResource({
-        resourceType: 'application',
-        resourceId: Number(edgeApplicationId.value),
-        version: null,
-        versions: readyVersionOptions.value
-      })
-    )
-  }
-  // Promote from the row menu: route to the composer with this version pinned.
-  const openPromoteRelease = ({ pin } = {}) => {
-    router.push(
-      releaseComposerRouteFromResource({
-        resourceType: 'application',
-        resourceId: Number(edgeApplicationId.value),
-        version: pin ? { id: pin } : null,
-        versions: readyVersionOptions.value
-      })
-    )
-  }
-  watch(isDeployDrawerOpen, (open) => {
-    if (!open) pinnedDeployVersionId.value = null
-  })
-
-  // Single shared row-menu driver (spec §3.3, Req 1.4/10.1): nav, Promote
-  // (routes to the composer) and Archive/Delete all flow through one router.
   const {
-    handleRowAction,
-    dialogConfig,
-    dialogProps,
-    dialogVisible,
-    handleConfirm,
-    handleVisibility
-  } = useVersionMenuActions({
-    resourceType: 'application',
-    resourceId: edgeApplicationId,
+    resource,
+    resourceId,
+    isLoading,
+    loadError,
+    latestVersionId,
+    activeTab,
+    isDeployDrawerOpen,
+    openRelease,
+    deployResourceContext,
+    versionsQuery,
+    rawVersions,
+    activeVersions,
+    activeVersionsLoading
+  } = useResourceVersionLanding({
+    load: (id) => edgeAppService.loadEdgeApplicationService({ id }),
+    provideKey: 'edgeApplication',
     versionService: edgeAppVersionService,
-    router,
-    openPromoteDrawer: openPromoteRelease,
-    onSuccess: () => {
-      versionsQuery.refetch?.()
-      refreshActiveVersions()
-    }
+    resourceType: 'application',
+    routeName: 'edit-application',
+    versionRouteName: 'edit-application-version',
+    showOverview: true
   })
 
-  const isCreatingDraft = ref(false)
-
-  const createDraft = async () => {
-    if (isCreatingDraft.value) return
-    isCreatingDraft.value = true
-    try {
-      const draft = await edgeAppVersionService.createDraft(edgeApplicationId.value, {})
-      if (draft?.id) goToVersion(draft.id)
-    } catch (err) {
-      if (err && typeof err.showErrors === 'function') {
-        err.showErrors(toast)
-      } else {
-        toast.add({
-          closable: true,
-          severity: 'error',
-          summary: 'Error',
-          detail: err?.message ?? 'Failed to create a new version. Try again.'
-        })
-      }
-    } finally {
-      isCreatingDraft.value = false
-    }
-  }
-
-  const readyVersionOptions = computed(() => toDeployableVersionOptions(rawVersions.value))
-
-  const deployResourceContext = computed(() => ({
-    resourceType: 'application',
-    resourceId: Number(edgeApplicationId.value),
-    resourceName: application.value?.name ?? '',
-    version: pinnedDeployVersionId.value ? { id: pinnedDeployVersionId.value } : null,
-    versions: readyVersionOptions.value
-  }))
-
-  const applicationTitle = computed(() => application.value?.name ?? '')
   const pageDescription =
     "Each version is an isolated snapshot of this Application's configuration. Edit a draft, then build it to publish an immutable version to the Edge."
 </script>
 
 <template>
-  <div
-    v-if="isLoadingApplication"
-    class="flex items-center justify-center p-8"
-    data-testid="application-v6-edit__loading"
+  <ResourceVersionLanding
+    v-model:active-tab="activeTab"
+    v-model:deploy-visible="isDeployDrawerOpen"
+    :is-loading="isLoading"
+    :load-error="loadError"
+    :title="resource?.name ?? ''"
+    :description="pageDescription"
+    :entity-name="resource?.name"
+    error-message="Failed to load application. Try refreshing the page."
+    :resource-context="deployResourceContext"
+    :latest-version-id="latestVersionId"
+    empty-state-description="Create a version on the Versions tab to start configuring this Application."
+    testid-prefix="application-v6-edit"
+    :show-overview="true"
+    :show-settings="false"
+    :show-variables="true"
   >
-    <ProgressSpinner
-      class="w-10 h-10 text-color"
-      strokeWidth="4"
-    />
-  </div>
-
-  <InlineMessage
-    v-else-if="loadError"
-    class="w-full"
-    severity="error"
-    data-testid="application-v6-edit__error"
-  >
-    Failed to load application. Try refreshing the page.
-  </InlineMessage>
-
-  <ContentBlock
-    v-else
-    data-testid="application-v6-edit"
-  >
-    <template #heading>
-      <PageHeadingBlock
-        :pageTitle="applicationTitle"
-        :description="pageDescription"
-        :entityName="application?.name"
-      >
-        <template #default>
-          <PrimeButton
-            label="Deploy"
-            icon="pi pi-cloud-upload"
-            size="small"
-            data-testid="application-v6-edit__deploy"
-            @click="openRelease"
-          />
-        </template>
-      </PageHeadingBlock>
-    </template>
-    <template #content>
-      <TabView v-model:activeIndex="activeTab">
-        <TabPanel
-          header="Versions"
-          :pt="{ root: { 'data-testid': 'application-v6-edit__tab__versions' } }"
-        >
-          <VersionListDataView
-            :items="items"
-            :columns="columns"
-            :loading="versionsQuery.isLoading.value"
-            :is-error="versionsQuery.isError?.value ?? false"
-            :has-versions="rawVersions.length > 0"
-            :search-term="searchTerm"
-            :filters="filters"
-            :filter-values="filterValues"
-            :sort="sort"
-            :sort-options="sortOptions"
-            :show-row-actions="true"
-            resource-type="application"
-            :paginator-rows="20"
-            search-placeholder="Search versions"
-            :empty-state="{
-              title: 'This application has no versions yet',
-              description:
-                'Create the first version to start configuring this application with the v6 versioning workflow.',
-              buttonLabel: 'New Version',
-              buttonAction: createDraft
-            }"
-            :error-state="{
-              title: 'Failed to load versions',
-              description: 'Something went wrong loading this application’s versions. Try again.',
-              buttonLabel: 'Retry',
-              buttonAction: () => versionsQuery.refetch?.()
-            }"
-            filtered-empty-title="No versions match your filters"
-            filtered-empty-description="Try a different search term or status filter."
-            data-testid="application-v6-versions__table"
-            @update:search-term="searchTerm = $event"
-            @update:filter-values="filterValues = $event"
-            @update:sort="sort = $event"
-            @refresh="versionsQuery.refetch?.()"
-            @row-action="handleRowAction"
-            class="mt-4"
-          >
-            <template #toolbar-actions>
-              <PrimeButton
-                v-if="rawVersions.length > 0"
-                label="New Version"
-                icon="pi pi-plus"
-                size="small"
-                class="h-[2.5rem]"
-                :loading="isCreatingDraft"
-                data-testid="application-v6-versions__new-draft"
-                @click="createDraft"
-              />
-            </template>
-          </VersionListDataView>
-        </TabPanel>
-
-        <TabPanel
-          header="Variables"
-          :pt="{ root: { 'data-testid': 'application-v6-edit__tab__variables' } }"
-        >
-          <ScopedVariablesTab
-            v-if="activeTab === 1"
-            scope-type="application"
-            :scope-id="edgeApplicationId"
-            class="mt-4"
-          />
-        </TabPanel>
-      </TabView>
-
-      <VersionActionDialog
-        v-if="dialogConfig"
-        v-bind="dialogProps"
-        :visible="dialogVisible"
-        @confirm="handleConfirm"
-        @update:visible="handleVisibility"
-      />
-
-      <DeployDrawerBlock
-        v-model:visible="isDeployDrawerOpen"
-        :resource-context="deployResourceContext"
+    <template #heading-actions>
+      <PrimeButton
+        label="Deploy"
+        icon="pi pi-cloud-upload"
+        size="small"
+        data-testid="application-v6-edit__deploy"
+        @click="openRelease"
       />
     </template>
-  </ContentBlock>
+    <template #overview>
+      <ResourceOverviewBlock
+        resource-type="application"
+        :resource-id="resourceId"
+        :raw-versions="rawVersions"
+        :active-versions="activeVersions"
+        :active-versions-loading="activeVersionsLoading"
+        :versions-query="versionsQuery"
+        testid-prefix="application-v6-overview"
+      />
+    </template>
+    <template #versions>
+      <VersionsTab :application-id="resourceId" />
+    </template>
+    <template #variables>
+      <ScopedVariablesTab
+        scope-type="application"
+        :scope-id="resourceId"
+      />
+    </template>
+  </ResourceVersionLanding>
 </template>

--- a/src/views/EdgeApplications/v6/tabs/VersionsTab.vue
+++ b/src/views/EdgeApplications/v6/tabs/VersionsTab.vue
@@ -1,10 +1,11 @@
 <script setup>
   /**
-   * VersionsTab — the version LISTING body of the Firewall v6 screen.
+   * VersionsTab — the version LISTING body of the Application v6 screen.
    *
-   * Lists every version of the Firewall with search/filter/sort and per-row
-   * actions (Clone / Archive / Delete). Clicking a version opens its FULL editor
-   * (VersionEditView). Owns its own versions query (deduped by queryKey).
+   * Lists every version of the Application with search/filter/sort and per-row
+   * actions (Clone / Archive / Delete / Promote). Clicking a version opens its
+   * FULL editor (VersionEditView). Owns its own versions query (deduped by
+   * queryKey), and reads the shared menu host provided by ResourceVersionLanding.
    */
   import { computed, inject, ref } from 'vue'
   import { useRouter } from 'vue-router'
@@ -14,16 +15,16 @@
   import VersionListDataView from '@/components/VersionListDataView'
   import VersionActionDialog from '@/templates/version-shell-block/components/VersionActionDialog.vue'
 
-  import { edgeFirewallVersionService } from '@/services/v2/edge-firewall/edge-firewall-version-service'
+  import { edgeAppVersionService } from '@/services/v2/edge-app/edge-app-version-service'
   import { useVersionList } from '@/composables/versioning/use-version-list'
   import { useActiveVersions } from '@/composables/versioning/use-active-versions'
   import { getVersionListColumns } from '@/composables/versioning/version-list-columns'
   import { useVersionMenuActions } from '@/composables/versioning/use-version-menu-actions'
 
-  defineOptions({ name: 'firewall-v6-versions-tab' })
+  defineOptions({ name: 'application-v6-versions-tab' })
 
   const props = defineProps({
-    firewallId: {
+    applicationId: {
       type: [String, Number],
       required: true
     }
@@ -32,13 +33,16 @@
   const router = useRouter()
   const toast = useToast()
 
-  const firewallId = computed(() => String(props.firewallId))
+  const applicationId = computed(() => String(props.applicationId))
   const isCreatingDraft = ref(false)
 
-  const versionsQuery = edgeFirewallVersionService.useListVersionsQuery(firewallId.value)
+  const versionsQuery = edgeAppVersionService.useListVersionsQuery(applicationId.value)
   const rawVersions = computed(() => versionsQuery.data.value?.body ?? [])
 
-  const resourceRef = computed(() => ({ resourceType: 'firewall', resourceId: firewallId.value }))
+  const resourceRef = computed(() => ({
+    resourceType: 'application',
+    resourceId: applicationId.value
+  }))
   const { activeVersions, refresh: refreshActiveVersions } = useActiveVersions(resourceRef)
 
   const { items, searchTerm, filterValues, sort, filters, sortOptions } = useVersionList(
@@ -53,11 +57,9 @@
   const goToVersion = (versionIdOrObject) => {
     const id = typeof versionIdOrObject === 'string' ? versionIdOrObject : versionIdOrObject?.id
     if (!id) return
-    router.push(`/firewalls/edit/${firewallId.value}/versions/${id}`)
+    router.push(`/applications/edit/${applicationId.value}/versions/${id}`)
   }
 
-  // The landing owns the release drawer; the tab only routes through the
-  // single shared row-menu driver (spec §3.3/3.6, Req 1.4/10.1).
   const menuHost = inject('versionMenuHost', {})
 
   const {
@@ -68,9 +70,9 @@
     handleConfirm,
     handleVisibility
   } = useVersionMenuActions({
-    resourceType: 'firewall',
-    resourceId: firewallId,
-    versionService: edgeFirewallVersionService,
+    resourceType: 'application',
+    resourceId: applicationId,
+    versionService: edgeAppVersionService,
     router,
     openPromoteDrawer: menuHost.openPromoteDrawer,
     onSuccess: () => {
@@ -83,7 +85,7 @@
     if (isCreatingDraft.value) return
     isCreatingDraft.value = true
     try {
-      const draft = await edgeFirewallVersionService.createDraft(firewallId.value, {})
+      const draft = await edgeAppVersionService.createDraft(applicationId.value, {})
       if (draft?.id) goToVersion(draft.id)
     } catch (err) {
       if (err && typeof err.showErrors === 'function') {
@@ -103,7 +105,7 @@
 </script>
 
 <template>
-  <div data-testid="firewall-v6-versions-tab">
+  <div data-testid="application-v6-versions-tab">
     <VersionListDataView
       :items="items"
       :columns="columns"
@@ -116,25 +118,25 @@
       :sort="sort"
       :sort-options="sortOptions"
       :show-row-actions="true"
-      resource-type="firewall"
+      resource-type="application"
       :paginator-rows="20"
       search-placeholder="Search versions"
       :empty-state="{
-        title: 'This firewall has no versions yet',
+        title: 'This application has no versions yet',
         description:
-          'Create the first version to start configuring this firewall with the v6 versioning workflow.',
+          'Create the first version to start configuring this application with the v6 versioning workflow.',
         buttonLabel: 'New Version',
         buttonAction: createDraft
       }"
       :error-state="{
         title: 'Failed to load versions',
-        description: 'Something went wrong loading this firewall’s versions. Try again.',
+        description: 'Something went wrong loading this application’s versions. Try again.',
         buttonLabel: 'Retry',
         buttonAction: () => versionsQuery.refetch?.()
       }"
       filtered-empty-title="No versions match your filters"
       filtered-empty-description="Try a different search term or status filter."
-      data-testid="firewall-v6-versions__table"
+      data-testid="application-v6-versions__table"
       @update:search-term="searchTerm = $event"
       @update:filter-values="filterValues = $event"
       @update:sort="sort = $event"
@@ -148,7 +150,7 @@
           icon="pi pi-plus"
           size="small"
           :loading="isCreatingDraft"
-          data-testid="firewall-v6-versions__new-draft"
+          data-testid="application-v6-versions__new-draft"
           @click="createDraft"
           class="h-[2.5rem]"
         />

--- a/src/views/EdgeFirewall/v6/EditView.vue
+++ b/src/views/EdgeFirewall/v6/EditView.vue
@@ -2,6 +2,7 @@
   import VersionsTab from '@/views/EdgeFirewall/v6/tabs/VersionsTab.vue'
   import MainSettingsTab from '@/views/EdgeFirewall/v6/tabs/MainSettingsTab.vue'
   import ResourceVersionLanding from '@/templates/version-shell-block/ResourceVersionLanding.vue'
+  import ResourceOverviewBlock from '@/templates/version-shell-block/ResourceOverviewBlock.vue'
   import ScopedVariablesTab from '@/views/Variables/v6/components/ScopedVariablesTab.vue'
   import { useResourceVersionLanding } from '@/composables/versioning/use-resource-version-landing'
   import { edgeFirewallService } from '@/services/v2/edge-firewall/edge-firewall-service'
@@ -20,14 +21,19 @@
     deployResourceContext,
     handleCommandSuccess,
     handleCommandError,
-    handleCancel
+    handleCancel,
+    versionsQuery,
+    rawVersions,
+    activeVersions,
+    activeVersionsLoading
   } = useResourceVersionLanding({
     load: (id) => edgeFirewallService.loadEdgeFirewallService({ id }),
     provideKey: 'edgeFirewall',
     versionService: edgeFirewallVersionService,
     resourceType: 'firewall',
     routeName: 'edit-firewall',
-    versionRouteName: 'edit-firewall-version'
+    versionRouteName: 'edit-firewall-version',
+    showOverview: true
   })
 
   const pageDescription =
@@ -48,8 +54,20 @@
     :latest-version-id="latestVersionId"
     empty-state-description="Create a version on the Versions tab to start configuring this Firewall."
     testid-prefix="firewall-v6-edit"
+    :show-overview="true"
     :show-variables="true"
   >
+    <template #overview>
+      <ResourceOverviewBlock
+        resource-type="firewall"
+        :resource-id="resourceId"
+        :raw-versions="rawVersions"
+        :active-versions="activeVersions"
+        :active-versions-loading="activeVersionsLoading"
+        :versions-query="versionsQuery"
+        testid-prefix="firewall-v6-overview"
+      />
+    </template>
     <template #versions>
       <VersionsTab :firewall-id="resourceId" />
     </template>

--- a/src/views/RealTimeEventsV2/Blocks/components/event-document-view.vue
+++ b/src/views/RealTimeEventsV2/Blocks/components/event-document-view.vue
@@ -381,8 +381,7 @@
                   : 'json-pre--compact'
             "
             data-testid="event-document-json"
-            >{{ jsonDocument }}</pre
-          >
+            >{{ jsonDocument }}</pre>
         </div>
       </TabPanel>
     </TabView>


### PR DESCRIPTION
## Summary
- Adds the **Overview** tab (default landing) to Edge Applications and Edge Firewall, showing **Live Deployments** (versions currently receiving traffic) and **Version History** (remaining versions with search / status filter / paginate)
- Replaces the previous per-row Traffic tag (from ENG-46624) on the Versions tab of these two resources; other versioned resources are untouched
- Plug-and-play scaffolding: `OVERVIEW_RESOURCE_CONFIG` + shared `createNameBasedWorkloadResolver()`, so a new resource type can opt in with one registry entry + one resolver
- Rows in both tables are clickable (opens the version editor); Version History keeps the full row menu (Clone / Archive / Delete / Promote)
- Skeleton loading state now waits for BOTH the versions query and the active-versions query to settle, matching the pattern used by `GenericDataView`

## Out of scope (per ticket)
- Metrics section (Requests / Errors / CPU Time) — placeholder-only, layout preserved for a follow-up
- Other versioned resources (Edge Functions, Connectors, Network Lists, WAF, Custom Pages) keep their current behavior — no Overview tab, no regression

## Test plan
- [ ] Edge Application: Overview loads with skeleton, then shows Live Deployments (Version + Live tag, Environment, Workload=—, Deployed) and Version History
- [ ] Edge Firewall: same shape as above
- [ ] Row-click on Live Deployments navigates to the correct version editor (composite `id` normalized)
- [ ] Row-click on Version History navigates to the version editor; kebab actions still work (Clone / Archive / Delete / Promote)
- [ ] Deleting a live version refreshes both tables (versions + active-versions)
- [ ] Versions tab of App/Firewall no longer shows the Traffic column
- [ ] Custom Pages / WAF / Edge Functions / Connectors / Network Lists — Traffic column still present, no Overview tab, no regression
- [ ] Loading state: `use-live-deployments` unit tests (`yarn test:unit:headless run src/tests/composables/versioning/use-live-deployments.test.js`)
- [ ] Manual QA against `docs/testing/versioning-overview-tab.feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)