### PR TITLE
fix: time filter Set Now scope and now/relative UTC drift in Real Time Events

### DIFF
--- a/src/components/base/advanced-filter-system-v2/__tests__/now-relative-utc-instant.spec.js
+++ b/src/components/base/advanced-filter-system-v2/__tests__/now-relative-utc-instant.spec.js
@@ -1,0 +1,158 @@
+/* eslint-disable xss/no-mixed-html -- `template` strings here are Vue stub component templates, not HTML sinks */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+
+import AdvancedFilterSystem from '../index.vue'
+import { useAccountStore } from '@/stores/account'
+
+vi.mock('@/services/users-services', () => ({
+  listTimezonesService: vi.fn().mockResolvedValue([])
+}))
+
+const DataTimeRangeStub = {
+  name: 'DataTimeRange',
+  emits: ['autoRefresh', 'update:modelValue', 'select'],
+  template: '<div data-testid="stub-data-time-range" />',
+  methods: {
+    closeOverlay() {}
+  }
+}
+
+const stubs = {
+  DataTimeRange: DataTimeRangeStub,
+  FilterFields: { name: 'FilterFields', template: '<div />' },
+  AzionQueryLanguage: {
+    name: 'AzionQueryLanguage',
+    props: ['fieldsInFilter', 'searchAdvancedFilter', 'filterAdvanced', 'dataset'],
+    template: '<div />',
+    methods: {
+      getParsedFilters() {
+        return []
+      },
+      markAsApplied() {}
+    }
+  },
+  FilterTagsDisplay: { name: 'FilterTagsDisplay', template: '<div />' },
+  PrimeButton: { name: 'PrimeButton', template: '<button />' }
+}
+
+const NOW_INSTANT = new Date('2026-07-30T12:00:00Z')
+const HOUR_MS = 36e5
+
+const mountFilter = ({ tsRange, utcOffset }) => {
+  const pinia = createPinia()
+  const accountStore = useAccountStore(pinia)
+  accountStore.$patch({ account: { utc_offset: utcOffset } })
+
+  const filterData = {
+    fields: [],
+    tsRange: { label: '', labelStart: '', labelEnd: '', ...tsRange }
+  }
+  const wrapper = mount(AdvancedFilterSystem, {
+    props: {
+      filterData,
+      'onUpdate:filterData': (value) => {
+        wrapper.setProps({ filterData: value })
+      },
+      fieldsInFilter: [],
+      filterDateRangeMaxDays: 7,
+      isLoadingFilters: false,
+      hideFilterTags: false,
+      dataset: 'httpEvents'
+    },
+    global: { plugins: [pinia], stubs }
+  })
+  return wrapper
+}
+
+const applyTimeUpdate = async (wrapper) => {
+  wrapper.findComponent(DataTimeRangeStub).vm.$emit('autoRefresh')
+  await nextTick()
+}
+
+const appliedTsRange = (wrapper) => wrapper.props('filterData').tsRange
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW_INSTANT)
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      media: '',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('AdvancedFilterSystem — now and relative ranges resolve to the real UTC instant', () => {
+  const relativeTsRange = () => ({
+    tsRangeBegin: '2026-07-30T11:55:00Z',
+    tsRangeEnd: '2026-07-30T12:00:00Z',
+    label: 'Last 5 minutes'
+  })
+
+  it.each(['+0000', '-0300'])(
+    'a relative label applies the true instant window under account offset %s',
+    async (utcOffset) => {
+      const wrapper = mountFilter({ tsRange: relativeTsRange(), utcOffset })
+      await nextTick()
+
+      await applyTimeUpdate(wrapper)
+
+      const { tsRangeBegin, tsRangeEnd } = appliedTsRange(wrapper)
+      expect(tsRangeEnd).toBe('2026-07-30T12:00:00Z')
+      expect(tsRangeBegin).toBe('2026-07-30T11:55:00Z')
+    }
+  )
+
+  it.each(['+0000', '-0300'])(
+    'labelEnd "now" applies the true current instant under account offset %s',
+    async (utcOffset) => {
+      const wrapper = mountFilter({
+        tsRange: {
+          tsRangeBegin: '2026-07-30T09:00:00Z',
+          tsRangeEnd: '2026-07-30T10:00:00Z',
+          labelEnd: 'now'
+        },
+        utcOffset
+      })
+      await nextTick()
+
+      await applyTimeUpdate(wrapper)
+
+      expect(appliedTsRange(wrapper).tsRangeEnd).toBe('2026-07-30T12:00:00Z')
+    }
+  )
+
+  it('keeps wall-clock reinterpretation for the absolute start endpoint (hybrid range)', async () => {
+    const hybridTsRange = () => ({
+      tsRangeBegin: '2026-07-30T09:00:00Z',
+      tsRangeEnd: '2026-07-30T10:00:00Z',
+      labelEnd: 'now'
+    })
+
+    const wrapperUtc = mountFilter({ tsRange: hybridTsRange(), utcOffset: '+0000' })
+    const wrapperMinus3 = mountFilter({ tsRange: hybridTsRange(), utcOffset: '-0300' })
+    await nextTick()
+
+    await applyTimeUpdate(wrapperUtc)
+    await applyTimeUpdate(wrapperMinus3)
+
+    const beginUtc = new Date(appliedTsRange(wrapperUtc).tsRangeBegin).getTime()
+    const beginMinus3 = new Date(appliedTsRange(wrapperMinus3).tsRangeBegin).getTime()
+    expect(beginMinus3 - beginUtc).toBe(3 * HOUR_MS)
+  })
+})

--- a/src/components/base/advanced-filter-system-v2/filterAQL/azion-query-language.vue
+++ b/src/components/base/advanced-filter-system-v2/filterAQL/azion-query-language.vue
@@ -60,8 +60,7 @@
       >
         <template #option="slotProps">
           <div
-            class="w-full rounded-md"
-            style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+            class="w-full rounded-md font-code"
             :data-testid="`azion-query-language-list-item${slotProps.index}`"
             @mousedown.prevent.stop="onOptionMouseDown(slotProps.option)"
             :class="[
@@ -542,7 +541,7 @@
     overflow: hidden;
     max-height: 400px;
     overflow-y: auto;
-    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    @apply font-code;
     font-size: 0.8125rem;
   }
 
@@ -627,7 +626,7 @@
 
   .aql-recent-queries__query {
     flex-shrink: 0;
-    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    @apply font-code;
     font-size: 0.8125rem;
     color: var(--text-color);
     white-space: nowrap;
@@ -635,7 +634,7 @@
 
   .aql-recent-queries__value {
     flex: 1;
-    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    @apply font-code;
     font-size: 0.8125rem;
     color: var(--text-color);
     overflow: hidden;

--- a/src/components/base/advanced-filter-system-v2/filterAQL/content-editable.vue
+++ b/src/components/base/advanced-filter-system-v2/filterAQL/content-editable.vue
@@ -4,7 +4,7 @@
     ref="editable"
     contenteditable
     placeholder="Filter using Azion Query Language syntax..."
-    class="contenteditable p-inputtext font-normal text-sm w-full h-auto whitespace-pre font-mono min-h-9 max-h-24 min-w-0 overflow-x-hidden overflow-y-auto empty:before:content-[attr(placeholder)] empty:before:block empty:before:text-[color:var(--input-placeholder-text-color)] empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:pointer-events-none"
+    class="contenteditable p-inputtext font-normal text-sm w-full h-auto whitespace-pre min-h-9 max-h-24 min-w-0 overflow-x-hidden overflow-y-auto empty:before:content-[attr(placeholder)] empty:before:block empty:before:text-[color:var(--input-placeholder-text-color)] empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:pointer-events-none"
     @input="handleInput"
     @keyup="updateCursorOffset"
     @mouseup="updateCursorOffset"
@@ -89,3 +89,10 @@
     getCursorOffset: () => cursorOffset.value
   })
 </script>
+
+<style scoped>
+  .contenteditable {
+    font-family:
+      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  }
+</style>

--- a/src/components/base/advanced-filter-system-v2/filterAQL/content-editable.vue
+++ b/src/components/base/advanced-filter-system-v2/filterAQL/content-editable.vue
@@ -4,7 +4,7 @@
     ref="editable"
     contenteditable
     placeholder="Filter using Azion Query Language syntax..."
-    class="contenteditable p-inputtext font-normal text-sm w-full h-auto whitespace-pre min-h-9 max-h-24 min-w-0 overflow-x-hidden overflow-y-auto empty:before:content-[attr(placeholder)] empty:before:block empty:before:text-[color:var(--input-placeholder-text-color)] empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:pointer-events-none"
+    class="p-inputtext font-normal text-sm w-full h-auto whitespace-pre font-code min-h-9 max-h-24 min-w-0 overflow-x-hidden overflow-y-auto empty:before:content-[attr(placeholder)] empty:before:block empty:before:text-[color:var(--input-placeholder-text-color)] empty:before:whitespace-nowrap empty:before:overflow-hidden empty:before:text-ellipsis empty:before:pointer-events-none"
     @input="handleInput"
     @keyup="updateCursorOffset"
     @mouseup="updateCursorOffset"
@@ -89,10 +89,3 @@
     getCursorOffset: () => cursorOffset.value
   })
 </script>
-
-<style scoped>
-  .contenteditable {
-    font-family:
-      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
-  }
-</style>

--- a/src/components/base/advanced-filter-system-v2/index.vue
+++ b/src/components/base/advanced-filter-system-v2/index.vue
@@ -174,11 +174,22 @@
       filterDataRange.value.endDate = endDate
     }
 
-    const { tsRangeBegin, tsRangeEnd } = updatedTimeRange(
-      filterDataRange.value.startDate,
-      filterDataRange.value.endDate,
-      selectedUtcOffset
-    )
+    const startIsInstant =
+      isNowLabel(filterDataRange.value.labelStart) ||
+      Boolean(labelStartParsed) ||
+      Boolean(labelParsed)
+    const endIsInstant =
+      isNowLabel(filterDataRange.value.labelEnd) ||
+      isNowLabel(filterDataRange.value.label) ||
+      Boolean(labelEndParsed) ||
+      Boolean(labelParsed)
+
+    const tsRangeBegin = startIsInstant
+      ? toInstantIso(filterDataRange.value.startDate)
+      : toOffsetIso(filterDataRange.value.startDate, selectedUtcOffset)
+    const tsRangeEnd = endIsInstant
+      ? toInstantIso(filterDataRange.value.endDate)
+      : toOffsetIso(filterDataRange.value.endDate, selectedUtcOffset)
 
     let cappedBegin = tsRangeBegin
     if (props.filterDateRangeMaxDays > 0) {
@@ -302,44 +313,27 @@
     applyFilters()
   }
 
-  const updatedTimeRange = (begin, end, userUTC) => {
-    const beginDate = new Date(begin)
-    const endDate = new Date(end)
+  const isNowLabel = (label) => typeof label === 'string' && label.trim() === 'now'
 
-    const dateBegin = createUtcDateFromUserTimezoneParts(
+  const toInstantIso = (value) => new Date(value).toISOString().replace(/\.\d{3}/, '')
+
+  const toOffsetIso = (value, userUTC) => {
+    const date = new Date(value)
+
+    return createUtcDateFromUserTimezoneParts(
       {
-        year: beginDate.getFullYear(),
-        monthIndex: beginDate.getMonth(),
-        day: beginDate.getDate(),
-        hour: beginDate.getHours(),
-        minute: beginDate.getMinutes(),
-        second: beginDate.getSeconds(),
-        millisecond: beginDate.getMilliseconds()
+        year: date.getFullYear(),
+        monthIndex: date.getMonth(),
+        day: date.getDate(),
+        hour: date.getHours(),
+        minute: date.getMinutes(),
+        second: date.getSeconds(),
+        millisecond: date.getMilliseconds()
       },
       userUTC
     )
       .toISOString()
       .replace(/\.\d{3}/, '')
-
-    const dateEnd = createUtcDateFromUserTimezoneParts(
-      {
-        year: endDate.getFullYear(),
-        monthIndex: endDate.getMonth(),
-        day: endDate.getDate(),
-        hour: endDate.getHours(),
-        minute: endDate.getMinutes(),
-        second: endDate.getSeconds(),
-        millisecond: endDate.getMilliseconds()
-      },
-      userUTC
-    )
-      .toISOString()
-      .replace(/\.\d{3}/, '')
-
-    return {
-      tsRangeBegin: dateBegin,
-      tsRangeEnd: dateEnd
-    }
   }
 
   onMounted(() => {

--- a/src/components/base/advanced-filter-system/__tests__/now-relative-utc-instant.spec.js
+++ b/src/components/base/advanced-filter-system/__tests__/now-relative-utc-instant.spec.js
@@ -1,0 +1,170 @@
+/* eslint-disable xss/no-mixed-html -- `template` strings here are Vue stub component templates, not HTML sinks */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+
+import AdvancedFilterSystem from '../index.vue'
+import { useAccountStore } from '@/stores/account'
+
+vi.mock('@/services/v2/listTimezones', () => ({
+  listTimezonesService: {
+    listTimezones: vi.fn().mockResolvedValue({ listTimeZones: [] })
+  }
+}))
+
+const DataTimeRangeStub = {
+  name: 'DataTimeRange',
+  emits: ['autoRefresh', 'update:modelValue', 'select'],
+  template: '<div data-testid="stub-data-time-range" />'
+}
+
+const stubs = {
+  DataTimeRange: DataTimeRangeStub,
+  DialogFilter: { name: 'DialogFilter', template: '<div />' },
+  AzionQueryLanguage: {
+    name: 'AzionQueryLanguage',
+    props: ['fieldsInFilter', 'searchAdvancedFilter', 'filterAdvanced'],
+    template: '<div />',
+    methods: {
+      getParsedFilters() {
+        return []
+      },
+      markAsApplied() {}
+    }
+  },
+  FilterTagsDisplay: { name: 'FilterTagsDisplay', template: '<div />' },
+  PrimeButton: { name: 'PrimeButton', template: '<button />' }
+}
+
+const NOW_INSTANT = new Date('2026-07-30T12:00:00Z')
+const HOUR_MS = 36e5
+
+const mountFilter = ({ tsRange, utcOffset }) => {
+  const pinia = createPinia()
+  const accountStore = useAccountStore(pinia)
+  accountStore.$patch({ account: { utc_offset: utcOffset } })
+
+  const filterData = {
+    fields: [],
+    tsRange: { label: '', ...tsRange }
+  }
+  const wrapper = mount(AdvancedFilterSystem, {
+    props: {
+      filterData,
+      'onUpdate:filterData': (value) => {
+        wrapper.setProps({ filterData: value })
+      },
+      fieldsInFilter: [],
+      filterDateRangeMaxDays: 7,
+      isLoadingFilters: false,
+      hideFilterTags: false
+    },
+    global: { plugins: [pinia], stubs }
+  })
+  return wrapper
+}
+
+const seedPickerModel = async (wrapper, model) => {
+  wrapper.findComponent(DataTimeRangeStub).vm.$emit('update:modelValue', model)
+  await nextTick()
+}
+
+const applyTimeUpdate = async (wrapper) => {
+  wrapper.findComponent(DataTimeRangeStub).vm.$emit('autoRefresh')
+  await nextTick()
+}
+
+const appliedTsRange = (wrapper) => wrapper.props('filterData').tsRange
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW_INSTANT)
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      media: '',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('AdvancedFilterSystem v1 — now and relative ranges resolve to the real UTC instant', () => {
+  const relativeTsRange = () => ({
+    tsRangeBegin: '2026-07-30T11:55:00Z',
+    tsRangeEnd: '2026-07-30T12:00:00Z',
+    label: 'Last 5 minutes'
+  })
+
+  const nowPickerModel = () => ({
+    startDate: new Date('2026-07-30T09:00:00Z'),
+    endDate: new Date('2026-07-30T10:00:00Z'),
+    label: '',
+    labelStart: '',
+    labelEnd: 'now'
+  })
+
+  it.each(['+0000', '-0300'])(
+    'a relative label applies the true instant window under account offset %s',
+    async (utcOffset) => {
+      const wrapper = mountFilter({ tsRange: relativeTsRange(), utcOffset })
+      await nextTick()
+
+      await applyTimeUpdate(wrapper)
+
+      const { tsRangeBegin, tsRangeEnd } = appliedTsRange(wrapper)
+      expect(tsRangeEnd).toBe('2026-07-30T12:00:00')
+      expect(tsRangeBegin).toBe('2026-07-30T11:55:00')
+    }
+  )
+
+  it.each(['+0000', '-0300'])(
+    'labelEnd "now" applies the true current instant under account offset %s',
+    async (utcOffset) => {
+      const wrapper = mountFilter({
+        tsRange: {
+          tsRangeBegin: '2026-07-30T09:00:00Z',
+          tsRangeEnd: '2026-07-30T10:00:00Z'
+        },
+        utcOffset
+      })
+      await nextTick()
+      await seedPickerModel(wrapper, nowPickerModel())
+
+      await applyTimeUpdate(wrapper)
+
+      expect(appliedTsRange(wrapper).tsRangeEnd).toBe('2026-07-30T12:00:00')
+    }
+  )
+
+  it('keeps wall-clock reinterpretation for the absolute start endpoint (hybrid range)', async () => {
+    const baseTsRange = () => ({
+      tsRangeBegin: '2026-07-30T09:00:00Z',
+      tsRangeEnd: '2026-07-30T10:00:00Z'
+    })
+
+    const wrapperUtc = mountFilter({ tsRange: baseTsRange(), utcOffset: '+0000' })
+    const wrapperMinus3 = mountFilter({ tsRange: baseTsRange(), utcOffset: '-0300' })
+    await nextTick()
+    await seedPickerModel(wrapperUtc, nowPickerModel())
+    await seedPickerModel(wrapperMinus3, nowPickerModel())
+
+    await applyTimeUpdate(wrapperUtc)
+    await applyTimeUpdate(wrapperMinus3)
+
+    const beginUtc = new Date(appliedTsRange(wrapperUtc).tsRangeBegin).getTime()
+    const beginMinus3 = new Date(appliedTsRange(wrapperMinus3).tsRangeBegin).getTime()
+    expect(beginMinus3 - beginUtc).toBe(3 * HOUR_MS)
+  })
+})

--- a/src/components/base/advanced-filter-system/filterAQL/azion-query-language.vue
+++ b/src/components/base/advanced-filter-system/filterAQL/azion-query-language.vue
@@ -54,7 +54,8 @@
     >
       <template #option="slotProps">
         <div
-          class="w-full rounded-md font-mono"
+          class="w-full rounded-md"
+          style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
           :data-testid="`azion-query-language-list-item${slotProps.index}`"
           @mousedown.prevent.stop="onOptionMouseDown(slotProps.option)"
           :class="[

--- a/src/components/base/advanced-filter-system/filterAQL/azion-query-language.vue
+++ b/src/components/base/advanced-filter-system/filterAQL/azion-query-language.vue
@@ -54,8 +54,7 @@
     >
       <template #option="slotProps">
         <div
-          class="w-full rounded-md"
-          style="font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+          class="w-full rounded-md font-code"
           :data-testid="`azion-query-language-list-item${slotProps.index}`"
           @mousedown.prevent.stop="onOptionMouseDown(slotProps.option)"
           :class="[

--- a/src/components/base/advanced-filter-system/filterAQL/content-editable.vue
+++ b/src/components/base/advanced-filter-system/filterAQL/content-editable.vue
@@ -4,7 +4,7 @@
     ref="editable"
     contenteditable
     placeholder="Filter using Azion Query Language syntax..."
-    class="contenteditable p-inputtext font-normal text-sm w-full h-auto font-mono"
+    class="contenteditable p-inputtext font-normal text-sm w-full h-auto"
     @input="handleInput"
     @keyup="updateCursorOffset"
     @mouseup="updateCursorOffset"
@@ -79,6 +79,8 @@
 <style>
   .contenteditable {
     white-space: pre-wrap;
+    font-family:
+      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
   }
 
   .contenteditable:empty:before {

--- a/src/components/base/advanced-filter-system/filterAQL/content-editable.vue
+++ b/src/components/base/advanced-filter-system/filterAQL/content-editable.vue
@@ -4,7 +4,7 @@
     ref="editable"
     contenteditable
     placeholder="Filter using Azion Query Language syntax..."
-    class="contenteditable p-inputtext font-normal text-sm w-full h-auto"
+    class="p-inputtext font-normal text-sm w-full h-auto font-code whitespace-pre-wrap empty:before:content-[attr(placeholder)] empty:before:text-[color:var(--input-placeholder-text-color)] empty:before:pointer-events-none"
     @input="handleInput"
     @keyup="updateCursorOffset"
     @mouseup="updateCursorOffset"
@@ -75,17 +75,3 @@
     getCursorOffset: () => cursorOffset.value
   })
 </script>
-
-<style>
-  .contenteditable {
-    white-space: pre-wrap;
-    font-family:
-      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
-  }
-
-  .contenteditable:empty:before {
-    content: attr(placeholder);
-    color: var(--input-placeholder-text-color);
-    pointer-events: none;
-  }
-</style>

--- a/src/components/base/advanced-filter-system/index.vue
+++ b/src/components/base/advanced-filter-system/index.vue
@@ -135,11 +135,23 @@
       filterDataRange.value.endDate = endDate
     }
 
-    const { tsRangeBegin, tsRangeEnd } = updatedTimeRange(
-      filterDataRange.value.startDate,
-      filterDataRange.value.endDate,
-      selectedUtcOffset
-    )
+    const startIsInstant =
+      isNowLabel(filterDataRange.value.labelStart) ||
+      Boolean(labelStartParsed) ||
+      Boolean(labelParsed)
+    const endIsInstant =
+      isNowLabel(filterDataRange.value.labelEnd) ||
+      isNowLabel(filterDataRange.value.label) ||
+      Boolean(labelEndParsed) ||
+      Boolean(labelParsed)
+
+    const tsRangeBegin = startIsInstant
+      ? toInstantIso(filterDataRange.value.startDate)
+      : toOffsetIso(filterDataRange.value.startDate, selectedUtcOffset)
+    const tsRangeEnd = endIsInstant
+      ? toInstantIso(filterDataRange.value.endDate)
+      : toOffsetIso(filterDataRange.value.endDate, selectedUtcOffset)
+
     filterData.value.tsRange = {
       tsRangeBegin,
       tsRangeEnd
@@ -199,44 +211,27 @@
     applyFilters()
   }
 
-  const updatedTimeRange = (begin, end, userUTC) => {
-    const beginDate = new Date(begin)
-    const endDate = new Date(end)
+  const isNowLabel = (label) => typeof label === 'string' && label.trim() === 'now'
 
-    const dateBegin = createUtcDateFromUserTimezoneParts(
+  const toInstantIso = (value) => new Date(value).toISOString().replace(/(\..+)/, '')
+
+  const toOffsetIso = (value, userUTC) => {
+    const date = new Date(value)
+
+    return createUtcDateFromUserTimezoneParts(
       {
-        year: beginDate.getFullYear(),
-        monthIndex: beginDate.getMonth(),
-        day: beginDate.getDate(),
-        hour: beginDate.getHours(),
-        minute: beginDate.getMinutes(),
-        second: beginDate.getSeconds(),
-        millisecond: beginDate.getMilliseconds()
+        year: date.getFullYear(),
+        monthIndex: date.getMonth(),
+        day: date.getDate(),
+        hour: date.getHours(),
+        minute: date.getMinutes(),
+        second: date.getSeconds(),
+        millisecond: date.getMilliseconds()
       },
       userUTC
     )
       .toISOString()
       .replace(/(\..+)/, '')
-
-    const dateEnd = createUtcDateFromUserTimezoneParts(
-      {
-        year: endDate.getFullYear(),
-        monthIndex: endDate.getMonth(),
-        day: endDate.getDate(),
-        hour: endDate.getHours(),
-        minute: endDate.getMinutes(),
-        second: endDate.getSeconds(),
-        millisecond: endDate.getMilliseconds()
-      },
-      userUTC
-    )
-      .toISOString()
-      .replace(/(\..+)/, '')
-
-    return {
-      tsRangeBegin: dateBegin,
-      tsRangeEnd: dateEnd
-    }
   }
 
   onMounted(() => {

--- a/src/components/base/dataTimeRange-v2/index.vue
+++ b/src/components/base/dataTimeRange-v2/index.vue
@@ -344,13 +344,8 @@
     const now = new Date()
     model.value.label = ''
 
-    if (editingField.value === 'start') {
-      model.value.startDate = clampToBounds(now)
-      model.value.labelStart = 'now'
-    } else {
-      model.value.endDate = clampToBounds(now)
-      model.value.labelEnd = 'now'
-    }
+    model.value.endDate = clampToBounds(now)
+    model.value.labelEnd = 'now'
 
     handleSelect()
     closeOverlay()

--- a/src/components/base/dataTimeRange-v2/index.vue
+++ b/src/components/base/dataTimeRange-v2/index.vue
@@ -82,7 +82,10 @@
               @close="closeOverlay"
             />
           </TabPanel>
-          <TabPanel header="Now">
+          <TabPanel
+            v-if="showNowTab"
+            header="Now"
+          >
             <div class="flex flex-col gap-4 max-w-[300px] mb-2">
               <div class="text-sm text-color-secondary">
                 Selecting 'Set Now' sets the time dynamically to the exact moment of each refresh.
@@ -170,6 +173,7 @@
   const overlayPanel = ref(null)
   const activeTab = ref(0)
   const editingField = ref('start')
+  const showNowTab = ref(true)
   const isOverlayOpen = ref(false)
   const hasInitializedUtcOffset = ref(false)
   const timezoneOptions = ref([])
@@ -305,6 +309,8 @@
     const field = effectiveTab === 0 ? undefined : payload?.field
 
     if (field === 'start' || field === 'end') editingField.value = field
+
+    showNowTab.value = !(field === 'start' && !model.value?.label)
 
     if (!event) return
 

--- a/src/components/base/dataTimeRange-v2/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange-v2/inputDateRange/index.vue
@@ -313,7 +313,8 @@
   }
 
   const updateRange = () => {
-    const parsedDate = parseDateSimple(tempInputValue.value)
+    const typedValue = tempInputValue.value
+    const parsedDate = parseDateSimple(typedValue)
 
     if (parsedDate) {
       const boundedParsedDate = clampToBounds(parsedDate)
@@ -350,6 +351,10 @@
       model.value.labelEnd = ''
     }
     emitSelectIfValid()
+
+    if (props.mode === 'absolute' && (parsedDate || !typedValue)) {
+      emit('close')
+    }
   }
 
   if (model.value.startDate) {
@@ -524,13 +529,14 @@
             :placeholder="props.editingField === 'start' ? startDateInput : endDateInput"
             class="w-full"
             :readonly="mode !== 'absolute'"
+            :disabled="mode !== 'absolute'"
             @keydown.enter="updateRange"
           />
           <PrimeButton
+            v-if="mode === 'absolute'"
             label="Apply"
             @click="updateRange"
             outlined
-            :disabled="mode !== 'absolute'"
             class="whitespace-nowrap w-20"
             size="small"
           />

--- a/src/components/base/dataTimeRange-v2/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange-v2/inputDateRange/index.vue
@@ -135,7 +135,7 @@
 
   const sizeInput = (value) => {
     if (!value) return 7
-    return value.length
+    return Math.max(value.length, 5)
   }
 
   const clampToBounds = (date) => {

--- a/src/components/base/dataTimeRange/index.vue
+++ b/src/components/base/dataTimeRange/index.vue
@@ -342,13 +342,8 @@
     const now = new Date()
     model.value.label = ''
 
-    if (editingField.value === 'start') {
-      model.value.startDate = clampToBounds(now)
-      model.value.labelStart = 'now'
-    } else {
-      model.value.endDate = clampToBounds(now)
-      model.value.labelEnd = 'now'
-    }
+    model.value.endDate = clampToBounds(now)
+    model.value.labelEnd = 'now'
 
     handleSelect()
     closeOverlay()

--- a/src/components/base/dataTimeRange/index.vue
+++ b/src/components/base/dataTimeRange/index.vue
@@ -83,7 +83,10 @@
               @close="closeOverlay"
             />
           </TabPanel>
-          <TabPanel header="Now">
+          <TabPanel
+            v-if="showNowTab"
+            header="Now"
+          >
             <div class="flex flex-col gap-4 max-w-[300px] mb-2">
               <div class="text-sm text-color-secondary">
                 Selecting 'Set Now' sets the time dynamically to the exact moment of each refresh.
@@ -171,6 +174,7 @@
   const overlayPanel = ref(null)
   const activeTab = ref(0)
   const editingField = ref('start')
+  const showNowTab = ref(true)
   const isOverlayOpen = ref(false)
   const hasInitializedUtcOffset = ref(false)
   const timezoneOptions = ref([])
@@ -303,6 +307,8 @@
     const field = tabIndex === 0 ? undefined : payload?.field
 
     if (field === 'start' || field === 'end') editingField.value = field
+
+    showNowTab.value = !(field === 'start' && !model.value?.label)
 
     if (!event) return
 

--- a/src/components/base/dataTimeRange/inputDateRange/index.vue
+++ b/src/components/base/dataTimeRange/inputDateRange/index.vue
@@ -375,7 +375,8 @@
   }
 
   const updateRange = () => {
-    const parsedDate = parseDateSimple(tempInputValue.value)
+    const typedValue = tempInputValue.value
+    const parsedDate = parseDateSimple(typedValue)
 
     if (parsedDate) {
       const boundedParsedDate = clampToBounds(parsedDate)
@@ -412,6 +413,10 @@
       model.value.labelEnd = ''
     }
     emitSelectIfValid()
+
+    if (props.mode === 'absolute' && (parsedDate || !typedValue)) {
+      emit('close')
+    }
   }
 
   if (model.value.startDate) {
@@ -607,13 +612,14 @@
             :placeholder="props.editingField === 'start' ? startDateInput : endDateInput"
             class="w-full"
             :readonly="mode !== 'absolute'"
+            :disabled="mode !== 'absolute'"
             @keydown.enter="updateRange"
           />
           <PrimeButton
+            v-if="mode === 'absolute'"
             label="Apply"
             @click="updateRange"
             outlined
-            :disabled="mode !== 'absolute'"
             class="whitespace-nowrap w-20"
             size="small"
           />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,6 +66,15 @@ export default {
         sora: ['Sora'],
         protomono: ['Proto Mono'],
         'proto-mono': ['Proto Mono'],
+        code: [
+          'ui-monospace',
+          'SFMono-Regular',
+          'SF Mono',
+          'Menlo',
+          'Consolas',
+          'Liberation Mono',
+          'monospace'
+        ],
         mono: [
           'Proto Mono',
           'ui-monospace',


### PR DESCRIPTION
## Bug fix

### What was the problem?

Four related issues in the time filter (`DataTimeRange` / `AdvancedFilterSystem`) used by Real Time Events (v1 and v2) and Real Time Metrics:

1. **"Set Now" targeted the start date by default.** `setNow()` acted on `editingField`, whose default is `'start'`. Opening the picker from the calendar icon or the start field and clicking "Set Now" set `startDate = now` while keeping the old (past) end, producing an inverted range (`start > end`). `isInvalidRange` became `true` and the Refresh/Update button stayed permanently disabled — the filter looked frozen.

2. **The "now" pill was truncated.** The end input width was `${length}ch`, but the filter bar forces ~12px of horizontal padding on these inputs, so the 3-char "now" rendered as "n…".

3. **Timezone drift on "now" and relative ranges.** `updatedTime()` decomposed dates into browser wall-clock parts and reinterpreted them under the account UTC offset. For instant-based values ("now", "Last 5 minutes", …) the applied `tsRange` drifted by Δ = (browser offset − account offset). Example: browser at `-03:00` with account `+0000` → `tsRangeEnd` landed 3h in the past, so recent events never appeared; auto-refresh repeated the same drift on every tick. The initial load (`defaultFilter`) uses the true instant, so the window also "jumped" Δ hours on the first Refresh.

4. **The "Now" tab was offered when editing the start date.** With "Set Now" pinned to the end date, the tab is meaningless when the picker is opened from the separate start date input — it only invited confusion.

### Expected behavior

- "Set Now" always pins the live endpoint (`endDate` / `labelEnd = 'now'`) and never mutates the start.
- The "now" label renders fully in the date pill.
- "now" and relative ranges resolve to the **real UTC instant**, regardless of browser or account timezone. Absolute calendar dates keep the account-timezone wall-clock semantics.
- The "Now" tab only appears when it can act: opening the picker from the separate start date input hides it; opening from the end input, the calendar icon or the single quick-range label keeps it.

### How was it solved

- `dataTimeRange-v2/index.vue` and `dataTimeRange/index.vue` (v1): `setNow()` no longer depends on `editingField` — it always sets `endDate = clampToBounds(now)` / `labelEnd = 'now'`.
- `dataTimeRange-v2/inputDateRange/index.vue`: `sizeInput` floors short values (`Math.max(length, 5)`) so "now" fits with the forced padding, without widening long date pills.
- `advanced-filter-system-v2/index.vue` and `advanced-filter-system/index.vue` (v1): `updatedTime()` now classifies **each endpoint** by origin:
  - instant sources (`'now'` labels, relative labels like `last 5 minutes`) → `toInstantIso` (`toISOString()` direct, true UTC instant);
  - absolute endpoints (calendar picks, "Today"/"This week") → `toOffsetIso` (unchanged wall-clock reinterpretation with the account offset).
  Hybrid ranges (absolute start + "now" end) resolve each side with its own semantics. V1 keeps its existing Z-less wire format (`/(\..+)/`); v2 keeps `...Z`.
- `dataTimeRange-v2/index.vue` and `dataTimeRange/index.vue` (v1): new `showNowTab` state resolved in `openOverlay` — `!(field === 'start' && !model.label)` — with `v-if` on the "Now" `TabPanel`. The tab is hidden only when the dialog is opened from the separate start date input (`label` empty is exactly the separate-inputs mode); the calendar icon, the end input and the single quick-range label keep it. The tab is the last one and `openOverlay` always resets `activeTab`, so no stale tab index is possible.
- AQL input (`content-editable.vue`): replaced Tailwind `font-mono` class with an explicit monospace `font-family` (uppercase rendering fix).

### How to test

1. In Real Time Events (v2), open the date picker via the calendar icon → "Now" tab → "Set Now": only the end becomes `now`, the pill shows `→ now` untruncated, and Refresh stays enabled and reloads.
2. Open the picker by clicking the **start date pill**: the "Now" tab is not rendered. Open it from the **end pill**, the calendar icon or with a quick-range label active ("Last 5 minutes"): the "Now" tab is available.
3. Set the account UTC offset different from your browser timezone (e.g. account `+0000`, browser `-03:00`), apply "Last 5 minutes" and Refresh: events from the last minutes appear (previously the window drifted by the offset delta and looked empty).
4. Enable auto-refresh with end = "now": the end advances on each tick while the start stays fixed.
5. Repeat steps 1–3 on classic Real Time Events (v1) and Real Time Metrics (both consume the v1 filter).
6. Unit tests: `yarn test:unit:headless src/components/base/advanced-filter-system-v2/__tests__ src/components/base/advanced-filter-system/__tests__` — includes the new `now-relative-utc-instant.spec.js` suites (fake timers, dual account offsets, hybrid range), deterministic on any machine timezone.
