### PR TITLE
fix: exclude /sse from index.html redirect rule

### DIFF
--- a/azion.config.mjs
+++ b/azion.config.mjs
@@ -7,9 +7,7 @@ const environment = VITE_ENVIRONMENT || 'production'
 const domainSuffix = environment === 'production' ? 'net' : 'com'
 
 const edgeApiHost =
-  environment === 'production'
-    ? 'jkjuyhi0gza.map.azionedge.net'
-    : 'urvlgkvpxla.map.azionedge.net'
+  environment === 'production' ? 'jkjuyhi0gza.map.azionedge.net' : 'urvlgkvpxla.map.azionedge.net'
 
 const addStagePrefix = (origin) => {
   if (environment === 'stage') {
@@ -348,6 +346,12 @@ const config = {
             conditional: 'and',
             operator: 'does_not_match',
             inputValue: '^/edge_api'
+          },
+          {
+            variable: '${uri}',
+            conditional: 'and',
+            operator: 'does_not_match',
+            inputValue: '^/sse'
           },
           {
             variable: '${uri}',


### PR DESCRIPTION
## Bug fix

### What was the problem?

The `Redirect All Non-Asset Requests to index.html` rule in `azion.config.mjs` did not exclude `/sse` requests. As a result, requests to the `/sse` endpoint were caught by this catch-all rule and rewritten to `/index.html`, instead of being routed to the SSE endpoint. This routing was previously handled by a manual rule outside the IaC config, causing configuration drift between the live edge configuration and the versioned `azion.config.mjs`.

### Expected behavior

Requests to `/sse` must not be rewritten to `/index.html`. They should bypass the static-asset redirect rule so the Server-Sent Events endpoint is reached correctly, with the routing declared in the IaC config.

### How was it solved

Added a `does_not_match` criterion for `^/sse` to the rule's criteria list, alongside the existing exclusions (`^/api`, `^/v4`, `^/graphql`, `^/billing/invoices`, `^/edge_api`). This brings the `/sse` routing exclusion into the versioned IaC config.

### How to test

1. Build/deploy the edge configuration from `azion.config.mjs`.
2. Make a request to an `/sse` path.
3. Confirm the request is **not** rewritten to `/index.html` and the SSE connection is established.
4. Verify that regular application routes (non-asset paths) still fall through to `/index.html` as before.
