### PR TITLE
fix: versioning fixes for Variables scope and Digital Certificates breadcrumb

### DIFF
--- a/src/router/routes/digital-certificates-routes/index.js
+++ b/src/router/routes/digital-certificates-routes/index.js
@@ -131,7 +131,13 @@ export const digitalCertificatesRoutes = {
             to: '/digital-certificates'
           },
           {
-            to: '/digital-certificates/edit-crl',
+            label: 'CRL',
+            to: {
+              path: '/digital-certificates',
+              query: { certificate: 'certificateRevogationList' }
+            }
+          },
+          {
             dynamic: true,
             routeParam: 'id'
           }

--- a/src/services/v2/variables/v6/__tests__/variables-v6-adapter.test.js
+++ b/src/services/v2/variables/v6/__tests__/variables-v6-adapter.test.js
@@ -282,27 +282,27 @@ describe('VariablesV6Adapter — transformCreatePayload scope', () => {
     ])
   })
 
-  it('maps environment and deployment scopes to their <type>_id', () => {
+  it('maps environment and deployment scopes to resource_id', () => {
     expect(
       buildScope([
         { type: 'environment', resourceType: '', id: '123' },
         { type: 'deployment', resourceType: '', id: '456' }
       ])
     ).toEqual([
-      { resource_type: 'environment', environment_id: '123' },
-      { resource_type: 'deployment', deployment_id: '456' }
+      { resource_type: 'environment', resource_id: '123' },
+      { resource_type: 'deployment', resource_id: '456' }
     ])
   })
 
-  it('maps a resource scope to its concrete resourceType and <resourceType>_id', () => {
+  it('maps a resource scope to its concrete resourceType and resource_id', () => {
     expect(
       buildScope([
         { type: 'resource', resourceType: 'application', id: '1001' },
         { type: 'resource', resourceType: 'firewall', id: '999' }
       ])
     ).toEqual([
-      { resource_type: 'application', application_id: '1001' },
-      { resource_type: 'firewall', firewall_id: '999' }
+      { resource_type: 'application', resource_id: '1001' },
+      { resource_type: 'firewall', resource_id: '999' }
     ])
   })
 

--- a/src/services/v2/variables/v6/variables-v6-adapter.js
+++ b/src/services/v2/variables/v6/variables-v6-adapter.js
@@ -24,7 +24,7 @@ const transformScopePayload = (scope) => {
   return scope.map((item) => {
     if (item.type === 'global') return { resource_type: 'global' }
     const type = item.type === 'resource' ? item.resourceType : item.type
-    return { resource_type: type, [`${type}_id`]: item.id }
+    return { resource_type: type, resource_id: item.id }
   })
 }
 

--- a/src/services/v2/variables/variables-adapter.js
+++ b/src/services/v2/variables/variables-adapter.js
@@ -68,7 +68,7 @@ export const VariablesAdapter = {
     return scope.map((item) => {
       if (item.type === 'global') return { resource_type: 'global' }
       const idKey = `${item.type}_id`
-      return { resource_type: item.type, [idKey]: item[idKey] }
+      return { resource_type: item.type, resource_id: item[idKey] }
     })
   }
 }

--- a/src/views/Variables/FormFields/FormFieldsScope.vue
+++ b/src/views/Variables/FormFields/FormFieldsScope.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { useFieldArray } from 'vee-validate'
+  import { useFieldArray, useFormValues } from 'vee-validate'
   import PrimeButton from '@aziontech/webkit/button'
   import InlineMessage from '@aziontech/webkit/inlinemessage'
   import FormHorizontal from '@/templates/create-form-block/form-horizontal'
@@ -8,9 +8,12 @@
   defineOptions({ name: 'form-fields-scope' })
 
   const { fields, push, remove } = useFieldArray('scope')
+  const formValues = useFormValues()
 
   const addScope = () => {
-    push({ type: 'global', resourceType: '', id: '' })
+    const scopes = formValues.value?.scope ?? []
+    const hasGlobal = scopes.some((scope) => scope?.type === 'global')
+    push({ type: hasGlobal ? '' : 'global', resourceType: '', id: '' })
   }
 </script>
 

--- a/src/views/Variables/FormFields/ScopeRow.vue
+++ b/src/views/Variables/FormFields/ScopeRow.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { computed, ref, watch } from 'vue'
-  import { useField } from 'vee-validate'
+  import { useField, useFormValues } from 'vee-validate'
   import PrimeButton from '@aziontech/webkit/button'
   import FieldDropdown from '@aziontech/webkit/field-dropdown'
   import { environmentService } from '@/services/v2/environment/environment-service'
@@ -24,6 +24,40 @@
   const { value: typeValue } = useField(typeFieldName.value)
   const { value: resourceTypeValue } = useField(resourceTypeFieldName.value)
   const { value: idValue } = useField(idFieldName.value)
+
+  const formValues = useFormValues()
+  const allScopes = computed(() => formValues.value?.scope ?? [])
+
+  const isGlobalTakenElsewhere = computed(() =>
+    allScopes.value.some((scope, position) => position !== props.index && scope?.type === 'global')
+  )
+
+  const scopeTypeOptions = computed(() =>
+    SCOPE_TYPE_OPTIONS.map((option) =>
+      option.value === 'global' ? { ...option, disabled: isGlobalTakenElsewhere.value } : option
+    )
+  )
+
+  const currentInstanceKey = computed(() =>
+    typeValue.value === 'resource' ? resourceTypeValue.value : typeValue.value
+  )
+
+  const takenInstanceIds = computed(() => {
+    const taken = new Set()
+    allScopes.value.forEach((scope, position) => {
+      if (position === props.index || !scope?.id) return
+      const scopeKey = scope.type === 'resource' ? scope.resourceType : scope.type
+      if (scopeKey && scopeKey === currentInstanceKey.value) taken.add(scope.id)
+    })
+    return taken
+  })
+
+  const instanceOptions = computed(() =>
+    options.value.map((option) => ({
+      ...option,
+      disabled: takenInstanceIds.value.has(option.value)
+    }))
+  )
 
   const isResource = computed(() => typeValue.value === 'resource')
   const showResourceType = computed(() => isResource.value)
@@ -105,12 +139,13 @@
     <div class="flex items-end gap-2">
       <div class="flex flex-wrap gap-3 w-full">
         <FieldDropdown
-          :options="SCOPE_TYPE_OPTIONS"
+          :options="scopeTypeOptions"
           :name="typeFieldName"
           label="Type"
           placeholder="Select a scope type"
           optionLabel="label"
           optionValue="value"
+          optionDisabled="disabled"
           required
           class="flex-1 min-w-[12rem]"
           :data-testid="`variables-form__scope-type-${index}`"
@@ -129,12 +164,13 @@
         />
         <FieldDropdown
           v-if="showInstance"
-          :options="options"
+          :options="instanceOptions"
           :name="idFieldName"
           :label="instanceLabel"
           :placeholder="loadingOptions ? 'Loading...' : `Select a ${instanceLabel.toLowerCase()}`"
           optionLabel="label"
           optionValue="value"
+          optionDisabled="disabled"
           filter
           :loading="loadingOptions"
           :disabled="loadingOptions"


### PR DESCRIPTION
## Bug fix

Ajustes de versionamento identificados nos testes do Console (epic ENG-37446 / task pai ENG-46669). O PR agrupa três correções relacionadas a Variables e Digital Certificates.

### Tasks

- [ENG-47098](https://aziontech.atlassian.net/browse/ENG-47098) — Variables: permite selecionar o scope `Global` mais de uma vez.
- [ENG-47099](https://aziontech.atlassian.net/browse/ENG-47099) — Digital Certificates: breadcrumb com comportamento errado (link 404 e nível CRL ausente).
- [ENG-47100](https://aziontech.atlassian.net/browse/ENG-47100) — Variables: payload de scope envia `{type}_id` em vez de `resource_id`.

### What was the problem?

1. **Variables — scope `Global` duplicado (ENG-47098):** era possível adicionar `Global` em mais de uma linha do scope, gerando entradas duplicadas no payload.
2. **Digital Certificates — breadcrumb (ENG-47099):** o último nível (nome do certificado, dinâmico) era clicável e levava a uma página 404; e na edição de CRL o breadcrumb pulava direto de `Digital Certificates` para o nome do item, sem o nível `CRL`.
3. **Variables — payload de scope (ENG-47100):** a chave do id do recurso era montada a partir do tipo (`environment_id`, `deployment_id`, `application_id`, `firewall_id`) em vez do campo esperado pelo contrato, `resource_id`.

### Expected behavior

1. O scope `Global` deve ser único: após selecionado em uma linha, a opção fica desabilitada nas demais e novas linhas não entram como `global`.
2. O último nível do breadcrumb deve ser apenas texto (não clicável) e, na edição de CRL, o caminho deve ser `Digital Certificates > CRL > <nome>`, com o nível `CRL` apontando para a listagem filtrada.
3. Cada item de scope deve ser enviado como `{ resource_type: <tipo>, resource_id: <id> }`. O scope `global` continua sem id (`{ resource_type: 'global' }`).

### How was it solved

- **ENG-47098** — `src/views/Variables/FormFields/FormFieldsScope.vue` e `src/views/Variables/FormFields/ScopeRow.vue`: novas linhas só entram como `global` quando ainda não há um global; a opção `global` e as instâncias já selecionadas ficam desabilitadas no dropdown (`optionDisabled`), evitando duplicatas.
- **ENG-47099** — `src/router/routes/digital-certificates-routes/index.js`: adicionado o nível `CRL` apontando para `/digital-certificates` com a query `certificate=certificateRevogationList`; o nível dinâmico (`dynamic: true, routeParam: 'id'`) deixou de receber `to`, tornando-se apenas texto.
- **ENG-47100** — `src/services/v2/variables/variables-adapter.js` e `src/services/v2/variables/v6/variables-v6-adapter.js`: o transform de scope passa a emitir `resource_id`. Testes atualizados em `src/services/v2/variables/v6/__tests__/variables-v6-adapter.test.js`.

### How to test

**ENG-47098 — Variables (scope Global único)**
1. Acesse Variables > Create e adicione uma linha de scope com tipo `Global`.
2. Adicione outra linha e confirme que a opção `Global` aparece desabilitada.
3. Confirme que instâncias já selecionadas (environment/deployment/application/firewall) também ficam desabilitadas em outras linhas.

**ENG-47099 — Digital Certificates (breadcrumb)**
1. Acesse Digital Certificates e edite um certificado; confirme que o último nível do breadcrumb (nome) não é clicável.
2. Edite uma CRL e confirme o breadcrumb `Digital Certificates > CRL > <nome>`, com `CRL` levando à listagem filtrada por CRL.

**ENG-47100 — Variables (payload de scope)**
1. Crie/edite uma variável com scopes de environment, deployment, application e firewall.
2. Inspecione o payload e confirme que cada item vai como `{ resource_type, resource_id }` (e `global` sem id).


[ENG-47098]: https://aziontech.atlassian.net/browse/ENG-47098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-47099]: https://aziontech.atlassian.net/browse/ENG-47099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-47100]: https://aziontech.atlassian.net/browse/ENG-47100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ