### PR TITLE
[ENG-37279] fix: render external sidebar links as anchors to avoid 404 on current tab

### DIFF
--- a/src/layout/components/menu-production/index.vue
+++ b/src/layout/components/menu-production/index.vue
@@ -43,8 +43,12 @@
       @focus="scrollToFocusedItem"
     >
       <template #item="{ item, label, props }">
-        <router-link
-          :to="item.to"
+        <component
+          :is="item.external ? 'a' : 'router-link'"
+          :to="item.external ? undefined : item.to"
+          :href="item.external ? item.to : undefined"
+          :target="item.external ? '_blank' : undefined"
+          :rel="item.external ? 'noopener noreferrer' : undefined"
           @click.prevent="redirectToRoute(item)"
           @click.middle="windowOpen(item.to)"
           :data-testid="`sidebar-block__menu-item__${item.id}`"
@@ -60,7 +64,7 @@
             :value="item.tag"
             class="ml-2"
           />
-        </router-link>
+        </component>
       </template>
     </PrimeMenu>
   </Sidebar>

--- a/src/tests/layout/menu-production.test.js
+++ b/src/tests/layout/menu-production.test.js
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MenuProduction from '@/layout/components/menu-production/index.vue'
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  windowOpen: vi.fn(),
+  menus: []
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.routerPush })
+}))
+
+vi.mock('@/helpers/window-open', () => ({
+  windowOpen: mocks.windowOpen
+}))
+
+vi.mock('@vueuse/core', async () => {
+  const { ref } = await vi.importActual('vue')
+  return {
+    useMagicKeys: () => ({ meta: ref(false), control: ref(false) })
+  }
+})
+
+vi.mock('@/stores/account', () => ({
+  useAccountStore: () => ({
+    account: { kind: 'client', client_flags: [] },
+    hasAccessToMarketplaceProducts: true
+  })
+}))
+
+vi.mock('@services/sidebar-menus-services', () => ({
+  listSidebarMenusService: () => ({ body: { menus: mocks.menus } })
+}))
+
+vi.mock('@aziontech/webkit/button', () => ({
+  default: { template: '<button><slot /></button>' }
+}))
+
+vi.mock('@aziontech/webkit/prime-tag', () => ({
+  default: { template: '<span><slot /></span>' }
+}))
+
+vi.mock('@aziontech/webkit/sidebar', () => ({
+  default: { template: '<div><slot /></div>' }
+}))
+
+// PrimeMenu stub: renders the #item slot for each leaf menu item, mirroring how
+// the real component drives the slot with { item, label, props }.
+vi.mock('@aziontech/webkit/menu', () => ({
+  default: {
+    props: ['model'],
+    computed: {
+      leaves() {
+        return this.model.flatMap((entry) => (entry.items ? entry.items : [entry]))
+      }
+    },
+    template: `
+      <div>
+        <template v-for="(item, index) in leaves" :key="index">
+          <slot
+            name="item"
+            :item="item"
+            :label="item.label"
+            :props="{ action: {}, icon: {}, label: {} }"
+          />
+        </template>
+      </div>
+    `
+  }
+}))
+
+const RouterLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>'
+}
+
+const mountMenu = () =>
+  mount(MenuProduction, {
+    global: {
+      stubs: {
+        RouterLink: RouterLinkStub
+      },
+      directives: {
+        tooltip: () => {}
+      }
+    }
+  })
+
+describe('sidebar-block (menu-production)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.menus = []
+  })
+
+  it('opens external items in a new tab without navigating the current tab', async () => {
+    const externalUrl = 'https://caixa-siem.azion.com/login'
+    mocks.menus = [{ label: 'SIEM', to: externalUrl, id: 'siem', external: true }]
+
+    const wrapper = mountMenu()
+    const link = wrapper.get('[data-testid="sidebar-block__menu-item__siem"]')
+
+    // Regression guard: external links must render as a plain anchor targeting a
+    // new tab, never as a router-link (which resolves the absolute URL into a
+    // broken relative route and 404s the current tab).
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('href')).toBe(externalUrl)
+    expect(link.attributes('target')).toBe('_blank')
+    expect(link.attributes('rel')).toBe('noopener noreferrer')
+
+    await link.trigger('click')
+
+    expect(mocks.windowOpen).toHaveBeenCalledWith(externalUrl)
+    expect(mocks.routerPush).not.toHaveBeenCalled()
+  })
+
+  it('navigates internal items within the same tab', async () => {
+    mocks.menus = [{ label: 'Variables', to: '/variables', id: 'variables' }]
+
+    const wrapper = mountMenu()
+    const link = wrapper.get('[data-testid="sidebar-block__menu-item__variables"]')
+
+    expect(link.attributes('target')).toBeUndefined()
+
+    await link.trigger('click')
+
+    expect(mocks.routerPush).toHaveBeenCalledWith('/variables')
+    expect(mocks.windowOpen).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Bug fix

### What was the problem?

External sidebar menu items — the **Marketplace Products** entries such as **SIEM** and **Bot Manager** (visible for accounts with the `MARKETPLACE_PRODUCTS` flag, e.g. Caixa Econômica Federal) — were rendered with a `<router-link>`. Because their `to` is an absolute external URL (e.g. `https://caixa-siem.azion.com/login`), Vue Router did not recognize it as a route and resolved it relative to the current path, producing a broken location like `/real-time-metrics/edge-applications/https://caixa-siem.azion.com/login`.

On click, two handlers ran on the same anchor: `RouterLink`'s internal navigation pushed the current tab to that broken route (**404 on the original console tab**), while `windowOpen` correctly opened the target in a new tab. The result was the target opening fine in a new tab, but the original tab left showing a 404 page.

### Expected behavior

Clicking an external menu item opens the target in a new tab and leaves the original console tab unchanged on the current page.

### How was it solved

External items are now rendered as a plain `<a target="_blank" rel="noopener noreferrer">` via a dynamic `<component :is>` instead of a `<router-link>`, so no router navigation runs on the current tab. Internal items keep using `router-link` and behave exactly as before. This mirrors the external-link pattern already used in the help sidebar.

Added unit tests for the sidebar menu covering both paths:
- external item → renders an anchor with `target="_blank"`, calls `windowOpen`, and does **not** call `router.push`;
- internal item → calls `router.push` and does **not** open a new tab.

### How to test

1. Run the unit tests: `npx vitest run src/tests/layout/menu-production.test.js` — both cases should pass.
2. Manual (with an account that has the `MARKETPLACE_PRODUCTS` flag, or temporarily forcing the **Marketplace Products** group visible):
   - Log in with a client account and navigate to a nested route (e.g. **Real-Time Metrics**).
   - Open the sidebar (☰) → **Marketplace Products** → click **SIEM**.
   - Expected: SIEM opens in a new tab and the original tab stays on the current page (no 404).

### UI Changes (if applicable)

N/A — no visual change. Only the navigation behavior of external sidebar items was fixed.
